### PR TITLE
feat(diagnostics): parse gatling injection profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,9 @@ Enable JVM/runtime diagnostics when you need extra debug information:
 -Dpicatinny.diagnostics.enabled=true
 ```
 
-The banner uses the simulation name to render the expected workload shape: `Stability` is shown as `ramp-and-plateau`,
-while `MaxPerformance` is shown as `staged-increment`.
+Pass the same Gatling injection steps to `Utility.banner(...)` that you pass to `inject`/`injectOpen`. The banner parses
+the actual injector objects and renders the effective workload. If no injectors are passed, it falls back to
+`simulation.conf`.
 
 Example `simulation.conf`:
 
@@ -216,14 +217,16 @@ import org.galaxio.gatling.config.SimulationConfig._
 import org.galaxio.gatling.utils.Utility
 
 class Stability extends Simulation {
-  Utility.banner()
+  val injectionProfile = (
+    rampUsersPerSec(0).to(intensity).during(rampDuration),
+    constantUsersPerSec(intensity).during(stageDuration),
+  )
+
+  Utility.banner(injectionProfile)
   Utility.diagnostics()
 
   setUp(
-    scn.inject(
-      rampUsersPerSec(0).to(intensity).during(rampDuration),
-      constantUsersPerSec(intensity).during(stageDuration),
-    ),
+    scn.inject(injectionProfile._1, injectionProfile._2),
   ).protocols(http.baseUrl(baseUrl))
 }
 ```
