### PR TITLE
fix: simulationconfig javaapi scala 2.13 support

### DIFF
--- a/src/main/java/org/galaxio/gatling/javaapi/SimulationConfig.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/SimulationConfig.java
@@ -2,7 +2,7 @@ package org.galaxio.gatling.javaapi;
 
 import java.time.Duration;
 
-import static scala.compat.java8.DurationConverters.toJava;
+import static scala.jdk.javaapi.DurationConverters.toJava;
 
 public final class SimulationConfig {
 


### PR DESCRIPTION
getDuration does not work without this fix

https://github.com/scala/scala-java8-compat?tab=readme-ov-file#do-you-need-this
