### PR TITLE
ci: modernize tag-driven release changelog

### DIFF
--- a/.github/changelog/release-changelog-builder.json
+++ b/.github/changelog/release-changelog-builder.json
@@ -1,0 +1,90 @@
+{
+  "template": "# 🚀 Release #{{TO_TAG}}\n\n#{{CHANGELOG}}\n\n<details>\n<summary>📦 Other changes</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+  "empty_template": "# 🚀 Release #{{TO_TAG}}\n\nNo user-facing changes were detected.",
+  "commit_template": "- #{{TITLE}} by @#{{AUTHOR}} (#{{MERGE_SHA}})",
+  "categories": [
+    {
+      "title": "## 💥 Breaking Changes",
+      "labels": ["breaking", "boom", "💥"]
+    },
+    {
+      "title": "## ✨ Features",
+      "labels": ["feat", "feature", "sparkles", "✨"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix", "bug", "bugfix", "🐛"]
+    },
+    {
+      "title": "## ↩️ Reverts",
+      "labels": ["revert", "rewind", "↩️"]
+    },
+    {
+      "title": "## ⚡ Performance",
+      "labels": ["perf", "zap", "⚡"]
+    },
+    {
+      "title": "## ♻️ Refactoring",
+      "labels": ["refactor", "recycle", "♻️"]
+    },
+    {
+      "title": "## 📝 Documentation",
+      "labels": ["docs", "doc", "memo", "📝"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test", "tests", "white_check_mark", "test_tube", "🧪"]
+    },
+    {
+      "title": "## 🤖 CI / Build",
+      "labels": ["ci", "build", "construction_worker", "bricks", "🤖"]
+    },
+    {
+      "title": "## 📦 Dependencies",
+      "labels": ["deps", "dependency", "dependencies", "package", "📦"]
+    },
+    {
+      "title": "## 🧹 Chores",
+      "labels": ["chore", "style", "wrench", "broom", "🧹"]
+    },
+    {
+      "title": "## 🔒 Security",
+      "labels": ["security", "lock", "🔒"]
+    }
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(.+)!:",
+      "on_property": "title",
+      "target": "breaking"
+    },
+    {
+      "pattern": "BREAKING CHANGE",
+      "on_property": "body",
+      "method": "match",
+      "target": "breaking"
+    },
+    {
+      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-.]+\\))?(!)?: .+",
+      "on_property": "title",
+      "target": "$1"
+    },
+    {
+      "pattern": "^:(boom|sparkles|bug|zap|recycle|memo|white_check_mark|test_tube|construction_worker|bricks|package|wrench|broom|lock|rewind): .+",
+      "on_property": "title",
+      "target": "$1"
+    },
+    {
+      "pattern": "^(💥|✨|🐛|⚡|♻️|📝|🧪|🤖|📦|🧹|🔒|↩️) .+",
+      "on_property": "title",
+      "target": "$1"
+    }
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "trim_values": true,
+  "max_tags_to_fetch": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,10 @@ on:
   push:
     branches: ['**']
     tags: ['v*']
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   actions: read
   checks: write
   pull-requests: write
@@ -78,7 +79,9 @@ jobs:
     name: Release (tag-driven)
     needs: [test]
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -108,71 +111,7 @@ jobs:
           key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
           restore-keys: sbt-${{ runner.os }}-
 
