### PR TITLE
ci: tighten test workflow defaults

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,0 +1,13 @@
+pullRequests.frequency = "7 days"
+pullRequests.customLabels = ["dependencies", "scala"]
+pullRequests.grouping = [
+  {
+    name = "patch-updates"
+    title = "Patch dependency updates"
+    filter = [{ version = "patch" }]
+  }
+]
+
+updates.limit = 5
+updatePullRequests = "always"
+commits.message = "chore(deps): update ${artifactName} to ${nextVersion}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  checks: write
-  pull-requests: write
-  packages: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -28,19 +24,24 @@ env:
 
 jobs:
   test:
-    name: Lint, Compile & Test
+    name: Lint, Compile & Test (Java ${{ matrix.java-version }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['17', '21']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup Java (Temurin 17) with sbt cache
+      - name: Setup Java (Temurin ${{ matrix.java-version }}) with sbt cache
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: ${{ matrix.java-version }}
           cache: sbt
 
       - name: Setup sbt
@@ -68,8 +69,41 @@ jobs:
       - name: Test
         run: sbt test
 
-      - name: Coverage (optional)
-        run: sbt coverage test coverageOff coverageReport
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (Temurin 21) with sbt cache
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
+      - name: Cache Ivy/SBT
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-
+
+      - name: Coverage
+        run: sbt clean coverage test coverageOff coverageReport coverageAggregate
 
       - name: Upload coverage reports to Codecov
         if: always()
@@ -77,7 +111,7 @@ jobs:
 
   release:
     name: Release (tag-driven)
-    needs: [test]
+    needs: [test, coverage]
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -88,11 +122,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (Temurin 17) with sbt cache
+      - name: Setup Java (Temurin 21) with sbt cache
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: sbt
 
       - name: Setup sbt

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,31 @@
+name: Scala Steward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: scala-steward-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  scala-steward:
+    name: Update Scala dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Setup Java (Temurin 17)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          timeout: 30min

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ def UtilsModule(id: String) = Project(id, file(id))
 lazy val root = (project in file("."))
   .enablePlugins(GitVersioning)
   .settings(
-    name          := "gatling-picatinny",
-    scalaVersion  := "2.13.18",
+    name                     := "gatling-picatinny",
+    scalaVersion             := "2.13.18",
     libraryDependencies ++= gatlingCore,
     libraryDependencies ++= gatling,
     libraryDependencies ++= fastUUID,
@@ -18,9 +18,13 @@ lazy val root = (project in file("."))
     libraryDependencies ++= jwt,
     libraryDependencies ++= circeDeps,
     libraryDependencies ++= junit,
-    scalacOptions := Seq(
+    coverageMinimumStmtTotal := 45,
+    coverageFailOnMinimum    := true,
+    javacOptions ++= Seq("--release", "17"),
+    scalacOptions            := Seq(
       "-encoding",
       "UTF-8",
+      "-release:17",
       "-deprecation",
       "-feature",
       "-unchecked",


### PR DESCRIPTION
## What changed
- Tightens CI workflow defaults with least-privilege permissions and job timeouts.
- Runs normal tests against Java 17 and 21.
- Splits coverage into its own Java 21 job and enforces a 45% minimum statement coverage gate.
- Builds on Java 21 while targeting Java 17 bytecode/API compatibility for published artifacts.
- Adds Scala Steward scheduled/manual workflow plus repository config for weekly dependency update PRs.

## Commit split
- `ci: harden test workflow`
- `build: target Java 17 runtime`
- `ci: configure Scala Steward`

## Java compatibility
This PR targets Java 17 while allowing CI/release to run on Java 21:

```scala
javacOptions ++= Seq("--release", "17")
scalacOptions += "-release:17"
```

That prevents accidental use of Java APIs/classfile features newer than Java 17 in published artifacts.

## Scala Steward notes
The repository currently had no `.scala-steward.conf`, no Scala Steward workflow, and no historical PRs matching `scala-steward`. This PR adds `scala-steward-org/scala-steward-action@v2` on a weekly Monday schedule plus `workflow_dispatch` for manual runs.

For Scala Steward PR creation to work, GitHub Actions must be allowed to create pull requests in the repository or organization settings.

## Validation
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/scala-steward.yml`
- `git diff --check origin/main..HEAD`
- `coverageMinimumStmtTotal = 45.0`
- `Compile / scalacOptions` contains `-release:17`
- `Compile / javacOptions` contains `--release 17`
- `scalafmtSbtCheck`