@@ -231,6 +234,7 @@ class Stability extends Simulation {
 Java usage:
 
 ```java
+import io.gatling.javaapi.core.OpenInjectionStep;
 import io.gatling.javaapi.core.Simulation;
 import org.galaxio.gatling.javaapi.Utility;
 import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
@@ -239,15 +243,15 @@ import static org.galaxio.gatling.javaapi.SimulationConfig.*;
 
 public final class Stability extends Simulation {
     {
-        Utility.banner();
+        OpenInjectionStep[] injectionProfile = {
+            rampUsersPerSec(0).to(intensity()).during(rampDuration()),
+            constantUsersPerSec(intensity()).during(stageDuration())
+        };
+
+        Utility.banner(injectionProfile);
         Utility.diagnostics();
 
-        setUp(
-            scn.injectOpen(
-                rampUsersPerSec(0).to(intensity()).during(rampDuration()),
-                constantUsersPerSec(intensity()).during(stageDuration())
-            )
-        );
+        setUp(scn.injectOpen(injectionProfile));
     }
 }
 ```
@@ -257,21 +261,22 @@ Kotlin usage:
 ```kotlin
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
 import io.gatling.javaapi.core.CoreDsl.rampUsersPerSec
+import io.gatling.javaapi.core.OpenInjectionStep
 import io.gatling.javaapi.core.Simulation
 import org.galaxio.gatling.javaapi.Utility
 import org.galaxio.gatling.javaapi.SimulationConfig.*
 
 class Stability : Simulation() {
     init {
-        Utility.banner()
+        val injectionProfile = arrayOf<OpenInjectionStep>(
+            rampUsersPerSec(0.0).to(intensity()).during(rampDuration()),
+            constantUsersPerSec(intensity()).during(stageDuration()),
+        )
+
+        Utility.banner(*injectionProfile)
         Utility.diagnostics()
 
-        setUp(
-            scn.injectOpen(
-                rampUsersPerSec(0.0).to(intensity()).during(rampDuration()),
-                constantUsersPerSec(intensity()).during(stageDuration()),
-            ),
-        )
+        setUp(scn.injectOpen(*injectionProfile))
     }
 }
 ```
@@ -286,8 +291,8 @@ Startup output:
  Base URL     : http://localhost
 
  Workload
-   intensity      : 60 rpm = 1.00 rps
-   profile        : ramp-and-plateau
+   intensity      : 1.00 rps
+   profile        : provided-open-injection
    ramp duration  : 1m
    stage duration : 5m
    total duration : 6m
@@ -298,13 +303,18 @@ Startup output:
 
  ASCII preview
    rps
-    1.00 |            /_______________________________________________
-    0.75 |         ///
-    0.50 |      ///
-    0.25 |   ///
-    0.00 |///
-         +------------------------------------------------
-          00:00                                    06:00
+    1.00 |           //___________________________________________________________
+    0.89 |          /
+    0.78 |         /
+    0.67 |        /
+    0.56 |      //
+    0.44 |     /
+    0.33 |    /
+    0.22 |   /
+    0.11 | //
+    0.00 |/
+         +------------------------------------------------------------------------
+          00:00                                                            06:00
 ================================================================================
 ```
 

--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/MaxPerformance.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/MaxPerformance.java
@@ -4,23 +4,26 @@ import org.galaxio.gatling.javaapi.SimulationConfig;
 import org.galaxio.gatling.javaapi.Utility;
 import org.galaxio.gatling.transactions.Predef;
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario;
+import io.gatling.javaapi.core.OpenInjectionStep;
 
 import static io.gatling.javaapi.core.CoreDsl.incrementUsersPerSec;
 
 public final class MaxPerformance extends Predef.SimulationWithTransactions {
     {
-        Utility.banner();
+        OpenInjectionStep[] injectionProfile = {
+                incrementUsersPerSec(SimulationConfig.intensity() / SimulationConfig.stagesNumber())
+                        .times(SimulationConfig.stagesNumber())
+                        .eachLevelLasting(SimulationConfig.stageDuration())
+                        .separatedByRampsLasting(SimulationConfig.rampDuration())
+                        .startingFrom(0.0)
+        };
+
+        Utility.banner(injectionProfile);
         Utility.diagnostics();
 
         setUp(
                 PicatinnyScenario.apply("Picatinny Max Performance", "java-max-performance")
-                        .injectOpen(
-                                incrementUsersPerSec(SimulationConfig.intensity() / SimulationConfig.stagesNumber())
-                                        .times(SimulationConfig.stagesNumber())
-                                        .eachLevelLasting(SimulationConfig.stageDuration())
-                                        .separatedByRampsLasting(SimulationConfig.rampDuration())
-                                        .startingFrom(0.0)
-                        )
+                        .injectOpen(injectionProfile)
         ).maxDuration(PerformanceSupport.toScala(SimulationConfig.testDuration()))
                 .assertions(PerformanceSupport.noFailedRequests());
     }

--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/Stability.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/Stability.java
@@ -4,21 +4,24 @@ import org.galaxio.gatling.javaapi.SimulationConfig;
 import org.galaxio.gatling.javaapi.Utility;
 import org.galaxio.gatling.transactions.Predef;
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario;
+import io.gatling.javaapi.core.OpenInjectionStep;
 
 import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
 import static io.gatling.javaapi.core.CoreDsl.rampUsersPerSec;
 
 public final class Stability extends Predef.SimulationWithTransactions {
     {
-        Utility.banner();
+        OpenInjectionStep[] injectionProfile = {
+                rampUsersPerSec(0).to(SimulationConfig.intensity()).during(SimulationConfig.rampDuration()),
+                constantUsersPerSec(SimulationConfig.intensity()).during(SimulationConfig.stageDuration())
+        };
+
+        Utility.banner(injectionProfile);
         Utility.diagnostics();
 
         setUp(
                 PicatinnyScenario.apply("Picatinny Stability", "java-stability")
-                        .injectOpen(
-                                rampUsersPerSec(0).to(SimulationConfig.intensity()).during(SimulationConfig.rampDuration()),
-                                constantUsersPerSec(SimulationConfig.intensity()).during(SimulationConfig.stageDuration())
-                        )
+                        .injectOpen(injectionProfile)
         ).maxDuration(PerformanceSupport.toScala(SimulationConfig.testDuration()))
                 .assertions(PerformanceSupport.noFailedRequests());
     }

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/MaxPerformance.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/MaxPerformance.kt
@@ -1,6 +1,7 @@
 package org.galaxio.performance.picatinny
 
 import io.gatling.javaapi.core.CoreDsl.incrementUsersPerSec
+import io.gatling.javaapi.core.OpenInjectionStep
 import org.galaxio.gatling.javaapi.SimulationConfig
 import org.galaxio.gatling.javaapi.Utility
 import org.galaxio.gatling.transactions.Predef
@@ -8,18 +9,20 @@ import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class MaxPerformance : Predef.SimulationWithTransactions() {
     init {
-        Utility.banner()
+        val injectionProfile = arrayOf<OpenInjectionStep>(
+            incrementUsersPerSec(SimulationConfig.intensity() / SimulationConfig.stagesNumber())
+                .times(SimulationConfig.stagesNumber())
+                .eachLevelLasting(SimulationConfig.stageDuration())
+                .separatedByRampsLasting(SimulationConfig.rampDuration())
+                .startingFrom(0.0),
+        )
+
+        Utility.banner(*injectionProfile)
         Utility.diagnostics()
 
         setUp(
             PicatinnyScenario.apply("Picatinny Max Performance", "kotlin-max-performance")
-                .injectOpen(
-                    incrementUsersPerSec(SimulationConfig.intensity() / SimulationConfig.stagesNumber())
-                        .times(SimulationConfig.stagesNumber())
-                        .eachLevelLasting(SimulationConfig.stageDuration())
-                        .separatedByRampsLasting(SimulationConfig.rampDuration())
-                        .startingFrom(0.0),
-                ),
+                .injectOpen(*injectionProfile),
         ).maxDuration(PerformanceSupport.toScala(SimulationConfig.testDuration()))
             .assertions(PerformanceSupport.noFailedRequests())
     }

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/Stability.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/Stability.kt
@@ -2,6 +2,7 @@ package org.galaxio.performance.picatinny
 
 import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
 import io.gatling.javaapi.core.CoreDsl.rampUsersPerSec
+import io.gatling.javaapi.core.OpenInjectionStep
 import org.galaxio.gatling.javaapi.SimulationConfig
 import org.galaxio.gatling.javaapi.Utility
 import org.galaxio.gatling.transactions.Predef
@@ -9,15 +10,17 @@ import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class Stability : Predef.SimulationWithTransactions() {
     init {
-        Utility.banner()
+        val injectionProfile = arrayOf<OpenInjectionStep>(
+            rampUsersPerSec(0.0).to(SimulationConfig.intensity()).during(SimulationConfig.rampDuration()),
+            constantUsersPerSec(SimulationConfig.intensity()).during(SimulationConfig.stageDuration()),
+        )
+
+        Utility.banner(*injectionProfile)
         Utility.diagnostics()
 
         setUp(
             PicatinnyScenario.apply("Picatinny Stability", "kotlin-stability")
-                .injectOpen(
-                    rampUsersPerSec(0.0).to(SimulationConfig.intensity()).during(SimulationConfig.rampDuration()),
-                    constantUsersPerSec(SimulationConfig.intensity()).during(SimulationConfig.stageDuration()),
-                ),
+                .injectOpen(*injectionProfile),
         ).maxDuration(PerformanceSupport.toScala(SimulationConfig.testDuration()))
             .assertions(PerformanceSupport.noFailedRequests())
     }

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/MaxPerformance.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/MaxPerformance.scala
@@ -7,17 +7,18 @@ import org.galaxio.gatling.utils.Utility
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class MaxPerformance extends SimulationWithTransactions {
-  Utility.banner()
+  private val injectionProfile =
+    incrementUsersPerSec(intensity / stagesNumber)
+      .times(stagesNumber)
+      .eachLevelLasting(stageDuration)
+      .separatedByRampsLasting(rampDuration)
+      .startingFrom(0)
+
+  Utility.banner(injectionProfile)
   Utility.diagnostics()
 
   setUp(
-    PicatinnyScenario("Picatinny Max Performance", "scala-max-performance").inject(
-      incrementUsersPerSec(intensity / stagesNumber)
-        .times(stagesNumber)
-        .eachLevelLasting(stageDuration)
-        .separatedByRampsLasting(rampDuration)
-        .startingFrom(0),
-    ),
+    PicatinnyScenario("Picatinny Max Performance", "scala-max-performance").inject(injectionProfile),
   ).maxDuration(testDuration)
     .assertions(global.failedRequests.count.is(0))
 }

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Stability.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Stability.scala
@@ -7,14 +7,16 @@ import org.galaxio.gatling.utils.Utility
 import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
 
 class Stability extends SimulationWithTransactions {
-  Utility.banner()
+  private val injectionProfile = (
+    rampUsersPerSec(0) to intensity during rampDuration,
+    constantUsersPerSec(intensity) during stageDuration,
+  )
+
+  Utility.banner(injectionProfile)
   Utility.diagnostics()
 
   setUp(
-    PicatinnyScenario("Picatinny Stability", "scala-stability").inject(
-      rampUsersPerSec(0) to intensity during rampDuration,
-      constantUsersPerSec(intensity) during stageDuration,
-    ),
+    PicatinnyScenario("Picatinny Stability", "scala-stability").inject(injectionProfile._1, injectionProfile._2),
   ).maxDuration(testDuration)
     .assertions(global.failedRequests.count.is(0))
 }

--- a/src/main/java/org/galaxio/gatling/javaapi/Utility.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/Utility.java
@@ -1,14 +1,48 @@
 package org.galaxio.gatling.javaapi;
 
+import io.gatling.javaapi.core.ClosedInjectionStep;
+import io.gatling.javaapi.core.OpenInjectionStep;
+
+/**
+ * Convenience diagnostics facade for Java and Kotlin Gatling simulations.
+ *
+ * <p>Prefer {@code banner(OpenInjectionStep...)} or {@code banner(ClosedInjectionStep...)} when a simulation has
+ * explicit Gatling injection steps. Use {@code banner()} only when the banner must fall back to {@code simulation.conf}
+ * workload parameters.</p>
+ */
 public final class Utility {
 
     private Utility() {
     }
 
+    /**
+     * Prints the startup banner from {@code simulation.conf} workload settings when enabled.
+     */
     public static void banner() {
         org.galaxio.gatling.utils.Utility.banner();
     }
 
+    /**
+     * Prints the startup banner by parsing Java/Kotlin Gatling open injection steps.
+     *
+     * @param steps open injection steps passed to {@code injectOpen}
+     */
+    public static void banner(OpenInjectionStep... steps) {
+        org.galaxio.gatling.utils.Utility.banner(steps);
+    }
+
+    /**
+     * Prints the startup banner by parsing Java/Kotlin Gatling closed injection steps.
+     *
+     * @param steps closed injection steps passed to {@code injectClosed}
+     */
+    public static void banner(ClosedInjectionStep... steps) {
+        org.galaxio.gatling.utils.Utility.banner(steps);
+    }
+
+    /**
+     * Prints runtime/JVM diagnostics when enabled.
+     */
     public static void diagnostics() {
         org.galaxio.gatling.utils.Utility.diagnostics();
     }

--- a/src/main/scala/org/galaxio/gatling/diagnostics/AsciiWorkloadChart.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/AsciiWorkloadChart.scala
@@ -27,7 +27,7 @@ private[diagnostics] object AsciiWorkloadChart {
     }
       .mkString("\n")
 
-    s"""   rps
+    s"""   ${settings.unit}
        |$body
        |         +${"-" * Width}
        |          00:00${" " * math.max(1, Width - 12)}${Formatters.time(settings.testDuration)}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/InjectionProfileParser.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/InjectionProfileParser.scala
@@ -1,0 +1,153 @@
+package org.galaxio.gatling.diagnostics
+
+import io.gatling.core.controller.inject.closed._
+import io.gatling.core.controller.inject.open._
+
+import scala.concurrent.duration._
+
+private[gatling] object InjectionProfileParser {
+
+  def fromOpen(steps: Iterable[OpenInjectionStep]): Option[WorkloadSettings] = {
+    val segments = openSegments(flattenOpen(steps.toList))
+    fromSegments("provided-open-injection", "rps", segments)
+  }
+
+  def fromClosed(steps: Iterable[ClosedInjectionStep]): Option[WorkloadSettings] = {
+    val segments = closedSegments(flattenClosed(steps.toList))
+    fromSegments("provided-closed-injection", "users", segments)
+  }
+
+  def javaOpen(steps: Array[io.gatling.javaapi.core.OpenInjectionStep]): Option[WorkloadSettings] =
+    fromOpen(steps.iterator.map(_.asScala()).toList)
+
+  def javaClosed(steps: Array[io.gatling.javaapi.core.ClosedInjectionStep]): Option[WorkloadSettings] =
+    fromClosed(steps.iterator.map(_.asScala()).toList)
+
+  private def fromSegments(profile: String, unit: String, segments: List[WorkloadSegment]): Option[WorkloadSettings] =
+    segments.lastOption.map { last =>
+      val maxLevel = math.max(0.01, segments.map(segment => math.max(segment.fromRps, segment.toRps)).max)
+      WorkloadSettings(
+        intensityRps = maxLevel,
+        intensityText = s"${Formatters.decimal(maxLevel)} $unit",
+        profile = WorkloadProfile.Provided(profile),
+        stagesNumber = segments.count(segment => segment.kind == "stage" || segment.kind == "plateau"),
+        rampDuration = segments.find(_.kind.contains("ramp")).map(segment => segment.end - segment.start).getOrElse(0.seconds),
+        stageDuration =
+          segments.filter(segment => segment.kind == "stage" || segment.kind == "plateau").foldLeft(0.seconds)(_ + _.duration),
+        testDuration = last.end,
+        unit = unit,
+        segmentsOverride = Some(segments),
+      )
+    }
+
+  private def openSegments(steps: List[OpenInjectionStep]): List[WorkloadSegment] =
+    steps
+      .foldLeft((List.empty[WorkloadSegment], 0.seconds, 0.0)) { case ((segments, cursor, currentRate), step) =>
+        val (next, nextRate) = step match {
+          case s: NothingForOpenInjection   =>
+            List(WorkloadSegment(cursor, cursor + s.duration, "pause", 0.0, 0.0)) -> 0.0
+          case s: AtOnceOpenInjection       =>
+            List(WorkloadSegment(cursor, cursor, "at-once", currentRate, s.users.toDouble)) -> currentRate
+          case s: RampOpenInjection         =>
+            val rate = rateFromUsers(s.users, s.duration)
+            List(WorkloadSegment(cursor, cursor + s.duration, "constant-users", rate, rate)) -> rate
+          case s: ConstantRateOpenInjection =>
+            List(WorkloadSegment(cursor, cursor + s.duration, "plateau", s.rate, s.rate)) -> s.rate
+          case s: RampRateOpenInjection     =>
+            List(WorkloadSegment(cursor, cursor + s.duration, "ramp", s.startRate, s.endRate)) -> s.endRate
+          case s: PoissonOpenInjection      =>
+            List(WorkloadSegment(cursor, cursor + s.duration, "randomized-ramp", s.startRate, s.endRate)) -> s.endRate
+          case s: HeavisideOpenInjection    =>
+            stressPeak(cursor, longField(s, 0), s.duration) -> currentRate
+          case other                        =>
+            val duration = durationField(other)
+            val rate     = rateFromUsers(longField(other, 0), duration)
+            List(WorkloadSegment(cursor, cursor + duration, other.productPrefix, rate, rate)) -> rate
+        }
+        (segments ++ next, cursor + durationField(step), nextRate)
+      }
+      ._1
+
+  private def closedSegments(steps: List[ClosedInjectionStep]): List[WorkloadSegment] =
+    steps
+      .foldLeft((List.empty[WorkloadSegment], 0.seconds)) { case ((segments, cursor), step) =>
+        val next = step match {
+          case s: ConstantConcurrentUsersInjection =>
+            val duration = durationField(s)
+            List(WorkloadSegment(cursor, cursor + duration, "plateau", s.number.toDouble, s.number.toDouble))
+          case s: RampConcurrentUsersInjection     =>
+            val duration = durationField(s)
+            List(WorkloadSegment(cursor, cursor + duration, "ramp", s.from.toDouble, s.to.toDouble))
+          case other                               =>
+            val duration = durationField(other)
+            val start    = doubleField(other, 0)
+            val end      = doubleField(other, math.max(0, other.productArity - 2))
+            List(WorkloadSegment(cursor, cursor + duration, other.productPrefix, start, end))
+        }
+        (segments ++ next, cursor + durationField(step))
+      }
+      ._1
+
+  private def flattenOpen(steps: List[OpenInjectionStep]): List[OpenInjectionStep] =
+    steps.flatMap {
+      case s: StairsUsersPerSecCompositeStep => openStairs(s)
+      case step                              => List(step)
+    }
+
+  private def flattenClosed(steps: List[ClosedInjectionStep]): List[ClosedInjectionStep] =
+    steps.flatMap {
+      case s: StairsConcurrentUsersCompositeStep => closedStairs(s)
+      case step                                  => List(step)
+    }
+
+  private def openStairs(step: StairsUsersPerSecCompositeStep): List[OpenInjectionStep] =
+    (1 to step.levels).toList.flatMap { level =>
+      val from = step.startingRate + step.rateIncrement * (level - 1)
+      val to   = step.startingRate + step.rateIncrement * level
+      List(
+        RampRateOpenInjection(from, to, step.rampDuration),
+        ConstantRateOpenInjection(to, step.duration),
+      )
+    }
+
+  private def closedStairs(step: StairsConcurrentUsersCompositeStep): List[ClosedInjectionStep] =
+    (1 to step.levels).toList.flatMap { level =>
+      val from = step.startingUsers + step.usersIncrement * (level - 1)
+      val to   = step.startingUsers + step.usersIncrement * level
+      List(
+        RampConcurrentUsersInjection(from, to, step.rampDuration),
+        ConstantConcurrentUsersInjection(to, step.levelDuration),
+      )
+    }
+
+  private def stressPeak(start: FiniteDuration, users: Long, duration: FiniteDuration): List[WorkloadSegment] = {
+    val peak = rateFromUsers(users, duration) * 2
+    val mid  = start + duration / 2
+    List(
+      WorkloadSegment(start, mid, "stress-peak", 0.0, peak),
+      WorkloadSegment(mid, start + duration, "stress-peak", peak, 0.0),
+    )
+  }
+
+  private def rateFromUsers(users: Long, duration: FiniteDuration): Double =
+    users.toDouble / math.max(1.0, duration.toSeconds.toDouble)
+
+  private def durationField(product: Product): FiniteDuration =
+    product.productIterator.collectFirst { case duration: FiniteDuration => duration }.getOrElse(0.seconds)
+
+  private def longField(product: Product, index: Int): Long =
+    product.productElement(index) match {
+      case value: Long => value
+      case value: Int  => value.toLong
+      case _           => 0L
+    }
+
+  private def doubleField(product: Product, index: Int): Double =
+    product.productElement(index) match {
+      case value: Double => value
+      case value: Int    => value.toDouble
+      case value: Long   => value.toDouble
+      case _             => 0.0
+    }
+
+}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala
@@ -1,5 +1,7 @@
 package org.galaxio.gatling.diagnostics
 
+import io.gatling.core.controller.inject.closed.ClosedInjectionStep
+import io.gatling.core.controller.inject.open.OpenInjectionStep
 import org.galaxio.gatling.config.ConfigManager
 import org.galaxio.gatling.utils.IntensityConverter.getIntensityFromString
 
@@ -10,24 +12,36 @@ object StartupBanner {
   private val InternalStackNames = Set("Utility", "StartupBanner", "Diagnostics")
 
   def printIfEnabled(): Unit =
-    printIfEnabled(None)
+    if (isEnabled) println(render())
+
+  def printOpenIfEnabled(openSteps: Iterable[OpenInjectionStep]): Unit =
+    printSettingsIfEnabled(InjectionProfileParser.fromOpen(openSteps))
+
+  def printClosedIfEnabled(closedSteps: Iterable[ClosedInjectionStep]): Unit =
+    printSettingsIfEnabled(InjectionProfileParser.fromClosed(closedSteps))
 
   def printIfEnabled(simulationClass: Class[_]): Unit =
-    printIfEnabled(Some(simulationClass))
+    printSimulationIfEnabled(Some(simulationClass))
 
-  private def printIfEnabled(simulationClass: Option[Class[_]]): Unit =
-    if (isEnabled) println(render(simulationClass))
+  private[gatling] def printSettingsIfEnabled(settings: Option[WorkloadSettings]): Unit =
+    if (isEnabled) println(settings.map(render).getOrElse(render()))
+
+  private def printSimulationIfEnabled(simulationClass: Option[Class[_]]): Unit =
+    if (isEnabled) println(render(simulationClass, None))
 
   private[gatling] def isEnabled: Boolean =
     ConfigManager.simulationConfig.get(EnabledPath, true)
 
   private[diagnostics] def render(): String =
-    render(None)
+    render(None, None)
+
+  private[diagnostics] def render(settings: WorkloadSettings): String =
+    render(None, Some(settings))
 
   private[diagnostics] def render(simulationClass: Class[_]): String =
-    render(Some(simulationClass))
+    render(Some(simulationClass), None)
 
-  private def render(simulationClass: Option[Class[_]]): String = {
+  private def render(simulationClass: Option[Class[_]], providedSettings: Option[WorkloadSettings]): String = {
     val config = ConfigManager.simulationConfig
     val stages = config.get[Int]("stagesNumber", 1)
     val line   = "=" * 80
@@ -39,12 +53,12 @@ object StartupBanner {
        | Simulation   : $name
        | Base URL     : ${config.get[String]("baseUrl", "<undefined>")}
        |
-       |${workloadBlock(name, stages)}
+       |${providedSettings.map(workloadBlock).getOrElse(configWorkloadBlock(name, stages))}
        |$line
        |""".stripMargin
   }
 
-  private def workloadBlock(simulationName: String, stages: Int): String = {
+  private def configWorkloadBlock(simulationName: String, stages: Int): String = {
     val config        = ConfigManager.simulationConfig
     val intensityText = config.getOpt[String]("intensity")
     val ramp          = config.getOpt[FiniteDuration]("rampDuration")
@@ -56,6 +70,7 @@ object StartupBanner {
         val fallback = profile match {
           case WorkloadProfile.RampAndPlateau  => rampDuration + stageDuration
           case WorkloadProfile.StagedIncrement => (rampDuration + stageDuration) * stages
+          case WorkloadProfile.Provided(_)     => rampDuration + stageDuration
         }
         val total    = config.get[FiniteDuration]("testDuration", fallback)
         val settings = WorkloadSettings(
@@ -68,14 +83,7 @@ object StartupBanner {
           testDuration = total,
         )
 
-        s""" Workload
-           |${settingsBlock(settings)}
-           |
-           | Timeline
-           |${WorkloadTimeline.render(settings)}
-           |
-           | ASCII preview
-           |${AsciiWorkloadChart.render(settings)}""".stripMargin
+        workloadBlock(settings)
 
       case _ =>
         val missing = List(
@@ -89,18 +97,34 @@ object StartupBanner {
     }
   }
 
+  private def workloadBlock(settings: WorkloadSettings): String =
+    s""" Workload
+       |${settingsBlock(settings)}
+       |
+       | Timeline
+       |${WorkloadTimeline.render(settings)}
+       |
+       | ASCII preview
+       |${AsciiWorkloadChart.render(settings)}""".stripMargin
+
   private def settingsBlock(settings: WorkloadSettings): String =
     List(
-      "intensity"      -> s"${settings.intensityText} = ${Formatters.decimal(settings.intensityRps)} rps",
+      "intensity"      -> intensityLine(settings),
       "profile"        -> settings.profile.label,
       "stages"         -> settings.stagesNumber.toString,
       "ramp duration"  -> Formatters.duration(settings.rampDuration),
       "stage duration" -> Formatters.duration(settings.stageDuration),
       "total duration" -> Formatters.duration(settings.testDuration),
-    ).filterNot { case (name, _) => name == "stages" && settings.profile == WorkloadProfile.RampAndPlateau }.map {
-      case (name, value) => s"   ${name.padTo(15, ' ')}: $value"
+    ).filterNot { case (name, _) =>
+      name == "stages" && (settings.profile == WorkloadProfile.RampAndPlateau || settings.stagesNumber <= 1)
+    }.map { case (name, value) =>
+      s"   ${name.padTo(15, ' ')}: $value"
     }
       .mkString("\n")
+
+  private def intensityLine(settings: WorkloadSettings): String =
+    if (settings.intensityText.endsWith(s" ${settings.unit}")) settings.intensityText
+    else s"${settings.intensityText} = ${Formatters.decimal(settings.intensityRps)} ${settings.unit}"
 
   private def simulationName(simulationClass: Option[Class[_]]): String =
     simulationClass

--- a/src/main/scala/org/galaxio/gatling/diagnostics/WorkloadTimeline.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/WorkloadTimeline.scala
@@ -10,6 +10,8 @@ private[diagnostics] final case class WorkloadSettings(
     rampDuration: FiniteDuration,
     stageDuration: FiniteDuration,
     testDuration: FiniteDuration,
+    unit: String = "rps",
+    segmentsOverride: Option[List[WorkloadSegment]] = None,
 )
 
 private[diagnostics] final case class WorkloadSegment(
@@ -18,7 +20,9 @@ private[diagnostics] final case class WorkloadSegment(
     kind: String,
     fromRps: Double,
     toRps: Double,
-)
+) {
+  def duration: FiniteDuration = end - start
+}
 
 private[diagnostics] sealed trait WorkloadProfile {
   def label: String
@@ -33,6 +37,8 @@ private[diagnostics] object WorkloadProfile {
     override val label: String = "staged-increment"
   }
 
+  final case class Provided(label: String) extends WorkloadProfile
+
   def fromSimulationName(name: String): WorkloadProfile =
     if (name.toLowerCase.contains("maxperformance")) StagedIncrement
     else RampAndPlateau
@@ -41,9 +47,12 @@ private[diagnostics] object WorkloadProfile {
 private[diagnostics] object WorkloadTimeline {
 
   def segments(settings: WorkloadSettings): List[WorkloadSegment] =
-    settings.profile match {
-      case WorkloadProfile.RampAndPlateau  => clamp(rampAndPlateau(settings), settings.testDuration)
-      case WorkloadProfile.StagedIncrement => clamp(stagedIncrement(settings), settings.testDuration)
+    settings.segmentsOverride.getOrElse {
+      settings.profile match {
+        case WorkloadProfile.RampAndPlateau  => clamp(rampAndPlateau(settings), settings.testDuration)
+        case WorkloadProfile.StagedIncrement => clamp(stagedIncrement(settings), settings.testDuration)
+        case WorkloadProfile.Provided(_)     => Nil
+      }
     }
 
   private def rampAndPlateau(settings: WorkloadSettings): List[WorkloadSegment] =
@@ -88,17 +97,18 @@ private[diagnostics] object WorkloadTimeline {
 
   def render(settings: WorkloadSettings): String =
     segments(settings)
-      .map(renderSegment)
+      .map(renderSegment(_, settings.unit))
       .mkString("\n")
 
-  private def renderSegment(segment: WorkloadSegment): String = {
+  private def renderSegment(segment: WorkloadSegment, unit: String): String = {
     val range = s"${Formatters.time(segment.start)} - ${Formatters.time(segment.end)}"
     val label = segment.kind.padTo(5, ' ')
     val level = Formatters.decimal(segment.toRps)
 
     segment.kind match {
-      case "ramp" => s"   $range  $label  ${Formatters.decimal(segment.fromRps)} -> $level rps"
-      case _      => s"   $range  $label  $level rps"
+      case "ramp" | "randomized-ramp" | "stress-peak" =>
+        s"   $range  $label  ${Formatters.decimal(segment.fromRps)} -> $level $unit"
+      case _                                          => s"   $range  $label  $level $unit"
     }
   }
 

--- a/src/main/scala/org/galaxio/gatling/utils/Utility.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/Utility.scala
@@ -1,12 +1,63 @@
 package org.galaxio.gatling.utils
 
 import org.galaxio.gatling.diagnostics.{Diagnostics, StartupBanner}
+import io.gatling.core.controller.inject.closed.ClosedInjectionStep
+import io.gatling.core.controller.inject.open.OpenInjectionStep
 
+/** Convenience diagnostics facade for Gatling simulations.
+  *
+  * Use `banner(injectionProfile)` when the simulation has explicit Gatling injection steps. Use `banner()` only when the banner
+  * must fall back to `simulation.conf` workload parameters.
+  */
 object Utility {
 
+  /** Prints the startup banner from `simulation.conf` workload settings when `picatinny.startup.banner.enabled` is true.
+    */
   def banner(): Unit =
     StartupBanner.printIfEnabled()
 
+  /** Prints the startup banner by parsing Scala Gatling open or closed injection steps.
+    */
+  def banner(steps: Iterable[_]): Unit =
+    printFromValues(steps.toList)
+
+  /** Prints the startup banner by parsing a single Scala Gatling open injection step.
+    */
+  def banner(step: OpenInjectionStep): Unit =
+    StartupBanner.printOpenIfEnabled(List(step))
+
+  /** Prints the startup banner by parsing a single Scala Gatling closed injection step.
+    */
+  def banner(step: ClosedInjectionStep): Unit =
+    StartupBanner.printClosedIfEnabled(List(step))
+
+  /** Prints the startup banner by parsing a tuple of Scala Gatling injection steps.
+    */
+  def banner(steps: Product): Unit =
+    printFromValues(steps.productIterator.toList)
+
+  /** Prints the startup banner by parsing Java/Kotlin Gatling open injection steps.
+    */
+  def banner(steps: Array[io.gatling.javaapi.core.OpenInjectionStep]): Unit =
+    StartupBanner.printSettingsIfEnabled(org.galaxio.gatling.diagnostics.InjectionProfileParser.javaOpen(steps))
+
+  /** Prints the startup banner by parsing Java/Kotlin Gatling closed injection steps.
+    */
+  def banner(steps: Array[io.gatling.javaapi.core.ClosedInjectionStep]): Unit =
+    StartupBanner.printSettingsIfEnabled(org.galaxio.gatling.diagnostics.InjectionProfileParser.javaClosed(steps))
+
+  private def printFromValues(values: List[Any]): Unit =
+    values match {
+      case values if values.forall(_.isInstanceOf[OpenInjectionStep])   =>
+        StartupBanner.printOpenIfEnabled(values.collect { case step: OpenInjectionStep => step })
+      case values if values.forall(_.isInstanceOf[ClosedInjectionStep]) =>
+        StartupBanner.printClosedIfEnabled(values.collect { case step: ClosedInjectionStep => step })
+      case _                                                            =>
+        banner()
+    }
+
+  /** Prints runtime/JVM diagnostics when `picatinny.diagnostics.enabled` is true.
+    */
   def diagnostics(): Unit =
     Diagnostics.printIfEnabled()
 

--- a/src/test/resources/simulation.conf
+++ b/src/test/resources/simulation.conf
@@ -12,3 +12,6 @@ stagesNumber: 5
 rampDuration: 10 minutes
 stageDuration: 30 minutes
 intensity: 3600 rph
+
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = true

--- a/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
@@ -147,6 +147,130 @@ class DiagnosticsSpec extends AnyFlatSpec with Matchers with OptionValues {
     )
   }
 
+  it should "parse open rate profile with pause, ramp and plateau" in {
+    val settings = InjectionProfileParser
+      .fromOpen(
+        Seq(
+          nothingFor(2.seconds),
+          rampUsersPerSec(1).to(3).during(4.seconds),
+          constantUsersPerSec(3).during(5.seconds),
+        ),
+      )
+      .value
+
+    settings.unit shouldBe "rps"
+    settings.intensityRps shouldBe 3.0
+    settings.rampDuration shouldBe 4.seconds
+    settings.stageDuration shouldBe 5.seconds
+    settings.testDuration shouldBe 11.seconds
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 2.seconds, "pause", 0.0, 0.0),
+      WorkloadSegment(2.seconds, 6.seconds, "ramp", 1.0, 3.0),
+      WorkloadSegment(6.seconds, 11.seconds, "plateau", 3.0, 3.0),
+    )
+  }
+
+  it should "parse open user profile with at once and ramp users" in {
+    val settings = InjectionProfileParser
+      .fromOpen(
+        Seq(
+          atOnceUsers(25),
+          rampUsers(50).during(10.seconds),
+        ),
+      )
+      .value
+
+    settings.unit shouldBe "rps"
+    settings.intensityRps shouldBe 25.0
+    settings.testDuration shouldBe 10.seconds
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 0.seconds, "at-once", 0.0, 25.0),
+      WorkloadSegment(0.seconds, 10.seconds, "constant-users", 5.0, 5.0),
+    )
+  }
+
+  it should "parse open stress peak profile as a rise and fall" in {
+    val settings = InjectionProfileParser
+      .fromOpen(
+        Seq(
+          stressPeakUsers(20).during(10.seconds),
+        ),
+      )
+      .value
+
+    settings.unit shouldBe "rps"
+    settings.intensityRps shouldBe 4.0
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 5.seconds, "stress-peak", 0.0, 4.0),
+      WorkloadSegment(5.seconds, 10.seconds, "stress-peak", 4.0, 0.0),
+    )
+  }
+
+  it should "parse closed concurrent users profile with plateau and ramp" in {
+    val settings = InjectionProfileParser
+      .fromClosed(
+        Seq(
+          constantConcurrentUsers(5).during(3.seconds),
+          rampConcurrentUsers(5).to(12).during(7.seconds),
+        ),
+      )
+      .value
+
+    settings.unit shouldBe "users"
+    settings.intensityRps shouldBe 12.0
+    settings.profile.label shouldBe "provided-closed-injection"
+    settings.rampDuration shouldBe 7.seconds
+    settings.stageDuration shouldBe 3.seconds
+    settings.testDuration shouldBe 10.seconds
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 3.seconds, "plateau", 5.0, 5.0),
+      WorkloadSegment(3.seconds, 10.seconds, "ramp", 5.0, 12.0),
+    )
+  }
+
+  it should "parse closed concurrent stairs profile" in {
+    val settings = InjectionProfileParser
+      .fromClosed(
+        Seq(
+          incrementConcurrentUsers(3)
+            .times(2)
+            .eachLevelLasting(4.seconds)
+            .separatedByRampsLasting(2.seconds)
+            .startingFrom(1),
+        ),
+      )
+      .value
+
+    settings.unit shouldBe "users"
+    settings.intensityRps shouldBe 7.0
+    settings.stagesNumber shouldBe 2
+    settings.rampDuration shouldBe 2.seconds
+    settings.stageDuration shouldBe 8.seconds
+    settings.testDuration shouldBe 12.seconds
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 2.seconds, "ramp", 1.0, 4.0),
+      WorkloadSegment(2.seconds, 6.seconds, "plateau", 4.0, 4.0),
+      WorkloadSegment(6.seconds, 8.seconds, "ramp", 4.0, 7.0),
+      WorkloadSegment(8.seconds, 12.seconds, "plateau", 7.0, 7.0),
+    )
+  }
+
+  it should "parse Java open injection steps used by Java and Kotlin facade" in {
+    val steps = Array(
+      io.gatling.javaapi.core.CoreDsl.rampUsersPerSec(0.0).to(2.0).during(java.time.Duration.ofSeconds(2)),
+      io.gatling.javaapi.core.CoreDsl.constantUsersPerSec(2.0).during(java.time.Duration.ofSeconds(3)),
+    )
+
+    val settings = InjectionProfileParser.javaOpen(steps).value
+
+    settings.unit shouldBe "rps"
+    settings.intensityRps shouldBe 2.0
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 2.seconds, "ramp", 0.0, 2.0),
+      WorkloadSegment(2.seconds, 5.seconds, "plateau", 2.0, 2.0),
+    )
+  }
+
   it should "render startup banner with workload preview" in {
     val banner = StartupBanner.render()
 

--- a/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
@@ -1,11 +1,13 @@
 package org.galaxio.gatling.diagnostics
 
+import io.gatling.core.Predef._
+import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class DiagnosticsSpec extends AnyFlatSpec with Matchers {
+class DiagnosticsSpec extends AnyFlatSpec with Matchers with OptionValues {
 
   it should "format durations in a compact human readable form" in {
     Formatters.duration(0.seconds) shouldBe "0s"
@@ -107,6 +109,44 @@ class DiagnosticsSpec extends AnyFlatSpec with Matchers {
     AsciiWorkloadChart.strokeColumns(chart).exists(_.contains("|")) shouldBe true
   }
 
+  it should "parse explicit Gatling stability injection as ramp and plateau" in {
+    val settings = InjectionProfileParser
+      .fromOpen(
+        Seq(
+          rampUsersPerSec(0).to(1).during(1.second),
+          constantUsersPerSec(1).during(4.seconds),
+        ),
+      )
+      .value
+
+    settings.profile.label shouldBe "provided-open-injection"
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 1.second, "ramp", 0.0, 1.0),
+      WorkloadSegment(1.second, 5.seconds, "plateau", 1.0, 1.0),
+    )
+  }
+
+  it should "parse explicit Gatling max performance stairs injection" in {
+    val settings = InjectionProfileParser
+      .fromOpen(
+        Seq(
+          incrementUsersPerSec(0.5)
+            .times(2)
+            .eachLevelLasting(1.second)
+            .separatedByRampsLasting(1.second)
+            .startingFrom(0),
+        ),
+      )
+      .value
+
+    WorkloadTimeline.segments(settings) shouldBe List(
+      WorkloadSegment(0.seconds, 1.second, "ramp", 0.0, 0.5),
+      WorkloadSegment(1.second, 2.seconds, "plateau", 0.5, 0.5),
+      WorkloadSegment(2.seconds, 3.seconds, "ramp", 0.5, 1.0),
+      WorkloadSegment(3.seconds, 4.seconds, "plateau", 1.0, 1.0),
+    )
+  }
+
   it should "render startup banner with workload preview" in {
     val banner = StartupBanner.render()
 
@@ -120,9 +160,9 @@ class DiagnosticsSpec extends AnyFlatSpec with Matchers {
     banner should include("_")
   }
 
-  it should "enable startup banner by default and keep diagnostics disabled by default" in {
+  it should "enable startup banner and diagnostics in test resources" in {
     StartupBanner.isEnabled shouldBe true
-    Diagnostics.isEnabled shouldBe false
+    Diagnostics.isEnabled shouldBe true
   }
 
 }

--- a/src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala
@@ -22,14 +22,16 @@ class UtilityIntegrationSpec extends AnyFlatSpec with Matchers {
     AsciiWorkloadChart.hasContinuousStroke(text) shouldBe true
   }
 
-  "Utility.diagnostics" should "stay silent when diagnostics flag is disabled" in {
+  "Utility.diagnostics" should "print diagnostics when enabled in test resources" in {
     val output = new java.io.ByteArrayOutputStream()
 
     Console.withOut(output) {
       Utility.diagnostics()
     }
 
-    output.toString("UTF-8") shouldBe empty
+    val text = output.toString("UTF-8")
+    text should include("Diagnostics")
+    text should include("jvm args")
   }
 
 }


### PR DESCRIPTION
## Summary
- parse explicit Gatling open/closed injection steps for `Utility.banner(...)`
- render startup banner workload/timeline/ASCII chart from actual injector objects, with `simulation.conf` fallback
- support Scala tuple/collection/single-step usage and Java/Kotlin varargs via the Java facade
- update Scala/Java/Kotlin examples and README usage
- enable diagnostics in test/example resources
- expand diagnostics unit coverage across open, closed, staged, stress peak, user/rate, and Java facade profiles

## Tested Profiles
- `rampUsersPerSec` + `constantUsersPerSec` stability profile
- `incrementUsersPerSec` max-performance stairs profile
- `nothingFor` + ramp + plateau open rate profile
- `atOnceUsers` + `rampUsers` open user profile
- `stressPeakUsers` rise/fall profile
- `constantConcurrentUsers` + `rampConcurrentUsers` closed profile
- `incrementConcurrentUsers` closed stairs profile
- Java/Kotlin facade conversion from Java `OpenInjectionStep[]`

## Verification
- `sbt scalafmtAll scalafmtSbt test` — 102 tests passed
- `sbt scalafmtAll scalafmtSbt test publishLocal publishM2`
- `sbt -Dpicatinny.version='1.1.0+0-902e840a+20260428-2159-SNAPSHOT' 'Gatling/testOnly org.galaxio.performance.picatinny.Stability'`
- `sbt -Dpicatinny.version='1.1.0+0-902e840a+20260428-2155-SNAPSHOT' 'Gatling/testOnly org.galaxio.performance.picatinny.MaxPerformance'`
- `mvn -Dpicatinny.version='1.1.0+0-902e840a+20260428-2155-SNAPSHOT' -Dgatling.simulationClass=org.galaxio.performance.picatinny.Stability gatling:test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) /tmp/codex-gradle/gradle-8.10.2/bin/gradle --no-daemon -Dorg.gradle.java.home=$(/usr/libexec/java_home -v 17) gatlingClasses -PpicatinnyVersion='1.1.0+0-902e840a+20260428-2155-SNAPSHOT'`
