### PR TITLE
feat(config): harden simulation config api

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ duration: {
     durationVariable: 3600s
 }
 booleanVariable: true
+stringListVariable: ["foo", "bar"]
+client {
+  timeout: 10 seconds
+}
 ```
 
 Scala example:
@@ -142,6 +146,10 @@ val intVariable = getIntParam("intVariable")
 val doubleVariable = getDoubleParam("doubleVariable")
 val durationVariable = getDurationParam("duration.durationVariable")
 val booleanVariable = getBooleanParam("booleanVariable")
+val stringListVariable = getStringListParam("stringListVariable")
+val clientConfig = getConfigParam("client")
+
+val optionalValue = getOptStringParam("optionalVariable")
 ```
 
 Java example:
@@ -154,6 +162,10 @@ int intVariable = getIntParam("intVariable");
 double doubleVariable = getDoubleParam("doubleVariable");
 Duration durationVariable = getDurationParam("duration.durationVariable");
 boolean booleanVariable = getBooleanParam("booleanVariable");
+List<String> stringListVariable = getStringListParam("stringListVariable");
+Config clientConfig = getConfigParam("client");
+
+Optional<String> optionalValue = getOptStringParam("optionalVariable");
 ```
 
 Kotlin example:
@@ -166,7 +178,30 @@ val intVariable = getIntParam("intVariable")
 val doubleVariable = getDoubleParam("doubleVariable")
 val durationVariable = getDurationParam("duration.durationVariable")
 val booleanVariable = getBooleanParam("booleanVariable")
+val stringListVariable = getStringListParam("stringListVariable")
+val clientConfig = getConfigParam("client")
+
+val optionalValue = getOptStringParam("optionalVariable")
 ```
+
+Required getters throw `SimulationConfigException` when a value is missing or has an invalid type. Optional getters return
+`None` in Scala and `Optional.empty()` in Java/Kotlin when the path is not defined.
+
+JVM system properties override values from `simulation.conf`, which is useful for CI and environment-specific runs:
+
+```bash
+sbt Gatling/test -DbaseUrl=https://test.example.org -Dintensity="120 rpm"
+```
+
+Workload defaults are validated when they are first read:
+
+- `stagesNumber` must be greater than `0`
+- `intensity` must resolve to a value greater than `0` rps
+- `rampDuration` must be `0` or greater
+- `stageDuration` and `testDuration` must be greater than `0`
+
+Config values are logged when they are read. Paths containing words like `password`, `secret`, `token`, `apiKey`, or
+`credential` are masked in logs as `******`.
 
 ### startup banner and diagnostics
 

--- a/src/main/java/org/galaxio/gatling/javaapi/SimulationConfig.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/SimulationConfig.java
@@ -1,60 +1,208 @@
 package org.galaxio.gatling.javaapi;
 
+import com.typesafe.config.Config;
+
 import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import static scala.jdk.javaapi.DurationConverters.toJava;
