### PR TITLE
feat(diagnostics): add startup utility banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@
 *.html
 /example/target/
 /example/example.iml
+/examples/**/.gradle/
+/examples/**/build/
+/examples/**/target/
+/examples/**/project/project/
+/examples/**/project/target/
 *.sc
 /.bsp
 # coursier cache

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * [Installation](#installation)
 * [Usage](#usage)
     * [config](#config)
+    * [startup banner and diagnostics](#startup-banner-and-diagnostics)
     * [feeders](#feeders)
         * [HC Vault feeder](#hc-vault-feeder)
         * [SeparatedValuesFeeder](#separatedvaluesfeeder)
@@ -165,6 +166,146 @@ val intVariable = getIntParam("intVariable")
 val doubleVariable = getDoubleParam("doubleVariable")
 val durationVariable = getDurationParam("duration.durationVariable")
 val booleanVariable = getBooleanParam("booleanVariable")
+```
+
+### startup banner and diagnostics
+
+Picatinny provides explicit utility methods for startup output. Put them where it makes sense for your project: in a
+simulation class, a shared package object, or another project bootstrap point.
+
+Default behavior:
+
+```text
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = false
+```
+
+Disable the banner for quiet runs:
+
+```bash
+-Dpicatinny.startup.banner.enabled=false
+```
+
+Enable JVM/runtime diagnostics when you need extra debug information:
+
+```bash
+-Dpicatinny.diagnostics.enabled=true
+```
+
+The banner uses the simulation name to render the expected workload shape: `Stability` is shown as `ramp-and-plateau`,
+while `MaxPerformance` is shown as `staged-increment`.
+
+Example `simulation.conf`:
+
+```hocon
+baseUrl = "http://localhost"
+intensity = "60 rpm"
+stagesNumber = 2
+rampDuration = 1 minute
+stageDuration = 5 minutes
+
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = false
+```
+
+Scala usage:
+
+```scala
+import io.gatling.core.Predef._
+import org.galaxio.gatling.config.SimulationConfig._
+import org.galaxio.gatling.utils.Utility
+
+class Stability extends Simulation {
+  Utility.banner()
+  Utility.diagnostics()
+
+  setUp(
+    scn.inject(
+      rampUsersPerSec(0).to(intensity).during(rampDuration),
+      constantUsersPerSec(intensity).during(stageDuration),
+    ),
+  ).protocols(http.baseUrl(baseUrl))
+}
+```
+
+Java usage:
+
+```java
+import io.gatling.javaapi.core.Simulation;
+import org.galaxio.gatling.javaapi.Utility;
+import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
+import static io.gatling.javaapi.core.CoreDsl.rampUsersPerSec;
+import static org.galaxio.gatling.javaapi.SimulationConfig.*;
+
+public final class Stability extends Simulation {
+    {
+        Utility.banner();
+        Utility.diagnostics();
+
+        setUp(
+            scn.injectOpen(
+                rampUsersPerSec(0).to(intensity()).during(rampDuration()),
+                constantUsersPerSec(intensity()).during(stageDuration())
+            )
+        );
+    }
+}
+```
+
+Kotlin usage:
+
+```kotlin
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.rampUsersPerSec
+import io.gatling.javaapi.core.Simulation
+import org.galaxio.gatling.javaapi.Utility
+import org.galaxio.gatling.javaapi.SimulationConfig.*
+
+class Stability : Simulation() {
+    init {
+        Utility.banner()
+        Utility.diagnostics()
+
+        setUp(
+            scn.injectOpen(
+                rampUsersPerSec(0.0).to(intensity()).during(rampDuration()),
+                constantUsersPerSec(intensity()).during(stageDuration()),
+            ),
+        )
+    }
+}
+```
+
+Startup output:
+
+```text
+================================================================================
+ Picatinny Gatling Run
+================================================================================
+ Simulation   : Stability
+ Base URL     : http://localhost
+
+ Workload
+   intensity      : 60 rpm = 1.00 rps
+   profile        : ramp-and-plateau
+   ramp duration  : 1m
+   stage duration : 5m
+   total duration : 6m
+
+ Timeline
+   00:00 - 01:00  ramp   0.00 -> 1.00 rps
+   01:00 - 06:00  plateau  1.00 rps
+
+ ASCII preview
+   rps
+    1.00 |            /_______________________________________________
+    0.75 |         ///
+    0.50 |      ///
+    0.25 |   ///
+    0.00 |///
+         +------------------------------------------------
+          00:00                                    06:00
+================================================================================
 ```
 
 ### feeders

--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/MaxPerformance.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/MaxPerformance.java
@@ -1,6 +1,7 @@
 package org.galaxio.performance.picatinny;
 
 import org.galaxio.gatling.javaapi.SimulationConfig;
+import org.galaxio.gatling.javaapi.Utility;
 import org.galaxio.gatling.transactions.Predef;
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario;
 
@@ -8,6 +9,9 @@ import static io.gatling.javaapi.core.CoreDsl.incrementUsersPerSec;
 
 public final class MaxPerformance extends Predef.SimulationWithTransactions {
     {
+        Utility.banner();
+        Utility.diagnostics();
+
         setUp(
                 PicatinnyScenario.apply("Picatinny Max Performance", "java-max-performance")
                         .injectOpen(

--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/Stability.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/Stability.java
@@ -1,6 +1,7 @@
 package org.galaxio.performance.picatinny;
 
 import org.galaxio.gatling.javaapi.SimulationConfig;
+import org.galaxio.gatling.javaapi.Utility;
 import org.galaxio.gatling.transactions.Predef;
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario;
 
@@ -9,6 +10,9 @@ import static io.gatling.javaapi.core.CoreDsl.rampUsersPerSec;
 
 public final class Stability extends Predef.SimulationWithTransactions {
     {
+        Utility.banner();
+        Utility.diagnostics();
+
         setUp(
                 PicatinnyScenario.apply("Picatinny Stability", "java-stability")
                         .injectOpen(

--- a/examples/java-maven-example/src/test/resources/simulation.conf
+++ b/examples/java-maven-example/src/test/resources/simulation.conf
@@ -8,3 +8,6 @@ stageDuration = 1 second
 testDuration = 5 seconds
 pacing = 1 second
 scenarioName = "Picatinny synthetic business flow"
+
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = true

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/MaxPerformance.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/MaxPerformance.kt
@@ -2,11 +2,15 @@ package org.galaxio.performance.picatinny
 
 import io.gatling.javaapi.core.CoreDsl.incrementUsersPerSec
 import org.galaxio.gatling.javaapi.SimulationConfig
+import org.galaxio.gatling.javaapi.Utility
 import org.galaxio.gatling.transactions.Predef
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class MaxPerformance : Predef.SimulationWithTransactions() {
     init {
+        Utility.banner()
+        Utility.diagnostics()
+
         setUp(
             PicatinnyScenario.apply("Picatinny Max Performance", "kotlin-max-performance")
                 .injectOpen(

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/Stability.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/Stability.kt
@@ -3,11 +3,15 @@ package org.galaxio.performance.picatinny
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
 import io.gatling.javaapi.core.CoreDsl.rampUsersPerSec
 import org.galaxio.gatling.javaapi.SimulationConfig
+import org.galaxio.gatling.javaapi.Utility
 import org.galaxio.gatling.transactions.Predef
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class Stability : Predef.SimulationWithTransactions() {
     init {
+        Utility.banner()
+        Utility.diagnostics()
+
         setUp(
             PicatinnyScenario.apply("Picatinny Stability", "kotlin-stability")
                 .injectOpen(

--- a/examples/kotlin-gradle-example/src/gatling/resources/simulation.conf
+++ b/examples/kotlin-gradle-example/src/gatling/resources/simulation.conf
@@ -8,3 +8,6 @@ stageDuration = 1 second
 testDuration = 5 seconds
 pacing = 1 second
 scenarioName = "Picatinny synthetic business flow"
+
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = true

--- a/examples/scala-sbt-example/src/test/resources/simulation.conf
+++ b/examples/scala-sbt-example/src/test/resources/simulation.conf
@@ -8,3 +8,6 @@ stageDuration = 1 second
 testDuration = 5 seconds
 pacing = 1 second
 scenarioName = "Picatinny synthetic business flow"
+
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = true

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/MaxPerformance.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/MaxPerformance.scala
@@ -3,9 +3,13 @@ package org.galaxio.performance.picatinny
 import io.gatling.core.Predef._
 import org.galaxio.gatling.config.SimulationConfig._
 import org.galaxio.gatling.transactions.Predef._
+import org.galaxio.gatling.utils.Utility
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class MaxPerformance extends SimulationWithTransactions {
+  Utility.banner()
+  Utility.diagnostics()
+
   setUp(
     PicatinnyScenario("Picatinny Max Performance", "scala-max-performance").inject(
       incrementUsersPerSec(intensity / stagesNumber)

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Stability.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Stability.scala
@@ -3,9 +3,13 @@ package org.galaxio.performance.picatinny
 import io.gatling.core.Predef._
 import org.galaxio.gatling.config.SimulationConfig._
 import org.galaxio.gatling.transactions.Predef._
+import org.galaxio.gatling.utils.Utility
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class Stability extends SimulationWithTransactions {
+  Utility.banner()
+  Utility.diagnostics()
+
   setUp(
     PicatinnyScenario("Picatinny Stability", "scala-stability").inject(
       rampUsersPerSec(0) to intensity during rampDuration,

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Utility.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Utility.scala
@@ -1,8 +1,0 @@
-package org.galaxio.performance.picatinny
-
-object Utility {
-  def debugMemoryAndOpts(): Unit = {
-    println(s"Runtime max memory: ${Runtime.getRuntime.maxMemory()}")
-    println(s"JVM input arguments: ${java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments}")
-  }
-}

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/picatinny.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/picatinny.scala
@@ -1,6 +1,0 @@
-package org.galaxio.performance
-
-package object picatinny {
-  if (sys.env.get("DEBUG").exists(_.equalsIgnoreCase("true")))
-    Utility.debugMemoryAndOpts()
-}

--- a/src/main/java/org/galaxio/gatling/javaapi/Utility.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/Utility.java
@@ -1,0 +1,15 @@
+package org.galaxio.gatling.javaapi;
+
+public final class Utility {
+
+    private Utility() {
+    }
+
+    public static void banner() {
+        org.galaxio.gatling.utils.Utility.banner();
+    }
+
+    public static void diagnostics() {
+        org.galaxio.gatling.utils.Utility.diagnostics();
+    }
+}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/AsciiWorkloadChart.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/AsciiWorkloadChart.scala
@@ -1,0 +1,84 @@
+package org.galaxio.gatling.diagnostics
+
+import scala.concurrent.duration._
+
+private[diagnostics] object AsciiWorkloadChart {
+  private val Width = 72
+  private val Rows  = 10
+
+  def render(settings: WorkloadSettings): String = {
+    val totalSeconds = math.max(1.0, settings.testDuration.toSeconds.toDouble)
+    val maxRps       = math.max(0.01, settings.intensityRps)
+    val grid         = Array.fill(Rows, Width)(' ')
+
+    WorkloadTimeline.segments(settings).foreach { segment =>
+      val start = Point(xFor(segment.start, totalSeconds), yFor(segment.fromRps, maxRps))
+      val end   = Point(xFor(segment.end, totalSeconds), yFor(segment.toRps, maxRps))
+
+      segment.kind match {
+        case "ramp" => drawRamp(grid, start, end)
+        case _      => drawHorizontal(grid, start.x, end.x, end.y)
+      }
+    }
+
+    val body = grid.zipWithIndex.map { case (chars, row) =>
+      val level = maxRps * (Rows - 1 - row) / (Rows - 1)
+      s"   ${Formatters.decimal(level).reverse.padTo(5, ' ').reverse} |${chars.mkString}"
+    }
+      .mkString("\n")
+
+    s"""   rps
+       |$body
+       |         +${"-" * Width}
+       |          00:00${" " * math.max(1, Width - 12)}${Formatters.time(settings.testDuration)}
+       |""".stripMargin
+  }
+
+  private[diagnostics] def strokeColumns(chart: String): IndexedSeq[String] =
+    chart.linesIterator
+      .filter(_.contains("|"))
+      .map(_.dropWhile(_ != '|').drop(1))
+      .toIndexedSeq
+
+  private[diagnostics] def hasContinuousStroke(chart: String): Boolean = {
+    val rows = strokeColumns(chart)
+    rows.nonEmpty && rows.map(_.length).minOption.exists { width =>
+      (0 until width).forall(column => rows.exists(row => "_/|".contains(row.charAt(column))))
+    }
+  }
+
+  private final case class Point(x: Int, y: Int)
+
+  private def drawRamp(grid: Array[Array[Char]], start: Point, end: Point): Unit =
+    if (start.x == end.x) drawVertical(grid, start.x, start.y, end.y)
+    else {
+      val fromX = math.min(start.x, end.x)
+      val toX   = math.max(start.x, end.x)
+
+      (fromX to toX).foreach { x =>
+        val progress = (x - start.x).toDouble / (end.x - start.x).toDouble
+        val y        = math.round(start.y + (end.y - start.y) * progress).toInt
+        put(grid, x, y, '/')
+      }
+    }
+
+  private def drawHorizontal(grid: Array[Array[Char]], startX: Int, endX: Int, y: Int): Unit =
+    (math.min(startX, endX) to math.max(startX, endX)).foreach(x => put(grid, x, y, '_', overwrite = false))
+
+  private def drawVertical(grid: Array[Array[Char]], x: Int, startY: Int, endY: Int): Unit =
+    (math.min(startY, endY) to math.max(startY, endY)).foreach(y => put(grid, x, y, '|'))
+
+  private def put(grid: Array[Array[Char]], x: Int, y: Int, char: Char, overwrite: Boolean = true): Unit =
+    if (grid.indices.contains(y) && grid(y).indices.contains(x) && (overwrite || grid(y)(x) == ' ')) grid(y)(x) = char
+
+  private def xFor(duration: FiniteDuration, totalSeconds: Double): Int = {
+    val normalized = math.max(0.0, math.min(1.0, duration.toSeconds.toDouble / totalSeconds))
+    math.round(normalized * (Width - 1)).toInt
+  }
+
+  private def yFor(level: Double, maxRps: Double): Int = {
+    val normalized = math.max(0.0, math.min(1.0, level / maxRps))
+    (Rows - 1) - math.round(normalized * (Rows - 1)).toInt
+  }
+
+}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/Diagnostics.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/Diagnostics.scala
@@ -1,0 +1,35 @@
+package org.galaxio.gatling.diagnostics
+
+import java.lang.management.ManagementFactory
+
+import org.galaxio.gatling.config.ConfigManager
+
+import scala.jdk.CollectionConverters._
+
+object Diagnostics {
+  private val EnabledPath = "picatinny.diagnostics.enabled"
+
+  def printIfEnabled(): Unit =
+    if (isEnabled) println(render())
+
+  private[gatling] def isEnabled: Boolean =
+    ConfigManager.simulationConfig.get(EnabledPath, false)
+
+  private[diagnostics] def render(): String = {
+    val runtime = Runtime.getRuntime
+    val mxBean  = ManagementFactory.getRuntimeMXBean
+    val args    = mxBean.getInputArguments.asScala.mkString(" ")
+
+    s"""Diagnostics
+       |   java           : ${System.getProperty("java.version")} ${System.getProperty("java.vendor")}
+       |   os             : ${System.getProperty("os.name")} ${System.getProperty("os.arch")}
+       |   timezone       : ${java.time.ZoneId.systemDefault()}
+       |   working dir    : ${System.getProperty("user.dir")}
+       |   max heap       : ${Formatters.bytes(runtime.maxMemory())}
+       |   total heap     : ${Formatters.bytes(runtime.totalMemory())}
+       |   free heap      : ${Formatters.bytes(runtime.freeMemory())}
+       |   jvm args       : ${if (args.isEmpty) "<empty>" else args}
+       |""".stripMargin
+  }
+
+}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/Formatters.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/Formatters.scala
@@ -1,0 +1,40 @@
+package org.galaxio.gatling.diagnostics
+
+import java.util.Locale
+
+import scala.concurrent.duration.FiniteDuration
+
+private[diagnostics] object Formatters {
+
+  def decimal(value: Double): String =
+    String.format(Locale.US, "%.2f", Double.box(value))
+
+  def duration(duration: FiniteDuration): String = {
+    val seconds = math.max(0L, duration.toSeconds)
+    if (seconds == 0L) "0s"
+    else {
+      val hours   = seconds / 3600
+      val minutes = (seconds % 3600) / 60
+      val secs    = seconds  % 60
+
+      List(hours -> "h", minutes -> "m", secs -> "s").collect { case (value, suffix) if value > 0 => s"$value$suffix" }
+        .mkString(" ")
+    }
+  }
+
+  def time(duration: FiniteDuration): String = {
+    val seconds = math.max(0L, duration.toSeconds)
+    val hours   = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    val secs    = seconds  % 60
+
+    if (hours > 0) f"$hours%02d:$minutes%02d:$secs%02d"
+    else f"$minutes%02d:$secs%02d"
+  }
+
+  def bytes(value: Long): String = {
+    val mb = value.toDouble / 1024.0 / 1024.0
+    if (mb >= 1024.0) f"${mb / 1024.0}%.2f g" else f"$mb%.0f m"
+  }
+
+}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala
@@ -1,0 +1,137 @@
+package org.galaxio.gatling.diagnostics
+
+import org.galaxio.gatling.config.ConfigManager
+import org.galaxio.gatling.utils.IntensityConverter.getIntensityFromString
+
+import scala.concurrent.duration.FiniteDuration
+
+object StartupBanner {
+  private val EnabledPath        = "picatinny.startup.banner.enabled"
+  private val InternalStackNames = Set("Utility", "StartupBanner", "Diagnostics")
+
+  def printIfEnabled(): Unit =
+    printIfEnabled(None)
+
+  def printIfEnabled(simulationClass: Class[_]): Unit =
+    printIfEnabled(Some(simulationClass))
+
+  private def printIfEnabled(simulationClass: Option[Class[_]]): Unit =
+    if (isEnabled) println(render(simulationClass))
+
+  private[gatling] def isEnabled: Boolean =
+    ConfigManager.simulationConfig.get(EnabledPath, true)
+
+  private[diagnostics] def render(): String =
+    render(None)
+
+  private[diagnostics] def render(simulationClass: Class[_]): String =
+    render(Some(simulationClass))
+
+  private def render(simulationClass: Option[Class[_]]): String = {
+    val config = ConfigManager.simulationConfig
+    val stages = config.get[Int]("stagesNumber", 1)
+    val line   = "=" * 80
+    val name   = simulationName(simulationClass)
+
+    s"""$line
+       | Picatinny Gatling Run
+       |$line
+       | Simulation   : $name
+       | Base URL     : ${config.get[String]("baseUrl", "<undefined>")}
+       |
+       |${workloadBlock(name, stages)}
+       |$line
+       |""".stripMargin
+  }
+
+  private def workloadBlock(simulationName: String, stages: Int): String = {
+    val config        = ConfigManager.simulationConfig
+    val intensityText = config.getOpt[String]("intensity")
+    val ramp          = config.getOpt[FiniteDuration]("rampDuration")
+    val stage         = config.getOpt[FiniteDuration]("stageDuration")
+
+    (intensityText, ramp, stage) match {
+      case (Some(intensity), Some(rampDuration), Some(stageDuration)) =>
+        val profile  = WorkloadProfile.fromSimulationName(simulationName)
+        val fallback = profile match {
+          case WorkloadProfile.RampAndPlateau  => rampDuration + stageDuration
+          case WorkloadProfile.StagedIncrement => (rampDuration + stageDuration) * stages
+        }
+        val total    = config.get[FiniteDuration]("testDuration", fallback)
+        val settings = WorkloadSettings(
+          intensityRps = getIntensityFromString(intensity),
+          intensityText = intensity,
+          profile = profile,
+          stagesNumber = stages,
+          rampDuration = rampDuration,
+          stageDuration = stageDuration,
+          testDuration = total,
+        )
+
+        s""" Workload
+           |${settingsBlock(settings)}
+           |
+           | Timeline
+           |${WorkloadTimeline.render(settings)}
+           |
+           | ASCII preview
+           |${AsciiWorkloadChart.render(settings)}""".stripMargin
+
+      case _ =>
+        val missing = List(
+          "intensity"     -> intensityText,
+          "rampDuration"  -> ramp,
+          "stageDuration" -> stage,
+        ).collect { case (name, None) => name }.mkString(", ")
+
+        s""" Workload
+           |   unavailable   : missing $missing""".stripMargin
+    }
+  }
+
+  private def settingsBlock(settings: WorkloadSettings): String =
+    List(
+      "intensity"      -> s"${settings.intensityText} = ${Formatters.decimal(settings.intensityRps)} rps",
+      "profile"        -> settings.profile.label,
+      "stages"         -> settings.stagesNumber.toString,
+      "ramp duration"  -> Formatters.duration(settings.rampDuration),
+      "stage duration" -> Formatters.duration(settings.stageDuration),
+      "total duration" -> Formatters.duration(settings.testDuration),
+    ).filterNot { case (name, _) => name == "stages" && settings.profile == WorkloadProfile.RampAndPlateau }.map {
+      case (name, value) => s"   ${name.padTo(15, ' ')}: $value"
+    }
+      .mkString("\n")
+
+  private def simulationName(simulationClass: Option[Class[_]]): String =
+    simulationClass
+      .map(_.getSimpleName)
+      .filter(_.nonEmpty)
+      .orElse(
+        sys.props
+          .get("gatling.core.simulationClass")
+          .map(_.split('.').last),
+      )
+      .orElse(sys.props.get("gatling.simulationClass").map(_.split('.').last))
+      .orElse(stackSimulationName)
+      .getOrElse("<unknown>")
+
+  private def stackSimulationName: Option[String] =
+    Thread
+      .currentThread()
+      .getStackTrace
+      .iterator
+      .map(_.getClassName)
+      .filterNot(name =>
+        name.startsWith("java.") ||
+          name.startsWith("jdk.") ||
+          name.startsWith("sun.") ||
+          name.startsWith("scala.") ||
+          name.startsWith("sbt.") ||
+          name.startsWith("io.gatling.") ||
+          name.startsWith("org.galaxio.gatling."),
+      )
+      .map(_.split('.').last.replace("$", ""))
+      .filterNot(InternalStackNames)
+      .find(_.nonEmpty)
+
+}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/WorkloadTimeline.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/WorkloadTimeline.scala
@@ -1,0 +1,105 @@
+package org.galaxio.gatling.diagnostics
+
+import scala.concurrent.duration._
+
+private[diagnostics] final case class WorkloadSettings(
+    intensityRps: Double,
+    intensityText: String,
+    profile: WorkloadProfile,
+    stagesNumber: Int,
+    rampDuration: FiniteDuration,
+    stageDuration: FiniteDuration,
+    testDuration: FiniteDuration,
+)
+
+private[diagnostics] final case class WorkloadSegment(
+    start: FiniteDuration,
+    end: FiniteDuration,
+    kind: String,
+    fromRps: Double,
+    toRps: Double,
+)
+
+private[diagnostics] sealed trait WorkloadProfile {
+  def label: String
+}
+
+private[diagnostics] object WorkloadProfile {
+  case object RampAndPlateau extends WorkloadProfile {
+    override val label: String = "ramp-and-plateau"
+  }
+
+  case object StagedIncrement extends WorkloadProfile {
+    override val label: String = "staged-increment"
+  }
+
+  def fromSimulationName(name: String): WorkloadProfile =
+    if (name.toLowerCase.contains("maxperformance")) StagedIncrement
+    else RampAndPlateau
+}
+
+private[diagnostics] object WorkloadTimeline {
+
+  def segments(settings: WorkloadSettings): List[WorkloadSegment] =
+    settings.profile match {
+      case WorkloadProfile.RampAndPlateau  => clamp(rampAndPlateau(settings), settings.testDuration)
+      case WorkloadProfile.StagedIncrement => clamp(stagedIncrement(settings), settings.testDuration)
+    }
+
+  private def rampAndPlateau(settings: WorkloadSettings): List[WorkloadSegment] =
+    List(
+      WorkloadSegment(0.seconds, settings.rampDuration, "ramp", 0.0, settings.intensityRps),
+      WorkloadSegment(
+        settings.rampDuration,
+        settings.rampDuration + settings.stageDuration,
+        "plateau",
+        settings.intensityRps,
+        settings.intensityRps,
+      ),
+    ).filter(segment => segment.end > segment.start)
+
+  private def stagedIncrement(settings: WorkloadSettings): List[WorkloadSegment] = {
+    val stageCount = math.max(1, settings.stagesNumber)
+    val step       = settings.intensityRps / stageCount
+
+    (1 to stageCount).toList.flatMap { stage =>
+      val previousLevel = step * (stage - 1)
+      val nextLevel     = step * stage
+      val offset        = (settings.rampDuration + settings.stageDuration) * (stage - 1).toLong
+      val rampEnd       = offset + settings.rampDuration
+      val stageEnd      = rampEnd + settings.stageDuration
+
+      List(
+        WorkloadSegment(offset, rampEnd, "ramp", previousLevel, nextLevel),
+        WorkloadSegment(rampEnd, stageEnd, "stage", nextLevel, nextLevel),
+      ).filter(segment => segment.end > segment.start)
+    }
+  }
+
+  private def clamp(segments: List[WorkloadSegment], testDuration: FiniteDuration): List[WorkloadSegment] =
+    segments.lastOption match {
+      case Some(last) if testDuration > last.end =>
+        segments :+ WorkloadSegment(last.end, testDuration, "hold", last.toRps, last.toRps)
+      case _                                     =>
+        segments.filter(_.start < testDuration).map { segment =>
+          if (segment.end > testDuration) segment.copy(end = testDuration) else segment
+        }
+    }
+
+  def render(settings: WorkloadSettings): String =
+    segments(settings)
+      .map(renderSegment)
+      .mkString("\n")
+
+  private def renderSegment(segment: WorkloadSegment): String = {
+    val range = s"${Formatters.time(segment.start)} - ${Formatters.time(segment.end)}"
+    val label = segment.kind.padTo(5, ' ')
+    val level = Formatters.decimal(segment.toRps)
+
+    segment.kind match {
+      case "ramp" => s"   $range  $label  ${Formatters.decimal(segment.fromRps)} -> $level rps"
+      case _      => s"   $range  $label  $level rps"
+    }
+  }
+
+}

--- a/src/main/scala/org/galaxio/gatling/utils/Utility.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/Utility.scala
@@ -1,0 +1,13 @@
+package org.galaxio.gatling.utils
+
+import org.galaxio.gatling.diagnostics.{Diagnostics, StartupBanner}
+
+object Utility {
+
+  def banner(): Unit =
+    StartupBanner.printIfEnabled()
+
+  def diagnostics(): Unit =
+    Diagnostics.printIfEnabled()
+
+}

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaUtilsTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaUtilsTest.java
@@ -72,4 +72,7 @@ public class JavaUtilsTest {
     Double intensity_prm = rpm(intensity);
     Double intensity_prs = rps(intensity);
     Double _intensity = getIntensityFromString(s_intensity);
+
+    Runnable startupBannerFacade = Utility::banner;
+    Runnable diagnosticsFacade = Utility::diagnostics;
 }

--- a/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
@@ -1,0 +1,128 @@
+package org.galaxio.gatling.diagnostics
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class DiagnosticsSpec extends AnyFlatSpec with Matchers {
+
+  it should "format durations in a compact human readable form" in {
+    Formatters.duration(0.seconds) shouldBe "0s"
+    Formatters.duration(60.seconds) shouldBe "1m"
+    Formatters.duration(61.seconds) shouldBe "1m 1s"
+    Formatters.duration(3661.seconds) shouldBe "1h 1m 1s"
+  }
+
+  it should "build workload timeline from Picatinny workload settings" in {
+    val settings = WorkloadSettings(
+      intensityRps = 1.0,
+      intensityText = "60 rpm",
+      profile = WorkloadProfile.StagedIncrement,
+      stagesNumber = 2,
+      rampDuration = 1.minute,
+      stageDuration = 5.minutes,
+      testDuration = 12.minutes,
+    )
+
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 1.minute, "ramp", 0.0, 0.5),
+      WorkloadSegment(1.minute, 6.minutes, "stage", 0.5, 0.5),
+      WorkloadSegment(6.minutes, 7.minutes, "ramp", 0.5, 1.0),
+      WorkloadSegment(7.minutes, 12.minutes, "stage", 1.0, 1.0),
+    )
+  }
+
+  it should "render ASCII chart with workload symbols" in {
+    val settings = WorkloadSettings(
+      intensityRps = 1.0,
+      intensityText = "60 rpm",
+      profile = WorkloadProfile.StagedIncrement,
+      stagesNumber = 2,
+      rampDuration = 1.minute,
+      stageDuration = 5.minutes,
+      testDuration = 12.minutes,
+    )
+
+    val chart = AsciiWorkloadChart.render(settings)
+
+    chart should include("|")
+    chart should include("/")
+    chart should include("_")
+    chart should include("1.00")
+    chart should include("00:00")
+    chart should include("12:00")
+    AsciiWorkloadChart.hasContinuousStroke(chart) shouldBe true
+  }
+
+  it should "render smooth chart without gaps for short ramps" in {
+    val settings = WorkloadSettings(
+      intensityRps = 10.0,
+      intensityText = "10 rps",
+      profile = WorkloadProfile.StagedIncrement,
+      stagesNumber = 4,
+      rampDuration = 1.second,
+      stageDuration = 3.seconds,
+      testDuration = 16.seconds,
+    )
+
+    val chart = AsciiWorkloadChart.render(settings)
+
+    AsciiWorkloadChart.hasContinuousStroke(chart) shouldBe true
+    chart.linesIterator.exists(line => line.contains("////") || line.contains("/")) shouldBe true
+  }
+
+  it should "build stability timeline as a single ramp and plateau" in {
+    val settings = WorkloadSettings(
+      intensityRps = 1.0,
+      intensityText = "60 rpm",
+      profile = WorkloadProfile.RampAndPlateau,
+      stagesNumber = 2,
+      rampDuration = 1.second,
+      stageDuration = 1.second,
+      testDuration = 5.seconds,
+    )
+
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 1.second, "ramp", 0.0, 1.0),
+      WorkloadSegment(1.second, 2.seconds, "plateau", 1.0, 1.0),
+      WorkloadSegment(2.seconds, 5.seconds, "hold", 1.0, 1.0),
+    )
+  }
+
+  it should "render vertical ramp only when ramp maps to one chart column" in {
+    val settings = WorkloadSettings(
+      intensityRps = 1.0,
+      intensityText = "60 rpm",
+      profile = WorkloadProfile.RampAndPlateau,
+      stagesNumber = 1,
+      rampDuration = 1.second,
+      stageDuration = 1.second,
+      testDuration = 10.minutes,
+    )
+
+    val chart = AsciiWorkloadChart.render(settings)
+
+    AsciiWorkloadChart.hasContinuousStroke(chart) shouldBe true
+    AsciiWorkloadChart.strokeColumns(chart).exists(_.contains("|")) shouldBe true
+  }
+
+  it should "render startup banner with workload preview" in {
+    val banner = StartupBanner.render()
+
+    banner should include("Picatinny Gatling Run")
+    banner should include("Workload")
+    banner should include("Timeline")
+    banner should include("ASCII preview")
+    banner should include("1.00 rps")
+    banner should include("|")
+    banner should include("/")
+    banner should include("_")
+  }
+
+  it should "enable startup banner by default and keep diagnostics disabled by default" in {
+    StartupBanner.isEnabled shouldBe true
+    Diagnostics.isEnabled shouldBe false
+  }
+
+}

--- a/src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala
@@ -1,0 +1,35 @@
+package org.galaxio.gatling.diagnostics
+
+import org.galaxio.gatling.utils.Utility
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UtilityIntegrationSpec extends AnyFlatSpec with Matchers {
+
+  "Utility.banner" should "print startup banner with a continuous workload chart" in {
+    val output = new java.io.ByteArrayOutputStream()
+
+    Console.withOut(output) {
+      Utility.banner()
+    }
+
+    val text = output.toString("UTF-8")
+    text should include("Picatinny Gatling Run")
+    text should include("ASCII preview")
+    text should include("|")
+    text should include("/")
+    text should include("_")
+    AsciiWorkloadChart.hasContinuousStroke(text) shouldBe true
+  }
+
+  "Utility.diagnostics" should "stay silent when diagnostics flag is disabled" in {
+    val output = new java.io.ByteArrayOutputStream()
+
+    Console.withOut(output) {
+      Utility.diagnostics()
+    }
+
+    output.toString("UTF-8") shouldBe empty
+  }
+
+}


### PR DESCRIPTION
## Summary
- add explicit `Utility.banner()` and `Utility.diagnostics()` API for Scala, Java, and Kotlin
- add startup banner with workload timeline and continuous ASCII chart based on Picatinny workload params
- add opt-in runtime/JVM diagnostics controlled by `picatinny.diagnostics.enabled`
- remove old Scala example DEBUG/package-object debug hook
- update README and Scala/Java/Kotlin examples, including Stability and MaxPerformance simulations
- ignore generated build artifacts from example projects

## Verification
- `sbt scalafmtAll scalafmtSbt test`
- `sbt publishLocal`
- `sbt publishM2`
- Scala example: `sbt -Dpicatinny.version='1.0.2+4-47b8d578+20260428-1042-SNAPSHOT' 'Gatling/testOnly org.galaxio.performance.picatinny.Stability'`
- Java example: `mvn -Dpicatinny.version='1.0.2+4-47b8d578+20260428-1042-SNAPSHOT' -Dgatling.simulationClass=org.galaxio.performance.picatinny.Stability gatling:test`
- Kotlin example: `gradle-8.10.2 gatlingRun -PpicatinnyVersion='1.0.2+4-47b8d578+20260428-1042-SNAPSHOT'`
- example compile checks for Scala, Java, and Kotlin after adding MaxPerformance calls

## Notes
- `SimulationConfig` and transaction lifecycle code are intentionally untouched.
- Kotlin full Gatling run was verified with Gradle 8.10.2 because the current Gatling Gradle plugin is not compatible with local Gradle 9.x runtime APIs.
