### PR TITLE
fix(transactions): execute simulation hooks

### DIFF
--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/TransactionCoverage.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/TransactionCoverage.java
@@ -10,4 +10,14 @@ public final class TransactionCoverage extends Predef.SimulationWithTransactions
         setUp(TransactionScenario.apply("Picatinny Transaction Coverage", "java-transaction-coverage").injectOpen(atOnceUsers(1)))
                 .assertions(PerformanceSupport.noFailedRequests());
     }
+
+    @Override
+    public void before() {
+        System.out.println("PICATINNY_TRANSACTION_COVERAGE_BEFORE_EXECUTED");
+    }
+
+    @Override
+    public void after() {
+        System.out.println("PICATINNY_TRANSACTION_COVERAGE_AFTER_EXECUTED");
+    }
 }

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/TransactionCoverage.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/TransactionCoverage.kt
@@ -9,4 +9,12 @@ class TransactionCoverage : Predef.SimulationWithTransactions() {
         setUp(TransactionScenario.apply("Picatinny Transaction Coverage", "kotlin-transaction-coverage").injectOpen(atOnceUsers(1)))
             .assertions(PerformanceSupport.noFailedRequests())
     }
+
+    override fun before() {
+        println("PICATINNY_TRANSACTION_COVERAGE_BEFORE_EXECUTED")
+    }
+
+    override fun after() {
+        println("PICATINNY_TRANSACTION_COVERAGE_AFTER_EXECUTED")
+    }
 }

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/TransactionCoverage.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/TransactionCoverage.scala
@@ -5,6 +5,14 @@ import org.galaxio.gatling.transactions.Predef._
 import org.galaxio.performance.picatinny.scenarios.TransactionScenario
 
 class TransactionCoverage extends SimulationWithTransactions {
+  before {
+    println("PICATINNY_TRANSACTION_COVERAGE_BEFORE_EXECUTED")
+  }
+
+  after {
+    println("PICATINNY_TRANSACTION_COVERAGE_AFTER_EXECUTED")
+  }
+
   setUp(
     TransactionScenario("Picatinny Transaction Coverage", "scala-transaction-coverage").inject(atOnceUsers(1)),
   ).assertions(global.failedRequests.count.is(0))

--- a/src/main/scala/org/galaxio/gatling/transactions/Predef.scala
+++ b/src/main/scala/org/galaxio/gatling/transactions/Predef.scala
@@ -11,6 +11,12 @@ import scala.jdk.CollectionConverters._
 
 object Predef {
   abstract class SimulationWithTransactions extends Simulation {
+    def before(): Unit = ()
+
+    def after(): Unit = ()
+
+    super.before(before())
+    super.after(after())
 
     override def setUp(populationBuilders: PopulationBuilder*): SetUp = setUp(populationBuilders.toList)
 

--- a/src/test/scala/org/galaxio/gatling/transactions/TransactionsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/transactions/TransactionsSpec.scala
@@ -1,6 +1,8 @@
 package org.galaxio.gatling.transactions
 
 import io.gatling.core.Predef._
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.scenario.SimulationParams
 import io.gatling.core.session.Expression
 import io.gatling.core.structure.{ScenarioBuilder, ScenarioContext}
 import org.scalatest.OptionValues._
@@ -10,6 +12,8 @@ import org.galaxio.gatling.transactions.Predef._
 import org.galaxio.gatling.transactions.actions.builders._
 
 object TransactionsSpec {
+  private implicit val configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()
+
   private val now                          = System.currentTimeMillis()
   val transactionScenario: ScenarioBuilder =
     scenario("Test transaction scenario")
@@ -38,6 +42,32 @@ object TransactionsSpec {
       .exec(s => s)
       .endTransaction("t1")
       .endTransaction("t2")
+
+  final class OverrideHookSimulation(hooks: scala.collection.mutable.ArrayBuffer[String]) extends SimulationWithTransactions {
+    setUp(scenario("Override hook scenario").exec(s => s).inject(atOnceUsers(1)))
+
+    override def before(): Unit = hooks += "before"
+
+    override def after(): Unit = hooks += "after"
+  }
+
+  final class RegisteredHookSimulation(hooks: scala.collection.mutable.ArrayBuffer[String]) extends SimulationWithTransactions {
+    before {
+      hooks += "before"
+    }
+
+    after {
+      hooks += "after"
+    }
+
+    setUp(scenario("Registered hook scenario").exec(s => s).inject(atOnceUsers(1)))
+  }
+
+  def paramsOf(simulation: SimulationWithTransactions): SimulationParams =
+    classOf[io.gatling.core.scenario.Simulation]
+      .getMethod("params", classOf[GatlingConfiguration])
+      .invoke(simulation, configuration)
+      .asInstanceOf[SimulationParams]
 }
 
 class TransactionsSpec extends AnyFlatSpec with Matchers with Mocks {
@@ -146,6 +176,26 @@ class TransactionsSpec extends AnyFlatSpec with Matchers with Mocks {
       status("KO"),
     )
     errorRecord.get.errorMsg.value shouldBe "has unclosed transaction t2"
+  }
+
+  "SimulationWithTransactions" should "execute override-style hooks for Java and Kotlin simulations" in {
+    val hooks            = scala.collection.mutable.ArrayBuffer.empty[String]
+    val simulationParams = paramsOf(new OverrideHookSimulation(hooks))
+
+    simulationParams.before()
+    simulationParams.after()
+
+    hooks.toSeq shouldBe Seq("before", "after")
+  }
+
+  it should "preserve registered Scala hooks" in {
+    val hooks            = scala.collection.mutable.ArrayBuffer.empty[String]
+    val simulationParams = paramsOf(new RegisteredHookSimulation(hooks))
+
+    simulationParams.before()
+    simulationParams.after()
+
+    hooks.toSeq shouldBe Seq("before", "after")
   }
 
 }


### PR DESCRIPTION
## Summary

Adds Java/Kotlin override-style lifecycle hooks to `SimulationWithTransactions` while preserving Scala Gatling DSL hooks. This fixes transaction simulations where `after()` was not executed for simulations extending `SimulationWithTransactions`.

## Changes

- Add no-op `before()` and `after()` methods to `SimulationWithTransactions` and register them through Gatling lifecycle hooks.
- Add regression coverage for override-style hooks and existing Scala registered hooks.
- Extend Java, Kotlin, and Scala transaction coverage examples with before/after diagnostics.

## Testing

- `cs launch sbt:1.10.0 -- scalafmtAll scalafmtSbt 'testOnly org.galaxio.gatling.transactions.TransactionsSpec'`
- Java Maven `TransactionCoverage` Gatling simulation: passed; before/after diagnostics printed.
- Scala sbt `TransactionCoverage` Gatling simulation: passed; before/after diagnostics printed.
- Kotlin Gradle `gatlingClasses`: passed with JDK 17; full `gatlingRun` is blocked locally by Gradle 9.4.1 / Gatling Gradle plugin 3.11.5.2 incompatibility around `reportsDir`.

Fixes #5