+import scala.jdk.javaapi.CollectionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
+/**
+ * Java and Kotlin facade for reading Picatinny simulation settings from {@code simulation.conf}.
+ *
+ * <p>JVM system properties override values from {@code simulation.conf}, so CI and environment-specific runs can pass
+ * values such as {@code -DbaseUrl=https://test.example.org} or {@code -Dintensity="120 rpm"}.</p>
+ *
+ * <p>Required getters throw {@link org.galaxio.gatling.config.SimulationConfigException} when a value is missing or has
+ * an invalid type. Optional getters return {@code Optional.empty()} when the path is not defined.</p>
+ */
 public final class SimulationConfig {
 
+    /**
+     * Reads a required string parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not a string
+     */
     public static String getStringParam(String path) {
-        return org.galaxio.gatling.config.SimulationConfig.getStringParam(path);
+        return org.galaxio.gatling.config.SimulationConfig.getStringParam(requirePath(path));
     }
 
+    /**
+     * Reads a required integer parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not an integer
+     */
     public static Integer getIntParam(String path) {
-        return org.galaxio.gatling.config.SimulationConfig.getIntParam(path);
+        return org.galaxio.gatling.config.SimulationConfig.getIntParam(requirePath(path));
     }
 
+    /**
+     * Reads a required double parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not numeric
+     */
     public static Double getDoubleParam(String path) {
-        return org.galaxio.gatling.config.SimulationConfig.getDoubleParam(path);
+        return org.galaxio.gatling.config.SimulationConfig.getDoubleParam(requirePath(path));
     }
 
+    /**
+     * Reads a required duration parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not a duration
+     */
     public static Duration getDurationParam(String path) {
-        return toJava(org.galaxio.gatling.config.SimulationConfig.getDurationParam(path));
+        return toJava(org.galaxio.gatling.config.SimulationConfig.getDurationParam(requirePath(path)));
     }
 
+    /**
+     * Reads a required boolean parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not a boolean
+     */
     public static Boolean getBooleanParam(String path) {
-        return org.galaxio.gatling.config.SimulationConfig.getBooleanParam(path);
+        return org.galaxio.gatling.config.SimulationConfig.getBooleanParam(requirePath(path));
     }
 
+    /**
+     * Reads a required list of strings.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not a string list
+     */
+    public static List<String> getStringListParam(String path) {
+        return CollectionConverters.asJava(org.galaxio.gatling.config.SimulationConfig.getStringListParam(requirePath(path)));
+    }
+
+    /**
+     * Reads a required nested Typesafe Config block.
+     *
+     * @throws NullPointerException when {@code path} is null
+     * @throws org.galaxio.gatling.config.SimulationConfigException when the path is missing or is not an object
+     */
+    public static Config getConfigParam(String path) {
+        return org.galaxio.gatling.config.SimulationConfig.getConfigParam(requirePath(path));
+    }
+
+    /**
+     * Reads an optional string parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<String> getOptStringParam(String path) {
+        return OptionConverters.toJava(org.galaxio.gatling.config.SimulationConfig.getOptStringParam(requirePath(path)));
+    }
+
+    /**
+     * Reads an optional integer parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<Integer> getOptIntParam(String path) {
+        scala.Option<Object> value = org.galaxio.gatling.config.SimulationConfig.getOptIntParam(requirePath(path));
+        return value.isDefined() ? Optional.of((Integer) value.get()) : Optional.empty();
+    }
+
+    /**
+     * Reads an optional double parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<Double> getOptDoubleParam(String path) {
+        scala.Option<Object> value = org.galaxio.gatling.config.SimulationConfig.getOptDoubleParam(requirePath(path));
+        return value.isDefined() ? Optional.of((Double) value.get()) : Optional.empty();
+    }
+
+    /**
+     * Reads an optional duration parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<Duration> getOptDurationParam(String path) {
+        scala.Option<scala.concurrent.duration.FiniteDuration> value =
+                org.galaxio.gatling.config.SimulationConfig.getOptDurationParam(requirePath(path));
+        return value.isDefined() ? Optional.of(toJava(value.get())) : Optional.empty();
+    }
+
+    /**
+     * Reads an optional boolean parameter.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<Boolean> getOptBooleanParam(String path) {
+        scala.Option<Object> value = org.galaxio.gatling.config.SimulationConfig.getOptBooleanParam(requirePath(path));
+        return value.isDefined() ? Optional.of((Boolean) value.get()) : Optional.empty();
+    }
+
+    /**
+     * Reads an optional list of strings.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<List<String>> getOptStringListParam(String path) {
+        scala.Option<scala.collection.immutable.List<String>> value =
+                org.galaxio.gatling.config.SimulationConfig.getOptStringListParam(requirePath(path));
+        return value.isDefined() ? Optional.of(CollectionConverters.asJava(value.get())) : Optional.empty();
+    }
+
+    /**
+     * Reads an optional nested Typesafe Config block.
+     *
+     * @throws NullPointerException when {@code path} is null
+     */
+    public static Optional<Config> getOptConfigParam(String path) {
+        return OptionConverters.toJava(org.galaxio.gatling.config.SimulationConfig.getOptConfigParam(requirePath(path)));
+    }
+
+    /** Returns the base HTTP URL used by simulations. */
     public static String baseUrl() {
         return org.galaxio.gatling.config.SimulationConfig.baseUrl();
     }
 
+    /** Returns the base authentication URL used by simulations. */
     public static String baseAuthUrl() {
         return org.galaxio.gatling.config.SimulationConfig.baseAuthUrl();
     }
 
+    /** Returns the base WebSocket URL used by simulations. */
     public static String wsBaseUrl() {
         return org.galaxio.gatling.config.SimulationConfig.wsBaseUrl();
     }
 
+    /** Returns the number of workload stages. Must be greater than zero. */
     public static Integer stagesNumber() {
         return org.galaxio.gatling.config.SimulationConfig.stagesNumber();
     }
 
+    /** Returns the ramp duration. Must be zero or greater. */
     public static Duration rampDuration() {
         return toJava(org.galaxio.gatling.config.SimulationConfig.rampDuration());
     }
 
+    /** Returns the stage duration. Must be greater than zero. */
     public static Duration stageDuration() {
         return toJava(org.galaxio.gatling.config.SimulationConfig.stageDuration());
     }
 
+    /** Returns the maximum simulation duration. Must be greater than zero. */
     public static Duration testDuration() {
         return toJava(org.galaxio.gatling.config.SimulationConfig.testDuration());
     }
 
+    /** Returns the target request intensity converted to requests per second. */
     public static Double intensity() {
         return org.galaxio.gatling.config.SimulationConfig.intensity();
+    }
+
+    private static String requirePath(String path) {
+        return Objects.requireNonNull(path, "path cannot be null");
     }
 }