-      - name: Compute next version & create tag on main
-        id: bump
-        if: github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          git fetch --tags --force --prune
-
-          LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" --first-parent 2>/dev/null || echo "")
-          echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
-          RANGE="${LAST_TAG:+${LAST_TAG}..HEAD}"
-
-          BUMP="patch"
-          COMMITS=$(git log --pretty=format:%s ${RANGE})
-          if echo "$COMMITS" | grep -Eiq 'BREAKING CHANGE|!:'; then
-            BUMP="major"
-          elif echo "$COMMITS" | grep -Eiq '^feat(\(.+\))?:'; then
-            BUMP="minor"
-          fi
-
-          if [ -z "$LAST_TAG" ]; then
-            MAJOR=0; MINOR=0; PATCH=0
-          else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST_TAG#v}"
-          fi
-
-          case "$BUMP" in
-            major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR+1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH+1)) ;;
-          esac
-
-          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
-
-          if git rev-parse -q --verify "refs/tags/${NEXT_TAG}" >/dev/null; then
-            TAG_COMMIT=$(git rev-list -n 1 "${NEXT_TAG}")
-            HEAD_COMMIT=$(git rev-parse HEAD)
-            if [ "${TAG_COMMIT}" = "${HEAD_COMMIT}" ]; then
-              SKIP_TAG_CREATE=1
-            else
-              while git rev-parse -q --verify "refs/tags/${NEXT_TAG}" >/dev/null; do
-                IFS='.' read -r MAJOR MINOR PATCH <<< "${NEXT_TAG#v}"
-                PATCH=$((PATCH+1))
-                NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
-              done
-            fi
-          fi
-
-          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
-          echo "tag=$NEXT_TAG" >> "$GITHUB_OUTPUT"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-
-          if [ "${SKIP_TAG_CREATE:-0}" != "1" ]; then
-            git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
-            git push origin "$NEXT_TAG"
-          fi
-
       - name: Publish to Sonatype via sbt-ci-release
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -182,14 +121,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            TAG="${GITHUB_REF##*/}"
-          else
-            TAG="${{ steps.bump.outputs.tag }}"
-            export GITHUB_REF="refs/tags/${TAG}"
-            export GITHUB_REF_NAME="${TAG}"
-          fi
-
+          TAG="${GITHUB_REF##*/}"
           VERSION="${TAG#v}"
           echo "Publishing version $VERSION (tag $TAG)"
 
@@ -205,43 +137,17 @@ jobs:
 
       - name: Generate Changelog
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        uses: mikepenz/release-changelog-builder-action@v6
         with:
           mode: "COMMIT"
-          fromTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.last_tag || '' }}
-          toTag:   ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
-          configurationJson: |
-            {
-              "template": "# Changelog\n\n#{{CHANGELOG}}",
-              "categories": [
-                {"title": "✨ Features", "labels": ["feat", "feature"]},
-                {"title": "🐛 Bug Fixes", "labels": ["fix", "bug"]},
-                {"title": "📝 Documentation", "labels": ["docs"]},
-                {"title": "⚡ Performance Improvements", "labels": ["perf"]},
-                {"title": "♻️ Refactoring", "labels": ["refactor"]},
-                {"title": "🧪 Tests", "labels": ["test"]},
-                {"title": "🧹 Chores", "labels": ["chore"]},
-                {"title": "📦 Dependencies", "labels": ["dependency"]},
-                {"title": "🚨 Breaking Changes", "labels": ["breaking"]},
-                {"title": "🤖 CI / Build", "labels": ["ci"]}
-              ],
-              "label_extractor": [
-                {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                  "on_property": "title",
-                  "target": "$1"
-                }
-              ]
-            }
+          configuration: .github/changelog/release-changelog-builder.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
+          tag_name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.changelog }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed
- Makes releases strictly tag-driven: publishing, changelog generation, and GitHub Release creation now run only for `v*` tag pushes.
- Moves release changelog rules into `.github/changelog/release-changelog-builder.json` so the workflow stays small and maintainable.
- Prioritizes Conventional Commits categories while still accepting gitmoji aliases.
- Adds Dependabot grouping for GitHub Actions updates.

## Conventional Commit changelog dry run
Simulated for the next tag after `v1.0.1` with the commit in this PR. Author is resolved from GitHub commit data (`author.login`), matching what `#{{AUTHOR}}` is meant to represent in the release action:

```md
# 🚀 Release v1.0.2-dry-run

## 🤖 CI / Build

- ci: modernize tag-driven release changelog by @jigarkhwar (beb5b71)
```

## Validation
- `jq empty .github/changelog/release-changelog-builder.json`
- Ruby YAML parse for `.github/workflows/ci.yml` and `.github/dependabot.yml`
- `git diff --check HEAD^..HEAD`
- `gh api repos/galax-io/gatling-picatinny/commits/beb5b717c1b97f8fff6b6a60b626c0bf84144c2d --jq '.author.login'` -> `jigarkhwar`