--- a/src/main/scala/org/galaxio/gatling/config/ConfigManager.scala
+++ b/src/main/scala/org/galaxio/gatling/config/ConfigManager.scala
@@ -7,8 +7,7 @@ import io.gatling.core.config.GatlingConfiguration
 private[gatling] object ConfigManager {
 
   lazy val simulationConfig: SimulationConfigUtils = SimulationConfigUtils(
-    ConfigFactory
-      .load("simulation.conf"),
+    ConfigFactory.systemProperties().withFallback(ConfigFactory.load("simulation.conf")),
   )
 
   lazy val influxConfig: Config = ConfigFactory

--- a/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
+++ b/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
@@ -1,0 +1,23 @@
+package org.galaxio.gatling.config
+
+private[config] object ConfigValueMasking {
+  private val SensitivePathTokens = Seq(
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "apikey",
+    "api-key",
+    "api_key",
+    "credential",
+  )
+
+  def displayValue(path: String, value: Any): String =
+    if (isSensitive(path)) "******" else String.valueOf(value)
+
+  def isSensitive(path: String): Boolean = {
+    val normalized = Option(path).getOrElse("").toLowerCase
+    SensitivePathTokens.exists(normalized.contains)
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/config/SimulationConfig.scala
+++ b/src/main/scala/org/galaxio/gatling/config/SimulationConfig.scala
@@ -2,35 +2,149 @@ package org.galaxio.gatling.config
 
 import org.galaxio.gatling.config.ConfigManager.simulationConfig
 import org.galaxio.gatling.utils.IntensityConverter.getIntensityFromString
+import com.typesafe.config.Config
 
 import scala.concurrent.duration._
+import scala.util.{Failure, Try}
 
+/** Entry point for reading Picatinny simulation settings from `simulation.conf`.
+  *
+  * JVM system properties override values from `simulation.conf`, so CI and environment-specific runs can pass values such as
+  * `-DbaseUrl=https://test.example.org` or `-Dintensity="120 rpm"`.
+  *
+  * Required getters throw [[SimulationConfigException]] when a value is missing or has an invalid type. Optional getters return
+  * `None` when the path is not defined.
+  */
 object SimulationConfig {
 
-  def getStringParam(path: String): String           = simulationConfig.get[String](path)
-  def getIntParam(path: String): Int                 = simulationConfig.get[Int](path)
-  def getDoubleParam(path: String): Double           = simulationConfig.get[Double](path)
-  def getDurationParam(path: String): FiniteDuration = simulationConfig.get[FiniteDuration](path)
-  def getBooleanParam(path: String): Boolean         = simulationConfig.get[Boolean](path)
+  /** Reads a required string parameter.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not a string
+    */
+  def getStringParam(path: String): String = simulationConfig.get[String](path)
 
-  def getStringParam(path: String, default: String): String                   = simulationConfig.get[String](path, default)
-  def getIntParam(path: String, default: Int): Int                            = simulationConfig.get[Int](path, default)
-  def getDoubleParam(path: String, default: Double): Double                   = simulationConfig.get[Double](path, default)
+  /** Reads a required integer parameter.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not an integer
+    */
+  def getIntParam(path: String): Int = simulationConfig.get[Int](path)
+
+  /** Reads a required double parameter.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not numeric
+    */
+  def getDoubleParam(path: String): Double = simulationConfig.get[Double](path)
+
+  /** Reads a required duration parameter as a finite Scala duration.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not a duration
+    */
+  def getDurationParam(path: String): FiniteDuration = simulationConfig.get[FiniteDuration](path)
+
+  /** Reads a required boolean parameter.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not a boolean
+    */
+  def getBooleanParam(path: String): Boolean = simulationConfig.get[Boolean](path)
+
+  /** Reads a required list of strings.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not a string list
+    */
+  def getStringListParam(path: String): List[String] = simulationConfig.get[List[String]](path)
+
+  /** Reads a required nested Typesafe Config block.
+    *
+    * @throws SimulationConfigException
+    *   when the path is missing or is not an object
+    */
+  def getConfigParam(path: String): Config = simulationConfig.get[Config](path)
+
+  /** Reads an optional string parameter. */
+  def getOptStringParam(path: String): Option[String] = simulationConfig.getOpt[String](path)
+
+  /** Reads an optional integer parameter. */
+  def getOptIntParam(path: String): Option[Int] = simulationConfig.getOpt[Int](path)
+
+  /** Reads an optional double parameter. */
+  def getOptDoubleParam(path: String): Option[Double] = simulationConfig.getOpt[Double](path)
+
+  /** Reads an optional duration parameter as a finite Scala duration. */
+  def getOptDurationParam(path: String): Option[FiniteDuration] = simulationConfig.getOpt[FiniteDuration](path)
+
+  /** Reads an optional boolean parameter. */
+  def getOptBooleanParam(path: String): Option[Boolean] = simulationConfig.getOpt[Boolean](path)
+
+  /** Reads an optional list of strings. */
+  def getOptStringListParam(path: String): Option[List[String]] = simulationConfig.getOpt[List[String]](path)
+
+  /** Reads an optional nested Typesafe Config block. */
+  def getOptConfigParam(path: String): Option[Config] = simulationConfig.getOpt[Config](path)
+
+  /** Reads a string parameter, returning `default` when the path is not defined. */
+  def getStringParam(path: String, default: String): String = simulationConfig.get[String](path, default)
+
+  /** Reads an integer parameter, returning `default` when the path is not defined. */
+  def getIntParam(path: String, default: Int): Int = simulationConfig.get[Int](path, default)
+
+  /** Reads a double parameter, returning `default` when the path is not defined. */
+  def getDoubleParam(path: String, default: Double): Double = simulationConfig.get[Double](path, default)
+
+  /** Reads a duration parameter, returning `default` when the path is not defined. */
   def getDurationParam(path: String, default: FiniteDuration): FiniteDuration =
     simulationConfig.get[FiniteDuration](path, default)
-  def getBooleanParam(path: String, default: Boolean): Boolean                = simulationConfig.get[Boolean](path, default)
 
-  lazy val baseUrl: String     = simulationConfig.get[String]("baseUrl")
+  /** Reads a boolean parameter, returning `default` when the path is not defined. */
+  def getBooleanParam(path: String, default: Boolean): Boolean = simulationConfig.get[Boolean](path, default)
+
+  /** Reads a list of strings, returning `default` when the path is not defined. */
+  def getStringListParam(path: String, default: List[String]): List[String] =
+    simulationConfig.get[List[String]](path, default)
+
+  /** Reads a nested Typesafe Config block, returning `default` when the path is not defined. */
+  def getConfigParam(path: String, default: Config): Config = simulationConfig.get[Config](path, default)
+
+  /** Base HTTP URL used by simulations. */
+  lazy val baseUrl: String = simulationConfig.get[String]("baseUrl")
+
+  /** Base authentication URL used by simulations. */
   lazy val baseAuthUrl: String = simulationConfig.get[String]("baseAuthUrl")
-  lazy val wsBaseUrl: String   = simulationConfig.get[String]("wsBaseUrl")
 
-  lazy val stagesNumber: Int = simulationConfig.get[Int]("stagesNumber", 1)
+  /** Base WebSocket URL used by simulations. */
+  lazy val wsBaseUrl: String = simulationConfig.get[String]("wsBaseUrl")
 
-  lazy val rampDuration: FiniteDuration  = simulationConfig.get[FiniteDuration]("rampDuration")
-  lazy val stageDuration: FiniteDuration = simulationConfig.get[FiniteDuration]("stageDuration")
-  lazy val testDuration: FiniteDuration  =
-    simulationConfig.get[FiniteDuration]("testDuration", (rampDuration + stageDuration) * stagesNumber)
+  /** Number of workload stages. Must be greater than zero. */
+  lazy val stagesNumber: Int = simulationConfig.requirePositive("stagesNumber", simulationConfig.get[Int]("stagesNumber", 1))
 
-  lazy val intensity: Double = getIntensityFromString(simulationConfig.get[String]("intensity"))
+  /** Ramp duration. Must be zero or greater. */
+  lazy val rampDuration: FiniteDuration =
+    simulationConfig.requireNonNegative("rampDuration", simulationConfig.get[FiniteDuration]("rampDuration"))
+
+  /** Stage duration. Must be greater than zero. */
+  lazy val stageDuration: FiniteDuration =
+    simulationConfig.requirePositive("stageDuration", simulationConfig.get[FiniteDuration]("stageDuration"))
+
+  /** Maximum simulation duration. Defaults to `(rampDuration + stageDuration) * stagesNumber` and must be greater than zero.
+    */
+  lazy val testDuration: FiniteDuration =
+    simulationConfig.requirePositive(
+      "testDuration",
+      simulationConfig.get[FiniteDuration]("testDuration", (rampDuration + stageDuration) * stagesNumber),
+    )
+
+  /** Target request intensity converted to requests per second. Supports `rps`, `rpm`, and `rph` suffixes. */
+  lazy val intensity: Double =
+    simulationConfig.requirePositive("intensity", parseIntensity(simulationConfig.get[String]("intensity")))
+
+  private def parseIntensity(value: String): Double =
+    Try(getIntensityFromString(value)).recoverWith { case e: IllegalArgumentException =>
+      Failure(new SimulationConfigException(s"Invalid simulation config value at intensity: ${e.getMessage}", e))
+    }.get
 
 }

--- a/src/main/scala/org/galaxio/gatling/config/SimulationConfigException.scala
+++ b/src/main/scala/org/galaxio/gatling/config/SimulationConfigException.scala
@@ -1,0 +1,6 @@
+package org.galaxio.gatling.config
+
+/** Signals that a value from `simulation.conf` or a JVM system property is missing, has an unsupported type, or violates
+  * Picatinny workload validation rules.
+  */
+class SimulationConfigException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)

--- a/src/main/scala/org/galaxio/gatling/config/SimulationConfigUtils.scala
+++ b/src/main/scala/org/galaxio/gatling/config/SimulationConfigUtils.scala
@@ -2,11 +2,13 @@ package org.galaxio.gatling.config
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.FiniteDuration
-import scala.reflect.runtime.universe._
-import scala.language.implicitConversions
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.language.implicitConversions
+import scala.reflect.runtime.universe._
+import scala.util.{Failure, Try}
 import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
 import com.typesafe.scalalogging.LazyLogging
 
 private[gatling] class SimulationConfigUtils(config: Config) extends LazyLogging {
@@ -22,32 +24,78 @@ private[gatling] class SimulationConfigUtils(config: Config) extends LazyLogging
 
   def get[T](path: String)(implicit tag: TypeTag[T]): T =
     getOpt(path).getOrElse {
-      logger.error(s"""Simulation param for ${path} is undefined""")
-      throw new RuntimeException(s"Configuration value at $path not found")
+      val message = s"Missing required simulation config value: $path. Define it in simulation.conf or pass -D$path=<value>."
+      logger.error(message)
+      throw new SimulationConfigException(message)
     }
 
   def get[T](path: String, default: => T)(implicit tag: TypeTag[T]): T =
     getOpt(path).getOrElse(default)
 
-  private def getValueByType[T](cfg: Config, path: String)(implicit tag: TypeTag[T]): T = {
-    val result = tag match {
-      case StringTag         => cfg.getString(path)
-      case TypeTag.Long      => cfg.getLong(path)
-      case TypeTag.Int       => cfg.getInt(path)
-      case TypeTag.Double    => cfg.getDouble(path)
-      case FiniteDurationTag => cfg.getDuration(path, TimeUnit.SECONDS).seconds
-      case StringListTag     => cfg.getStringList(path)
-      case TypeTag.Boolean   => cfg.getBoolean(path)
-      case BigDecimalTag     => BigDecimal(cfg.getString(path))
-      case ConfigTag         => cfg.getConfig(path)
-      case _                 =>
-        logger.error(s"Configuration option type $tag is not implemented")
-        throw new IllegalArgumentException(s"Configuration option type $tag not implemented")
+  def requirePositive(path: String, value: Int): Int =
+    requireCondition(path, value, value > 0, "must be greater than 0")
+
+  def requirePositive(path: String, value: Double): Double =
+    requireCondition(path, value, value > 0, "must be greater than 0")
+
+  def requirePositive(path: String, value: FiniteDuration): FiniteDuration =
+    requireCondition(path, value, value > Duration.Zero, "must be greater than 0")
+
+  def requireNonNegative(path: String, value: FiniteDuration): FiniteDuration =
+    requireCondition(path, value, value >= Duration.Zero, "must be 0 or greater")
+
+  private def getValueByType[T](cfg: Config, path: String)(implicit tag: TypeTag[T]): T =
+    readValueByType(cfg, path)
+      .map(_.asInstanceOf[T])
+      .map { value =>
+        logger.info(s"Simulation param for $path is set to: ${ConfigValueMasking.displayValue(path, value)}")
+        value
+      }
+      .recoverWith(configReadFailure(path, tag))
+      .get
+
+  private def readValueByType(cfg: Config, path: String)(implicit tag: TypeTag[_]): Try[Any] =
+    Try {
+      tag match {
+        case StringTag         => cfg.getString(path)
+        case TypeTag.Long      => cfg.getLong(path)
+        case TypeTag.Int       => cfg.getInt(path)
+        case TypeTag.Double    => cfg.getDouble(path)
+        case FiniteDurationTag => cfg.getDuration(path, TimeUnit.SECONDS).seconds
+        case StringListTag     => cfg.getStringList(path).asScala.toList
+        case TypeTag.Boolean   => cfg.getBoolean(path)
+        case BigDecimalTag     => BigDecimal(cfg.getString(path))
+        case ConfigTag         => cfg.getConfig(path)
+        case _                 => throw unsupportedTypeException(path, tag)
+      }
     }
-    val res    = result.asInstanceOf[T]
-    logger.info(s"Simulation param for $path is set to: ${res}")
-    res
+
+  private def configReadFailure(path: String, tag: TypeTag[_]): PartialFunction[Throwable, Try[Nothing]] = {
+    case e: SimulationConfigException => Failure(e)
+    case e: ConfigException           => Failure(invalidValueException(path, tag, e))
+    case e: NumberFormatException     => Failure(invalidValueException(path, tag, e))
   }
+
+  private def invalidValueException(path: String, tag: TypeTag[_], cause: Throwable): SimulationConfigException = {
+    val message = s"Invalid simulation config value at $path for expected type ${tag.tpe}: ${cause.getMessage}"
+    logger.error(message)
+    new SimulationConfigException(message, cause)
+  }
+
+  private def unsupportedTypeException(path: String, tag: TypeTag[_]): SimulationConfigException = {
+    val message = s"Configuration option type $tag is not implemented for path $path"
+    logger.error(message)
+    new SimulationConfigException(message)
+  }
+
+  private def requireCondition[T](path: String, value: T, valid: Boolean, rule: String): T =
+    if (valid) value
+    else {
+      val message = s"Invalid simulation config value at $path: $value ($rule)."
+      logger.error(message)
+      throw new SimulationConfigException(message)
+    }
+
 }
 
 private[gatling] object SimulationConfigUtils {

--- a/src/test/resources/simulation.conf
+++ b/src/test/resources/simulation.conf
@@ -7,6 +7,10 @@ intParam: 10
 doubleParam: 10.1
 booleanParam: true
 durationParam: 10 seconds
+stringListParam: ["first", "second"]
+nestedParam {
+  child: "value"
+}
 
 stagesNumber: 5
 rampDuration: 10 minutes

--- a/src/test/scala/org/galaxio/gatling/config/JavaConfigTest.scala
+++ b/src/test/scala/org/galaxio/gatling/config/JavaConfigTest.scala
@@ -35,6 +35,23 @@ class JavaConfigTest extends AnyFlatSpec with Matchers {
     getBooleanParam("booleanParam") shouldBe true
   }
 
+  it should "get string list param from simulation.conf" in {
+    getStringListParam("stringListParam") shouldBe java.util.List.of("first", "second")
+  }
+
+  it should "get nested config param from simulation.conf" in {
+    getConfigParam("nestedParam").getString("child") shouldBe "value"
+  }
+
+  it should "get optional param from simulation.conf" in {
+    getOptStringParam("stringParam").orElseThrow() shouldBe "testString"
+    getOptStringParam("missingParam").isEmpty shouldBe true
+  }
+
+  it should "get optional string list param from simulation.conf" in {
+    getOptStringListParam("stringListParam").orElseThrow() shouldBe java.util.List.of("first", "second")
+  }
+
   it should "get duration param from simulation.conf" in {
     getDurationParam("durationParam") shouldBe Duration.ofSeconds(10)
   }

--- a/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
@@ -1,0 +1,128 @@
+package org.galaxio.gatling.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class SimulationConfigUtilsSpec extends AnyFlatSpec with Matchers {
+
+  "SimulationConfigUtils" should "return optional values" in {
+    val config = SimulationConfigUtils(ConfigFactory.parseString("""existing = "value""""))
+
+    config.getOpt[String]("existing") shouldBe Some("value")
+    config.getOpt[String]("missing") shouldBe None
+  }
+
+  it should "read string lists and nested config blocks" in {
+    val config = SimulationConfigUtils(
+      ConfigFactory.parseString("""
+          |hosts = ["one", "two"]
+          |http {
+          |  headers {
+          |    accept = "application/json"
+          |  }
+          |}
+          |""".stripMargin),
+    )
+
+    config.get[List[String]]("hosts") shouldBe List("one", "two")
+    config.get[com.typesafe.config.Config]("http").getString("headers.accept") shouldBe "application/json"
+  }
+
+  it should "prefer system property overrides" in {
+    val property = "picatinny.config.override.test"
+    System.setProperty(property, "from-system-property")
+    ConfigFactory.invalidateCaches()
+    try {
+      val config = SimulationConfigUtils(
+        ConfigFactory.systemProperties().withFallback(ConfigFactory.parseString(s"""$property = "from-file"""")),
+      )
+
+      config.get[String](property) shouldBe "from-system-property"
+    } finally {
+      System.clearProperty(property)
+      ConfigFactory.invalidateCaches()
+    }
+  }
+
+  it should "throw a clear exception for missing required values" in {
+    val config = SimulationConfigUtils(ConfigFactory.parseString("""existing = "value""""))
+
+    val thrown = intercept[SimulationConfigException] {
+      config.get[String]("missing")
+    }
+
+    thrown.getMessage should include("Missing required simulation config value: missing")
+    thrown.getMessage should include("simulation.conf")
+    thrown.getMessage should include("-Dmissing=<value>")
+  }
+
+  it should "throw a clear exception for wrong value types" in {
+    val config = SimulationConfigUtils(ConfigFactory.parseString("""count = "not-an-int""""))
+
+    val thrown = intercept[SimulationConfigException] {
+      config.get[Int]("count")
+    }
+
+    thrown.getMessage should include("Invalid simulation config value at count")
+    thrown.getMessage should include("Int")
+  }
+
+  it should "validate positive numbers and durations" in {
+    val config = SimulationConfigUtils(ConfigFactory.empty())
+
+    config.requirePositive("stagesNumber", 1) shouldBe 1
+    config.requirePositive("intensity", 1.0) shouldBe 1.0
+    config.requirePositive("stageDuration", 1.second) shouldBe 1.second
+
+    intercept[SimulationConfigException](config.requirePositive("stagesNumber", 0))
+    intercept[SimulationConfigException](config.requirePositive("intensity", 0.0))
+    intercept[SimulationConfigException](config.requirePositive("stageDuration", Duration.Zero))
+  }
+
+  it should "validate non-negative durations" in {
+    val config = SimulationConfigUtils(ConfigFactory.empty())
+
+    config.requireNonNegative("rampDuration", Duration.Zero) shouldBe Duration.Zero
+    config.requireNonNegative("rampDuration", 1.second) shouldBe 1.second
+
+    val thrown = intercept[SimulationConfigException] {
+      config.requireNonNegative("rampDuration", -1.second)
+    }
+
+    thrown.getMessage should include("rampDuration")
+    thrown.getMessage should include("0 or greater")
+  }
+}
+
+class ConfigValueMaskingSpec extends AnyFlatSpec with Matchers {
+
+  "ConfigValueMasking" should "mask sensitive config paths" in {
+    Seq(
+      "db.password",
+      "service.passwd",
+      "service.pwd",
+      "oauth.secret",
+      "auth.token",
+      "client.apiKey",
+      "client.api-key",
+      "client.api_key",
+      "aws.credential",
+    ).foreach { path =>
+      ConfigValueMasking.displayValue(path, "raw-value") shouldBe "******"
+      ConfigValueMasking.isSensitive(path) shouldBe true
+    }
+  }
+
+  it should "leave non-sensitive values visible" in {
+    ConfigValueMasking.displayValue("baseUrl", "http://localhost") shouldBe "http://localhost"
+    ConfigValueMasking.isSensitive("baseUrl") shouldBe false
+  }
+
+  it should "handle null display inputs defensively" in {
+    ConfigValueMasking.displayValue(null, "value") shouldBe "value"
+    ConfigValueMasking.displayValue("token", null) shouldBe "******"
+  }
+}


### PR DESCRIPTION
## Summary
- add typed SimulationConfigException errors for missing, invalid, and unsupported config values
- expose optional, string-list, and nested Config getters in Scala plus Java/Kotlin facade parity
- make JVM system properties override simulation.conf values explicitly
- validate workload settings and mask sensitive config values in logs
- document the public Scala and Java config APIs

## Validation
- sbt scalafmtAll scalafmtSbt test doc
