### PR TITLE
feat(feeders): add faker generated feeder api

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,10 @@ Startup output:
 
 ### feeders
 
+> **New Faker API** — a composable, domain-oriented data generation layer is now available.
+> See [docs/faker-api.md](docs/faker-api.md) for the full API reference, migration examples, and Gatling integration patterns.
+> The old `Random*Feeder` helpers still work but are deprecated in favor of `Faker.*` + `GeneratedFeeder`.
+
 This module contains vast number of random feeders. They could be used as regular feeders and realize common needs, i.e.
 random phone number or random digit. Now it supports feeders for dates, numbers and digits, strings, uuids, phones.
 Basic examples will be provided below. Other feeders can be used in a similar way.
@@ -434,6 +438,13 @@ Kotlin example:
 ```Kotlin
   val vaultFeeder = VaultFeeder(vaultUrl, secretPath, roleId, secretId, keys)
 ```
+
+Additional one-record data source helpers:
+
+- `VaultFeeder.withToken(vaultUrl, secretPath, vaultToken, keys)` reads Vault data when CI already provides a token.
+- `VaultFeeder.fromPaths(vaultUrl, roleId, secretId, paths)` merges selected keys from several Vault paths.
+- `EnvFeeder(keys, prefix)` reads selected environment variables into a feeder record.
+- `HttpJsonFeeder(url, keys, headers)` reads selected top-level string fields from a JSON HTTP endpoint.
 
 #### SeparatedValuesFeeder
 

--- a/docs/faker-api.md
+++ b/docs/faker-api.md
@@ -1,0 +1,169 @@
+# Picatinny Faker API
+
+The faker API is a new user-first layer for generating test data in Gatling simulations.
+It is available as a new API while the old `Random*Feeder` helpers remain compatible and deprecated.
+
+```scala
+import org.galaxio.gatling.feeders.faker.Predef._
+import org.galaxio.gatling.feeders.faker._
+```
+
+## Core Idea
+
+`Faker.*` methods return `Generator[A]`, not an eager value.
+
+```scala
+val email: Generator[String] = Faker.internet.email()
+val sampled: String = email.sample()
+```
+
+This lets you reuse the same generator directly, compose it with `map`/`flatMap`, or pass it into a Gatling feeder.
+
+## Generated Gatling Feeder
+
+Use `GeneratedFeeder` when a scenario needs generated session attributes.
+
+```scala
+val users =
+  GeneratedFeeder(
+    "email" -> Faker.internet.email(),
+    "phone" -> Faker.phone.mobile(Country.RU, PhoneFormatMode.E164),
+    "inn" -> Faker.ru.inn.person(),
+    "amount" -> Faker.finance.amount(BigDecimal(100), BigDecimal(5000))
+  )
+```
+
+Gatling usage:
+
+```scala
+val scn = scenario("checkout")
+  .feed(users)
+  .exec(
+    http("checkout")
+      .post("/checkout")
+      .body(StringBody("""{"email":"#{email}","phone":"#{phone}","amount":"#{amount}"}"""))
+  )
+```
+
+Mixed records are represented as `Feeder[Any]`, because Gatling session maps commonly contain strings, numbers, booleans, and dates together. Single-field feeders keep their value type:
+
+```scala
+val emails = Faker.internet.email().toFeeder("email") // Feeder[String]
+```
+
+## Dependent Fields
+
+Use a generator `for` comprehension when one field depends on another.
+
+```scala
+val users =
+  GeneratedFeeder.records {
+    for {
+      gender <- Faker.person.gender()
+      name <- Faker.person.fullName(gender)
+      email <- Faker.internet.email(name, "example.com")
+    } yield Map(
+      "gender" -> gender.value,
+      "name" -> name,
+      "email" -> email
+    )
+  }
+```
+
+## Existing Gatling Feeders
+
+Picatinny should complement Gatling's built-in feeders, not duplicate them. Keep using Gatling `csv`, `jsonFile`, `jdbcFeeder`, and other native sources. Use faker syntax only to enrich or transform records.
+
+```scala
+val enriched =
+  csv("users.csv").circular
+    .withGenerated("traceId", Faker.uuid.string)
+    .withGenerated("sessionPhone", Faker.phone.mobile(Country.AR))
+```
+
+## Collections
+
+Use collection syntax when data is already in memory.
+
+```scala
+val countries =
+  List("RU", "AR", "BR")
+    .toFeeder("country")
+    .circular
+```
+
+Map domain objects explicitly to Gatling records:
+
+```scala
+case class User(id: String, email: String)
+
+val users =
+  List(User("1", "a@example.com"))
+    .toFeeder(user => Map("id" -> user.id, "email" -> user.email))
+    .queue
+```
+
+The returned collection is a normal Gatling-compatible in-memory feeder source, so use Gatling's own `.queue`, `.circular`, `.random`, and `.shuffle` strategies.
+
+## Generator Catalog
+
+The first slice includes:
+
+- `Faker.uuid.string`
+- `Faker.number.int`, `long`, `double`, `float`, `boolean`
+- `Faker.string.alphabetic`, `alphanumeric`, `numeric`, `hex`, `cyrillic`, `fromAlphabet`, `lengthBetween`
+- `Faker.person.gender`, `firstName`, `lastName`, `prefix`, `fullName`, `jobTitle`
+- `Faker.internet.email`, `username`, `domain`, `url`, `password`, `userAgent`, `ipv4`, `ipv6`
+- `Faker.location.country`, `countryCode`, `city`, `streetName`, `streetAddress`, `postalCode`, `latitude`, `longitude`
+- `Faker.localization.currency`, `languageCode`
+- `Faker.date.today`, `now`, `between`, `past`, `future`, `offset`, `range`
+- `Faker.finance.pan`, `amount`, `money`, `currency`, `accountNumber`, `bic`, `iban`, `transactionId`
+- `Faker.commerce.productName`, `category`, `sku`, `orderId`, `price`
+- `Faker.phone.mobile`, `tollFree`, `fromFormats`
+- `Faker.passport.ru`, `Faker.passport.number`
+- `Faker.ru.inn.person`, `Faker.ru.inn.company`, `kpp`, `ogrn`, `ogrnip`, `snils`
+- `Faker.br.cpf`
+- `Faker.ar.dni`
+- `Faker.weather.condition`, `temperatureCelsius`, `humidityPercent`, `pressureHPa`
+- `Faker.lorem.word`, `words`, `sentence`
+
+## Migration Examples
+
+Old:
+
+```scala
+RandomStringFeeder("name", 10)
+```
+
+New:
+
+```scala
+GeneratedFeeder.single("name", Faker.string.alphanumeric(10))
+```
+
+Old:
+
+```scala
+RandomNatITNFeeder("inn")
+```
+
+New:
+
+```scala
+GeneratedFeeder.single("inn", Faker.ru.inn.person())
+```
+
+Old:
+
+```scala
+RandomDateFeeder("createdAt", 30, 0)
+```
+
+New:
+
+```scala
+GeneratedFeeder.single(
+  "createdAt",
+  Faker.date.past(days = 30).format("yyyy-MM-dd")
+)
+```

--- a/docs/faker-api.md
+++ b/docs/faker-api.md
@@ -81,6 +81,24 @@ val enriched =
     .withGenerated("sessionPhone", Faker.phone.mobile(Country.AR))
 ```
 
+Use feeder transformations when external data needs small production-safe adjustments before it enters a scenario:
+
+```scala
+val normalized =
+  csv("users.csv").circular
+    .withGenerated(
+      "traceId" -> Faker.uuid.string,
+      "runCurrency" -> Faker.localization.currency(Country.US)
+    )
+    .renameKeys(Map("mail" -> "email"))
+    .withDefaults("country" -> "US")
+    .requireKeys("id", "email")
+    .dropKeys("debugOnly")
+```
+
+Available feeder syntax includes `withGenerated`, `rename`, `renameKeys`, `prefixKeys`, `suffixKeys`, `dropKeys`,
+`selectKeys`, `withDefaults`, `requireKeys`, `mapRecord`, and `takeRecords`.
+
 ## Collections
 
 Use collection syntax when data is already in memory.
@@ -110,7 +128,7 @@ The returned collection is a normal Gatling-compatible in-memory feeder source, 
 The first slice includes:
 
 - `Faker.uuid.string`
-- `Faker.number.int`, `long`, `double`, `float`, `boolean`
+- `Faker.number.int`, `long`, `double`, `float`, `byte`, `short`, `char`, `bigInt`, `bigDecimal`, `boolean`, `positiveInt`, `positiveLong`, `negativeInt`, `negativeLong`, `percentage`
 - `Faker.string.alphabetic`, `alphanumeric`, `numeric`, `hex`, `cyrillic`, `fromAlphabet`, `lengthBetween`
 - `Faker.person.gender`, `firstName`, `lastName`, `prefix`, `fullName`, `jobTitle`
 - `Faker.internet.email`, `username`, `domain`, `url`, `password`, `userAgent`, `ipv4`, `ipv6`
@@ -119,13 +137,21 @@ The first slice includes:
 - `Faker.date.today`, `now`, `between`, `past`, `future`, `offset`, `range`
 - `Faker.finance.pan`, `amount`, `money`, `currency`, `accountNumber`, `bic`, `iban`, `transactionId`
 - `Faker.commerce.productName`, `category`, `sku`, `orderId`, `price`
-- `Faker.phone.mobile`, `tollFree`, `fromFormats`
+- `Faker.phone.mobile`, `tollFree`, `fromFormats`, `builder` — 16 countries supported
 - `Faker.passport.ru`, `Faker.passport.number`
 - `Faker.ru.inn.person`, `Faker.ru.inn.company`, `kpp`, `ogrn`, `ogrnip`, `snils`
 - `Faker.br.cpf`
 - `Faker.ar.dni`
+- `Faker.es.nif` — Spanish NIF with valid check letter
+- `Faker.it.codiceFiscale` — Italian Codice Fiscale (structural format)
+- `Faker.de.steueridentifikationsnummer` — German tax ID
+- `Faker.us.ssn` — US Social Security Number
+- `Faker.gb.nino` — UK National Insurance Number
+- `Faker.fr.nir` — French social security number with valid key
 - `Faker.weather.condition`, `temperatureCelsius`, `humidityPercent`, `pressureHPa`
 - `Faker.lorem.word`, `words`, `sentence`
+- `Generator.sequence`, `Generator.listOf`, `Generator.mapOf`, `Generator.tupleOf` — collection combinators
+- `Generator.filter` — retry-based filtering
 
 ## Predefined Data
 

--- a/docs/faker-api.md
+++ b/docs/faker-api.md
@@ -127,6 +127,26 @@ The first slice includes:
 - `Faker.weather.condition`, `temperatureCelsius`, `humidityPercent`, `pressureHPa`
 - `Faker.lorem.word`, `words`, `sentence`
 
+## Predefined Data
+
+`FakerData` exposes the predefined catalogs used by `Faker`, so scenarios can build custom generators without copying internal data.
+
+```scala
+val qaJob = Faker.oneOf(FakerData.jobTitles.filter(_.contains("Engineer")))
+val ruCity = Faker.oneOf(FakerData.citiesByCountry(Country.RU))
+```
+
+Available catalogs include:
+
+- `FakerData.maleFirstNames`, `femaleFirstNames`, `lastNames`, `personPrefixes`, `jobTitles`
+- `FakerData.domains`, `userAgents`
+- `FakerData.citiesByCountry`, `streetNames`
+- `FakerData.currencies`
+- `FakerData.products`, `categories`
+- `FakerData.weatherConditions`
+- `FakerData.loremWords`
+- `FakerData.phoneFormatsByCountry`
+
 ## Migration Examples
 
 Old:

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
@@ -1,0 +1,60 @@
+package org.galaxio.performance.picatinny.feeders
+
+import io.gatling.core.Predef._
+import io.gatling.core.feeder.Feeder
+import org.galaxio.gatling.feeders.faker.Predef._
+import org.galaxio.gatling.feeders.faker._
+
+import java.time.LocalDate
+
+object GeneratedPicatinnyFeeders {
+
+  /** Basic generated user data for request payloads. */
+  val generatedUsers: Feeder[Any] =
+    GeneratedFeeder(
+      "userId" -> Faker.uuid.string,
+      "email" -> Faker.internet.email(),
+      "phone" -> Faker.phone.mobile(Country.RU, PhoneFormatMode.E164),
+      "city" -> Faker.location.city(Country.RU),
+      "jobTitle" -> Faker.person.jobTitle(),
+    )
+
+  /** Government identifiers are grouped separately from generic person data. */
+  val governmentIds: Feeder[Any] =
+    GeneratedFeeder(
+      "inn" -> Faker.ru.inn.person(),
+      "kpp" -> Faker.ru.kpp(),
+      "ogrn" -> Faker.ru.ogrn(),
+      "snils" -> Faker.ru.snils(),
+      "cpf" -> Faker.br.cpf(formatted = true),
+      "dni" -> Faker.ar.dni(),
+    )
+
+  /** Date generation stays focused on date semantics: ranges, offsets, and formatting. */
+  val dates: Feeder[Any] =
+    GeneratedFeeder(
+      "createdAt" -> Faker.date.past(days = 30).format("yyyy-MM-dd"),
+      "validFrom" -> Faker.date.between(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 6, 30)).format("yyyy-MM-dd"),
+      "validTo" -> Faker.date.future(days = 90).format("yyyy-MM-dd"),
+    )
+
+  /** Finance data is grouped separately from dates. */
+  val finance: Feeder[Any] =
+    GeneratedFeeder(
+      "pan" -> Faker.finance.pan("421345", "541673"),
+      "amount" -> Faker.finance.amount(BigDecimal(100), BigDecimal(5000)),
+      "currency" -> Faker.finance.currency(),
+      "iban" -> Faker.finance.iban(Country.DE),
+      "transactionId" -> Faker.finance.transactionId(),
+    )
+
+  /** In-memory collections can become feeders without replacing Gatling CSV/JDBC feeders. */
+  val countries: Feeder[Any] =
+    List("RU", "AR", "BR").toFeeder("country").circular
+
+  /** Existing Gatling feeders can be enriched with generated fields. */
+  val enrichedStaticUsers: Feeder[Any] =
+    Array(Map("sourceUser" -> "demo-user")).iterator
+      .withGenerated("traceId", Faker.uuid.string)
+      .withGenerated("sessionEmail", Faker.internet.email())
+}

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
@@ -1,7 +1,7 @@
 package org.galaxio.performance.picatinny.feeders
 
 import io.gatling.core.Predef._
-import io.gatling.core.feeder.Feeder
+import io.gatling.core.feeder.{Feeder, FeederBuilderBase}
 import org.galaxio.gatling.feeders.faker.Predef._
 import org.galaxio.gatling.feeders.faker._
 
@@ -49,7 +49,7 @@ object GeneratedPicatinnyFeeders {
     )
 
   /** In-memory collections can become feeders without replacing Gatling CSV/JDBC feeders. */
-  val countries: Feeder[Any] =
+  val countries: FeederBuilderBase[Any] =
     List("RU", "AR", "BR").toFeeder("country").circular
 
   /** Existing Gatling feeders can be enriched with generated fields. */

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/PicatinnyFeeders.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/PicatinnyFeeders.scala
@@ -8,8 +8,10 @@ import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneId}
+import scala.annotation.nowarn
 import scala.util.Random
 
+@nowarn("cat=deprecation")
 object PicatinnyFeeders {
   private val ruMobileFormat = PhoneFormat(
     countryCode = "+7",

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/scenarios/PicatinnyScenario.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/scenarios/PicatinnyScenario.scala
@@ -4,7 +4,7 @@ import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
 import org.galaxio.gatling.transactions.Predef._
 import org.galaxio.performance.picatinny.cases.PicatinnyCases
-import org.galaxio.performance.picatinny.feeders.PicatinnyFeeders
+import org.galaxio.performance.picatinny.feeders.{GeneratedPicatinnyFeeders, PicatinnyFeeders}
 
 object PicatinnyScenario {
   def apply(name: String, transactionName: String): ScenarioBuilder =
@@ -42,4 +42,8 @@ object PicatinnyScenario {
       .feed(PicatinnyFeeders.kpp)
       .feed(PicatinnyFeeders.snils)
       .feed(PicatinnyFeeders.passport)
+      .feed(GeneratedPicatinnyFeeders.generatedUsers)
+      .feed(GeneratedPicatinnyFeeders.governmentIds)
+      .feed(GeneratedPicatinnyFeeders.dates)
+      .feed(GeneratedPicatinnyFeeders.finance)
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/EnvFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/EnvFeeder.scala
@@ -1,0 +1,49 @@
+package org.galaxio.gatling.feeders
+
+import io.gatling.core.feeder.Record
+
+import java.util.Objects.requireNonNull
+
+/** Creates a one-record feeder from environment variables.
+  *
+  * This is useful for CI/CD pipelines where credentials, tenant identifiers, or small static test-data values are already
+  * injected as environment variables.
+  */
+object EnvFeeder {
+
+  /** Reads selected environment variables into a single feeder record.
+    *
+    * Missing variables are skipped. If no requested variables are present, an empty feeder source is returned.
+    *
+    * @param keys
+    *   environment variable names to read
+    * @param prefix
+    *   optional prefix to strip from environment variable names when creating feeder keys
+    */
+  def apply(keys: List[String], prefix: String = ""): IndexedSeq[Record[String]] = {
+    requireNonNull(keys, "Keys list must not be null")
+
+    val record = keys.flatMap { key =>
+      sys.env.get(key).map { value =>
+        val feederKey = if (prefix.nonEmpty && key.startsWith(prefix)) key.stripPrefix(prefix) else key
+        feederKey -> value
+      }
+    }.toMap
+
+    if (record.nonEmpty) IndexedSeq(record) else IndexedSeq.empty
+  }
+
+  /** Reads all environment variables matching a prefix into a single feeder record.
+    *
+    * The prefix is stripped from emitted feeder keys, so `PERF_TOKEN` with prefix `PERF_` becomes `TOKEN`.
+    */
+  def withPrefix(prefix: String): IndexedSeq[Record[String]] = {
+    require(prefix.nonEmpty, "Prefix must be non-empty")
+
+    val record = sys.env.collect {
+      case (key, value) if key.startsWith(prefix) => key.stripPrefix(prefix) -> value
+    }
+
+    if (record.nonEmpty) IndexedSeq(record) else IndexedSeq.empty
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/HttpJsonFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/HttpJsonFeeder.scala
@@ -1,0 +1,46 @@
+package org.galaxio.gatling.feeders
+
+import io.gatling.core.feeder.Record
+import org.galaxio.gatling.utils.THttpClient
+import org.json4s.native.JsonMethods
+import org.json4s.{DefaultFormats, Formats, JValue}
+
+import java.util.Objects.requireNonNull
+
+/** Creates a one-record feeder from a JSON HTTP endpoint.
+  *
+  * Use this for small configuration or test-data APIs. It extracts top-level JSON string fields only; richer JSON
+  * transformations should be performed before values reach the feeder boundary.
+  */
+object HttpJsonFeeder {
+
+  /** Fetches JSON from an HTTP GET endpoint and extracts selected top-level fields into a feeder record.
+    *
+    * @param url
+    *   full URL to fetch
+    * @param keys
+    *   top-level JSON field names to extract
+    * @param headers
+    *   optional HTTP headers as alternating `name, value, name, value, ...`
+    */
+  def apply(
+      url: String,
+      keys: List[String],
+      headers: Seq[String] = Seq.empty,
+  ): IndexedSeq[Record[String]] = {
+    require(url.nonEmpty, "URL must be non-empty")
+    requireNonNull(keys, "Keys list must not be null")
+
+    implicit val formats: DefaultFormats = org.json4s.DefaultFormats
+
+    val response = THttpClient().GET(url, headers).body()
+    val json     = JsonMethods.parse(response)
+    val data     = extractStringFields(json)
+    val keySet   = keys.toSet
+
+    IndexedSeq(data.view.filterKeys(keySet.contains).toMap)
+  }
+
+  private def extractStringFields(json: JValue)(implicit formats: Formats): Record[String] =
+    json.extract[Map[String, String]]
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomDateFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomDateFeeder.scala
@@ -5,6 +5,7 @@ import java.time.temporal.{ChronoUnit, TemporalUnit}
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.date with GeneratedFeeder instead", "faker-api")
 object RandomDateFeeder {
 
   def apply(

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomDateRangeFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomDateRangeFeeder.scala
@@ -6,6 +6,7 @@ import java.time.temporal.{ChronoUnit, TemporalUnit}
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.date.range with GeneratedFeeder.records instead", "faker-api")
 object RandomDateRangeFeeder {
 
   def apply(

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomDigitFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomDigitFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.number with GeneratedFeeder instead", "faker-api")
 object RandomDigitFeeder {
 
   def apply(paramName: String): Feeder[Int] = {

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomJurITNFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomJurITNFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.ru.inn.company with GeneratedFeeder instead", "faker-api")
 object RandomJurITNFeeder {
 
   /** Creates a feeder that generates a random ITN of the juridical person (Individual Taxpayer Number)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomKPPFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomKPPFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.ru.kpp with GeneratedFeeder instead", "faker-api")
 object RandomKPPFeeder {
 
   /** Creates a feeder that generates a random KPP (Tax Registration Reason Code)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomNatITNFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomNatITNFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.ru.inn.person with GeneratedFeeder instead", "faker-api")
 object RandomNatITNFeeder {
 
   /** Creates a feeder that generates a random ITN of the natural person (Individual Taxpayer Number)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomOGRNFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomOGRNFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.ru.ogrn with GeneratedFeeder instead", "faker-api")
 object RandomOGRNFeeder {
 
   /** Creates a feeder that generates a random OGRN (Primary State Registration Number)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomPANFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomPANFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.finance.pan with GeneratedFeeder instead", "faker-api")
 object RandomPANFeeder {
 
   /** Creates a feeder that generates a random PAN (Primary Account Number)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomPSRNSPFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomPSRNSPFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.ru.ogrnip with GeneratedFeeder instead", "faker-api")
 object RandomPSRNSPFeeder {
 
   /** Creates a feeder that generates a random PSRNSP (Primary State Registration Number of the Sole Proprietor)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomPhoneFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomPhoneFeeder.scala
@@ -5,6 +5,7 @@ import org.galaxio.gatling.utils.RandomPhoneGenerator
 import org.galaxio.gatling.utils.phone.TypePhone.TypePhone
 import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.phone with GeneratedFeeder instead", "faker-api")
 object RandomPhoneFeeder {
 
   def apply(

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomRangeStringFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomRangeStringFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.string.lengthBetween with GeneratedFeeder instead", "faker-api")
 object RandomRangeStringFeeder {
 
   lazy val alphabet = """abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#%"&*()_-+={}<>?|:[].~"""

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomRusPassportFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomRusPassportFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.passport.ru with GeneratedFeeder instead", "faker-api")
 object RandomRusPassportFeeder {
 
   /** Creates a feeder that generates a random russian passport series and number

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomSNILSFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomSNILSFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.ru.snils with GeneratedFeeder instead", "faker-api")
 object RandomSNILSFeeder {
 
   /** Creates a feeder that generates a random SNILS (Insurance Number of Individual Ledger Account)

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomStringFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomStringFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.string with GeneratedFeeder instead", "faker-api")
 object RandomStringFeeder {
 
   def apply(paramName: String, paramLength: Int = 10): Feeder[String] =

--- a/src/main/scala/org/galaxio/gatling/feeders/RandomUUIDFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RandomUUIDFeeder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.utils.RandomDataGenerators
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.uuid with GeneratedFeeder instead", "faker-api")
 object RandomUUIDFeeder {
 
   def apply(paramName: String): Feeder[String] =

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -1,14 +1,15 @@
 package org.galaxio.gatling.feeders
 
-import io.gatling.core.feeder._
+import io.gatling.core.feeder.Record
+import org.galaxio.gatling.utils.THttpClient
 import org.json4s.native.JsonMethods
 import org.json4s.{DefaultFormats, JValue}
-import org.galaxio.gatling.utils.THttpClient
 
 import java.util.Objects.requireNonNull
 
 object VaultFeeder {
 
+  /** Retrieves secrets from a single Vault path as a one-record feeder. */
   def apply(
       vaultUrl: String,
       secretPath: String,
@@ -38,8 +39,53 @@ object VaultFeeder {
     val vaultDataJson: JValue = JsonMethods.parse(vaultDataResponse)
     val data: Record[String]  = (vaultDataJson \ "data").extract[Map[String, String]]
 
-    IndexedSeq(data.view.filterKeys(keys.contains).toMap)
-
+    IndexedSeq(filterRecord(data, keys))
   }
 
+  /** Retrieves secrets from multiple Vault paths and merges them into a single record.
+    *
+    * Useful when test data is spread across several Vault secrets.
+    */
+  def fromPaths(
+      vaultUrl: String,
+      roleId: String,
+      secretId: String,
+      paths: List[(String, List[String])],
+  ): IndexedSeq[Record[String]] = {
+    requireNonNull(paths, "Paths list must not be null")
+    val merged = paths.flatMap { case (secretPath, keys) =>
+      apply(vaultUrl, secretPath, roleId, secretId, keys).flatMap(_.toSeq)
+    }.toMap
+    IndexedSeq(merged)
+  }
+
+  /** Retrieves secrets using Vault token authentication (no AppRole).
+    *
+    * Suitable for local development or CI environments where a token is already available.
+    */
+  def withToken(
+      vaultUrl: String,
+      secretPath: String,
+      vaultToken: String,
+      keys: List[String],
+  ): IndexedSeq[Record[String]] = {
+    requireNonNull(keys, "Keys list must not be null")
+
+    implicit val formats: DefaultFormats = org.json4s.DefaultFormats
+
+    val getHeaders: Seq[String]   = Seq("X-Vault-Token", vaultToken)
+    val vaultDataResponse: String = THttpClient()
+      .GET(s"""$vaultUrl/v1/$secretPath""", getHeaders)
+      .body()
+
+    val vaultDataJson: JValue = JsonMethods.parse(vaultDataResponse)
+    val data: Record[String]  = (vaultDataJson \ "data").extract[Map[String, String]]
+
+    IndexedSeq(filterRecord(data, keys))
+  }
+
+  private def filterRecord(data: Record[String], keys: List[String]): Record[String] = {
+    val selectedKeys = keys.toSet
+    data.view.filterKeys(selectedKeys.contains).toMap
+  }
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -12,15 +12,14 @@ import scala.math.BigDecimal.RoundingMode
 
 /** Faker facade for generating load-test data.
   *
-  * The API is intentionally domain-oriented: use `Faker.internet.email()` or
-  * `Faker.ru.inn.person()` in scenarios, then pass generators into
-  * `GeneratedFeeder` when Gatling needs session records.
+  * The API is intentionally domain-oriented: use `Faker.internet.email()` or `Faker.ru.inn.person()` in scenarios, then pass
+  * generators into `GeneratedFeeder` when Gatling needs session records.
   */
 object Faker {
 
   /** UUID generators. */
   object uuid {
-    def value: Generator[UUID]   = Generator.delay(UUID.randomUUID())
+    def value: Generator[UUID]    = Generator.delay(UUID.randomUUID())
     def string: Generator[String] = value.map(_.toString)
   }
 
@@ -74,13 +73,13 @@ object Faker {
 
   /** Person data generators. */
   object person {
-    private val MaleFirstNames =
+    private val MaleFirstNames   =
       Vector("Ivan", "Alexey", "Dmitry", "Sergey", "Nicolas", "John", "Pedro", "Lucas", "Martin", "Andres")
     private val FemaleFirstNames =
       Vector("Anna", "Maria", "Elena", "Sofia", "Camila", "Julia", "Lucia", "Valentina", "Fernanda", "Olga")
-    private val LastNames =
+    private val LastNames        =
       Vector("Ivanov", "Petrov", "Sidorov", "Garcia", "Silva", "Smith", "Brown", "Martinez", "Fernandez", "Volkov")
-    private val JobTitles =
+    private val JobTitles        =
       Vector(
         "Performance Engineer",
         "QA Engineer",
@@ -90,7 +89,7 @@ object Faker {
         "Data Engineer",
         "Security Engineer",
       )
-    private val Prefixes = Vector("Mr.", "Mrs.", "Ms.", "Dr.")
+    private val Prefixes         = Vector("Mr.", "Mrs.", "Ms.", "Dr.")
 
     def gender(): Generator[Gender] =
       oneOf(Gender.Male, Gender.Female, Gender.Unspecified)
@@ -122,7 +121,7 @@ object Faker {
 
   /** Internet-oriented generators. */
   object internet {
-    private val Domains = Vector("example.com", "test.local", "load.test", "picatinny.dev")
+    private val Domains    = Vector("example.com", "test.local", "load.test", "picatinny.dev")
     private val UserAgents = Vector(
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15",
@@ -134,7 +133,7 @@ object Faker {
 
     def email(domain: String = "example.com"): Generator[String] =
       for {
-        name <- person.fullName()
+        name   <- person.fullName()
         suffix <- string.alphanumeric(6)
       } yield emailFromName(name, domain, suffix)
 
@@ -166,7 +165,7 @@ object Faker {
 
     private def emailFromName(name: String, domain: String, suffix: String): String = {
       require(domain.nonEmpty, "Email domain must be non-empty")
-      val localPart = name.toLowerCase.replaceAll("[^a-z0-9]+", ".").stripPrefix(".").stripSuffix(".")
+      val localPart           = name.toLowerCase.replaceAll("[^a-z0-9]+", ".").stripPrefix(".").stripSuffix(".")
       val normalizedLocalPart = if (localPart.isEmpty) "user" else localPart
       s"$normalizedLocalPart.$suffix@$domain"
     }
@@ -181,10 +180,21 @@ object Faker {
       Country.US -> Vector("New York", "Austin", "Seattle", "Chicago"),
       Country.DE -> Vector("Berlin", "Munich", "Hamburg", "Frankfurt"),
     )
-    private val Streets = Vector("Main Street", "Performance Avenue", "Load Test Road", "Central Boulevard", "Liberty Street")
+    private val Streets                              = Vector("Main Street", "Performance Avenue", "Load Test Road", "Central Boulevard", "Liberty Street")
 
     def country(): Generator[Country] =
-      oneOf(Country.RU, Country.AR, Country.BR, Country.US, Country.GB, Country.DE, Country.FR, Country.ES, Country.IT, Country.AE)
+      oneOf(
+        Country.RU,
+        Country.AR,
+        Country.BR,
+        Country.US,
+        Country.GB,
+        Country.DE,
+        Country.FR,
+        Country.ES,
+        Country.IT,
+        Country.AE,
+      )
 
     def countryCode(): Generator[String] =
       country().map(_.iso2)
@@ -223,13 +233,13 @@ object Faker {
       location.country()
 
     def currency(country: Country): Generator[String] = country match {
-      case Country.RU => Generator.const("RUB")
-      case Country.AR => Generator.const("ARS")
-      case Country.BR => Generator.const("BRL")
-      case Country.GB => Generator.const("GBP")
-      case Country.AE => Generator.const("AED")
+      case Country.RU                                        => Generator.const("RUB")
+      case Country.AR                                        => Generator.const("ARS")
+      case Country.BR                                        => Generator.const("BRL")
+      case Country.GB                                        => Generator.const("GBP")
+      case Country.AE                                        => Generator.const("AED")
       case Country.DE | Country.FR | Country.ES | Country.IT => Generator.const("EUR")
-      case _ => Generator.const("USD")
+      case _                                                 => Generator.const("USD")
     }
 
     def languageCode(country: Country): Generator[String] = country match {
@@ -240,7 +250,7 @@ object Faker {
       case Country.FR => Generator.const("fr")
       case Country.ES => Generator.const("es")
       case Country.IT => Generator.const("it")
-      case _ => Generator.const("en")
+      case _          => Generator.const("en")
     }
   }
 
@@ -328,15 +338,16 @@ object Faker {
 
     def bic(): Generator[String] =
       for {
-        bank <- string.alphabetic(4).map(_.toUpperCase)
-        country <- location.countryCode()
+        bank         <- string.alphabetic(4).map(_.toUpperCase)
+        country      <- location.countryCode()
         locationCode <- string.alphanumeric(2).map(_.toUpperCase)
-        branch <- string.alphanumeric(3).map(_.toUpperCase)
+        branch       <- string.alphanumeric(3).map(_.toUpperCase)
       } yield s"$bank$country$locationCode$branch"
 
     def iban(country: Country = Country.DE): Generator[String] = country match {
       case Country.DE => string.numeric(18).map(value => s"DE89$value")
-      case Country.GB => string.alphanumeric(4).map(_.toUpperCase).zip(string.numeric(14)).map { case (bank, digits) => s"GB82$bank$digits" }
+      case Country.GB =>
+        string.alphanumeric(4).map(_.toUpperCase).zip(string.numeric(14)).map { case (bank, digits) => s"GB82$bank$digits" }
       case Country.FR => string.numeric(23).map(value => s"FR14$value")
       case _          => string.alphanumeric(20).map(value => s"${country.iso2}00${value.toUpperCase}")
     }
@@ -350,11 +361,11 @@ object Faker {
     private val Products   = Vector("Laptop", "Phone", "Subscription", "Support package", "Gift card")
     private val Categories = Vector("electronics", "services", "finance", "books", "travel")
 
-    def productName(): Generator[String] = oneOf(Products)
-    def category(): Generator[String]    = oneOf(Categories)
-    def sku(prefix: String = "SKU"): Generator[String] =
+    def productName(): Generator[String]                                                             = oneOf(Products)
+    def category(): Generator[String]                                                                = oneOf(Categories)
+    def sku(prefix: String = "SKU"): Generator[String]                                               =
       string.alphanumeric(10).map(value => s"$prefix-$value")
-    def orderId(prefix: String = "ord"): Generator[String] =
+    def orderId(prefix: String = "ord"): Generator[String]                                           =
       string.alphanumeric(16).map(value => s"$prefix-$value")
     def price(min: BigDecimal = BigDecimal(1), max: BigDecimal = BigDecimal(1000)): Generator[Money] =
       finance.money(min, max, "USD")
@@ -502,8 +513,9 @@ object Faker {
   def oneOf[A](first: A, second: A, rest: A*): Generator[A] =
     oneOf(first +: second +: rest)
 
-  implicit final class GeneratorTuple4Ops[A, B, C, D](private val tuple: (Generator[A], Generator[B], Generator[C], Generator[D]))
-      extends AnyVal {
+  implicit final class GeneratorTuple4Ops[A, B, C, D](
+      private val tuple: (Generator[A], Generator[B], Generator[C], Generator[D]),
+  ) extends AnyVal {
     def mapN[E](f: (A, B, C, D) => E): Generator[E] =
       for {
         a <- tuple._1

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -73,38 +73,20 @@ object Faker {
 
   /** Person data generators. */
   object person {
-    private val MaleFirstNames   =
-      Vector("Ivan", "Alexey", "Dmitry", "Sergey", "Nicolas", "John", "Pedro", "Lucas", "Martin", "Andres")
-    private val FemaleFirstNames =
-      Vector("Anna", "Maria", "Elena", "Sofia", "Camila", "Julia", "Lucia", "Valentina", "Fernanda", "Olga")
-    private val LastNames        =
-      Vector("Ivanov", "Petrov", "Sidorov", "Garcia", "Silva", "Smith", "Brown", "Martinez", "Fernandez", "Volkov")
-    private val JobTitles        =
-      Vector(
-        "Performance Engineer",
-        "QA Engineer",
-        "Backend Developer",
-        "SRE",
-        "Product Analyst",
-        "Data Engineer",
-        "Security Engineer",
-      )
-    private val Prefixes         = Vector("Mr.", "Mrs.", "Ms.", "Dr.")
-
     def gender(): Generator[Gender] =
       oneOf(Gender.Male, Gender.Female, Gender.Unspecified)
 
     def firstName(gender: Gender = Gender.Unspecified): Generator[String] = gender match {
-      case Gender.Male        => oneOf(MaleFirstNames)
-      case Gender.Female      => oneOf(FemaleFirstNames)
-      case Gender.Unspecified => oneOf(MaleFirstNames ++ FemaleFirstNames)
+      case Gender.Male        => oneOf(FakerData.maleFirstNames)
+      case Gender.Female      => oneOf(FakerData.femaleFirstNames)
+      case Gender.Unspecified => oneOf(FakerData.maleFirstNames ++ FakerData.femaleFirstNames)
     }
 
     def lastName(): Generator[String] =
-      oneOf(LastNames)
+      oneOf(FakerData.lastNames)
 
     def prefix(): Generator[String] =
-      oneOf(Prefixes)
+      oneOf(FakerData.personPrefixes)
 
     def fullName(gender: Gender = Gender.Unspecified): Generator[String] =
       for {
@@ -113,7 +95,7 @@ object Faker {
       } yield s"$first $last"
 
     def jobTitle(): Generator[String] =
-      oneOf(JobTitles)
+      oneOf(FakerData.jobTitles)
 
     def companyEmailName(): Generator[String] =
       fullName().map(_.toLowerCase.replaceAll("[^a-z0-9]+", ".").stripPrefix(".").stripSuffix("."))
@@ -121,15 +103,8 @@ object Faker {
 
   /** Internet-oriented generators. */
   object internet {
-    private val Domains    = Vector("example.com", "test.local", "load.test", "picatinny.dev")
-    private val UserAgents = Vector(
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15",
-      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
-    )
-
     def domain(): Generator[String] =
-      oneOf(Domains)
+      oneOf(FakerData.domains)
 
     def email(domain: String = "example.com"): Generator[String] =
       for {
@@ -153,7 +128,7 @@ object Faker {
       string.fromAlphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*", length)
 
     def userAgent(): Generator[String] =
-      oneOf(UserAgents)
+      oneOf(FakerData.userAgents)
 
     def ipv4(): Generator[String] =
       (number.int(1, 254), number.int(0, 255), number.int(0, 255), number.int(1, 254)).mapN { (a, b, c, d) =>
@@ -173,15 +148,6 @@ object Faker {
 
   /** Location and address generators for common payload fields. */
   object location {
-    private val Cities: Map[Country, Vector[String]] = Map(
-      Country.RU -> Vector("Moscow", "Saint Petersburg", "Kazan", "Novosibirsk"),
-      Country.AR -> Vector("Buenos Aires", "Cordoba", "Rosario", "Mendoza"),
-      Country.BR -> Vector("Sao Paulo", "Rio de Janeiro", "Brasilia", "Curitiba"),
-      Country.US -> Vector("New York", "Austin", "Seattle", "Chicago"),
-      Country.DE -> Vector("Berlin", "Munich", "Hamburg", "Frankfurt"),
-    )
-    private val Streets                              = Vector("Main Street", "Performance Avenue", "Load Test Road", "Central Boulevard", "Liberty Street")
-
     def country(): Generator[Country] =
       oneOf(
         Country.RU,
@@ -200,10 +166,10 @@ object Faker {
       country().map(_.iso2)
 
     def city(country: Country = Country.US): Generator[String] =
-      oneOf(Cities.getOrElse(country, Cities(Country.US)))
+      oneOf(FakerData.citiesByCountry.getOrElse(country, FakerData.citiesByCountry(Country.US)))
 
     def streetName(): Generator[String] =
-      oneOf(Streets)
+      oneOf(FakerData.streetNames)
 
     def streetAddress(country: Country = Country.US): Generator[String] =
       for {
@@ -331,7 +297,7 @@ object Faker {
       amount(min, max).map(Money(_, currency))
 
     def currency(): Generator[String] =
-      oneOf("USD", "EUR", "RUB", "BRL", "ARS", "GBP", "AED")
+      oneOf(FakerData.currencies)
 
     def accountNumber(length: Int = 20): Generator[String] =
       string.numeric(length)
@@ -358,11 +324,8 @@ object Faker {
 
   /** Commerce generators for request bodies and order scenarios. */
   object commerce {
-    private val Products   = Vector("Laptop", "Phone", "Subscription", "Support package", "Gift card")
-    private val Categories = Vector("electronics", "services", "finance", "books", "travel")
-
-    def productName(): Generator[String]                                                             = oneOf(Products)
-    def category(): Generator[String]                                                                = oneOf(Categories)
+    def productName(): Generator[String]                                                             = oneOf(FakerData.products)
+    def category(): Generator[String]                                                                = oneOf(FakerData.categories)
     def sku(prefix: String = "SKU"): Generator[String]                                               =
       string.alphanumeric(10).map(value => s"$prefix-$value")
     def orderId(prefix: String = "ord"): Generator[String]                                           =
@@ -389,18 +352,8 @@ object Faker {
       case PhoneFormatMode.TollFree      => TypePhone.TollFreePhoneNumber
     }
 
-    private def countryFormats(country: Country): Seq[PhoneFormat] = country match {
-      case Country.RU => Seq(PhoneFormat("+7", 10, Seq("903", "906", "908", "926", "999"), "+X XXX XXX-XX-XX"))
-      case Country.AR => Seq(PhoneFormat("+54", 10, Seq("11", "221", "351", "261"), "+XX XXX XXX-XXXX"))
-      case Country.BR => Seq(PhoneFormat("+55", 11, Seq("11", "21", "31", "41"), "+XX XX XXXXX-XXXX"))
-      case Country.GB => Seq(PhoneFormat("+44", 10, Seq("7400", "7500", "7700"), "+XX XXXX XXXXXX"))
-      case Country.DE => Seq(PhoneFormat("+49", 10, Seq("151", "152", "160", "170"), "+XX XXX XXXXXXX"))
-      case Country.FR => Seq(PhoneFormat("+33", 9, Seq("6", "7"), "+XX X XX XX XX XX"))
-      case Country.ES => Seq(PhoneFormat("+34", 9, Seq("6", "7"), "+XX XXX XXX XXX"))
-      case Country.IT => Seq(PhoneFormat("+39", 10, Seq("320", "328", "333"), "+XX XXX XXX XXXX"))
-      case Country.AE => Seq(PhoneFormat("+971", 9, Seq("50", "52", "54", "55"), "+XXX XX XXX XXXX"))
-      case _          => Seq.empty
-    }
+    private def countryFormats(country: Country): Seq[PhoneFormat] =
+      FakerData.phoneFormatsByCountry.getOrElse(country, Seq.empty)
   }
 
   /** Passport generators. */
@@ -459,10 +412,8 @@ object Faker {
 
   /** Weather values for synthetic telemetry and environment-like payloads. */
   object weather {
-    private val Conditions = Vector("clear", "cloudy", "rain", "storm", "snow", "fog", "wind")
-
     def condition(): Generator[String] =
-      oneOf(Conditions)
+      oneOf(FakerData.weatherConditions)
 
     def temperatureCelsius(min: Double = -30.0, max: Double = 45.0): Generator[Double] =
       number.double(min, max).map(value => BigDecimal(value).setScale(1, RoundingMode.HALF_UP).toDouble)
@@ -476,23 +427,8 @@ object Faker {
 
   /** Lorem ipsum generators for payload text. */
   object lorem {
-    private val Words = Vector(
-      "lorem",
-      "ipsum",
-      "dolor",
-      "sit",
-      "amet",
-      "consectetur",
-      "adipiscing",
-      "elit",
-      "sed",
-      "do",
-      "eiusmod",
-      "tempor",
-    )
-
     def word(): Generator[String] =
-      oneOf(Words)
+      oneOf(FakerData.loremWords)
 
     def words(count: Int): Generator[String] = {
       require(count > 0, s"count must be > 0: $count")

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -8,6 +8,7 @@ import java.time.temporal.ChronoUnit
 import java.time.{LocalDate, LocalDateTime, ZoneId}
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
+import scala.annotation.tailrec
 import scala.math.BigDecimal.RoundingMode
 
 /** Faker facade for generating load-test data.
@@ -27,14 +28,15 @@ object Faker {
   object number {
     def int(min: Int, max: Int): Generator[Int] = {
       require(min <= max, s"min must be <= max: $min > $max")
-      Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextInt(min, max + 1))
+      Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextLong(min.toLong, max.toLong + 1L).toInt)
     }
 
     def long(min: Long, max: Long): Generator[Long] = {
       require(min <= max, s"min must be <= max: $min > $max")
-      Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextLong(min, max + 1))
+      Generator.delay(nextLongInclusive(min, max))
     }
 
+    /** Generates a double in [min, max). Note: max is exclusive per JDK ThreadLocalRandom contract. */
     def double(min: Double, max: Double): Generator[Double] = {
       require(min <= max, s"min must be <= max: $min > $max")
       Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextDouble(min, max))
@@ -43,8 +45,68 @@ object Faker {
     def float(min: Float, max: Float): Generator[Float] =
       double(min.toDouble, max.toDouble).map(_.toFloat)
 
+    def byte(min: Byte = Byte.MinValue, max: Byte = Byte.MaxValue): Generator[Byte] =
+      int(min.toInt, max.toInt).map(_.toByte)
+
+    def short(min: Short = Short.MinValue, max: Short = Short.MaxValue): Generator[Short] =
+      int(min.toInt, max.toInt).map(_.toShort)
+
+    def char(min: Char = 'A', max: Char = 'z'): Generator[Char] =
+      int(min.toInt, max.toInt).map(_.toChar)
+
+    def bigInt(min: BigInt, max: BigInt): Generator[BigInt] = {
+      require(min <= max, s"min must be <= max: $min > $max")
+      val range = max - min + 1
+      Generator.delay(min + randomBigInt(range))
+    }
+
+    def bigDecimal(min: BigDecimal, max: BigDecimal, scale: Int = 2): Generator[BigDecimal] = {
+      require(scale >= 0, s"scale must be >= 0: $scale")
+      require(min <= max, s"min must be <= max: $min > $max")
+      val factor   = BigDecimal(10).pow(scale)
+      val minUnits = (min.setScale(scale, RoundingMode.CEILING) * factor).toBigInt
+      val maxUnits = (max.setScale(scale, RoundingMode.FLOOR) * factor).toBigInt
+      require(minUnits <= maxUnits, s"range has no values at scale $scale: $min..$max")
+      bigInt(minUnits, maxUnits).map(units => (BigDecimal(units) / factor).setScale(scale))
+    }
+
     def boolean: Generator[Boolean] =
       Generator.delay(ThreadLocalRandom.current().nextBoolean())
+
+    def positiveInt: Generator[Int]   = int(1, Int.MaxValue)
+    def positiveLong: Generator[Long] = long(1L, Long.MaxValue)
+    def negativeInt: Generator[Int]   = int(Int.MinValue, -1)
+    def negativeLong: Generator[Long] = long(Long.MinValue, -1L)
+    def percentage: Generator[Int]    = int(0, 100)
+
+    private def nextLongInclusive(min: Long, max: Long): Long =
+      if (min == max) min
+      else if (BigInt(max) - BigInt(min) + 1 <= BigInt(Long.MaxValue)) {
+        val bound = (BigInt(max) - BigInt(min) + 1).toLong
+        min + ThreadLocalRandom.current().nextLong(bound)
+      } else if (min == Long.MinValue) ThreadLocalRandom.current().nextLong()
+      else {
+        @tailrec
+        def retry(): Long = {
+          val value = ThreadLocalRandom.current().nextLong()
+          if (value >= min) value else retry()
+        }
+        retry()
+      }
+
+    private def randomBigInt(exclusiveUpperBound: BigInt): BigInt = {
+      require(exclusiveUpperBound > 0, s"exclusiveUpperBound must be > 0: $exclusiveUpperBound")
+      val bytes = new Array[Byte]((exclusiveUpperBound.bitLength + 7) / 8)
+
+      @tailrec
+      def retry(): BigInt = {
+        ThreadLocalRandom.current().nextBytes(bytes)
+        val candidate = BigInt(1, bytes)
+        if (candidate < exclusiveUpperBound) candidate else retry()
+      }
+
+      retry()
+    }
   }
 
   /** String generators for identifiers, payload fields, and templates. */
@@ -160,6 +222,12 @@ object Faker {
         Country.ES,
         Country.IT,
         Country.AE,
+        Country.JP,
+        Country.CN,
+        Country.IN,
+        Country.CA,
+        Country.AU,
+        Country.MX,
       )
 
     def countryCode(): Generator[String] =
@@ -183,6 +251,12 @@ object Faker {
       case Country.BR => string.numeric(8)
       case Country.US => string.numeric(5)
       case Country.DE => string.numeric(5)
+      case Country.JP => string.numeric(7)
+      case Country.CN => string.numeric(6)
+      case Country.IN => string.numeric(6)
+      case Country.CA => string.alphanumeric(6).map(_.toUpperCase)
+      case Country.AU => string.numeric(4)
+      case Country.MX => string.numeric(5)
       case _          => string.alphanumeric(6)
     }
 
@@ -204,6 +278,12 @@ object Faker {
       case Country.BR                                        => Generator.const("BRL")
       case Country.GB                                        => Generator.const("GBP")
       case Country.AE                                        => Generator.const("AED")
+      case Country.JP                                        => Generator.const("JPY")
+      case Country.CN                                        => Generator.const("CNY")
+      case Country.IN                                        => Generator.const("INR")
+      case Country.CA                                        => Generator.const("CAD")
+      case Country.AU                                        => Generator.const("AUD")
+      case Country.MX                                        => Generator.const("MXN")
       case Country.DE | Country.FR | Country.ES | Country.IT => Generator.const("EUR")
       case _                                                 => Generator.const("USD")
     }
@@ -216,6 +296,10 @@ object Faker {
       case Country.FR => Generator.const("fr")
       case Country.ES => Generator.const("es")
       case Country.IT => Generator.const("it")
+      case Country.JP => Generator.const("ja")
+      case Country.CN => Generator.const("zh")
+      case Country.IN => Generator.const("hi")
+      case Country.MX => Generator.const("es")
       case _          => Generator.const("en")
     }
   }
@@ -263,12 +347,19 @@ object Faker {
     ): Generator[(LocalDate, LocalDate)] = {
       require(minLengthDays >= 0, s"minLengthDays must be >= 0: $minLengthDays")
       require(minLengthDays <= maxLengthDays, s"minLengthDays must be <= maxLengthDays")
+      require(!from.isAfter(to), s"from must be <= to: $from > $to")
+      val totalDays   = ChronoUnit.DAYS.between(from, to)
+      require(
+        minLengthDays <= totalDays,
+        s"minLengthDays must fit inside the date range: $minLengthDays > $totalDays",
+      )
+      val latestStart = to.minusDays(minLengthDays)
       for {
-        start  <- between(from, to)
-        length <- number.long(minLengthDays, maxLengthDays)
+        start       <- between(from, latestStart)
+        maxEndLength = math.min(maxLengthDays, ChronoUnit.DAYS.between(start, to))
+        length      <- number.long(minLengthDays, maxEndLength)
       } yield {
-        val end = start.plusDays(length)
-        start -> (if (end.isAfter(to)) to else end)
+        start -> start.plusDays(length)
       }
     }
 
@@ -290,7 +381,7 @@ object Faker {
 
     def amount(min: BigDecimal, max: BigDecimal, scale: Int = 2): Generator[BigDecimal] = {
       require(min <= max, s"min must be <= max: $min > $max")
-      number.double(min.toDouble, max.toDouble).map(value => BigDecimal(value).setScale(scale, RoundingMode.HALF_UP))
+      number.bigDecimal(min, max, scale)
     }
 
     def money(min: BigDecimal, max: BigDecimal, currency: String = "USD"): Generator[Money] =
@@ -310,11 +401,19 @@ object Faker {
         branch       <- string.alphanumeric(3).map(_.toUpperCase)
       } yield s"$bank$country$locationCode$branch"
 
+    /** Generates IBAN-like strings. Check digits are hardcoded placeholders — values will not pass strict ISO 7064 validation
+      * but are structurally correct for load-test payloads.
+      */
     def iban(country: Country = Country.DE): Generator[String] = country match {
       case Country.DE => string.numeric(18).map(value => s"DE89$value")
       case Country.GB =>
         string.alphanumeric(4).map(_.toUpperCase).zip(string.numeric(14)).map { case (bank, digits) => s"GB82$bank$digits" }
       case Country.FR => string.numeric(23).map(value => s"FR14$value")
+      case Country.ES => string.numeric(20).map(value => s"ES91$value")
+      case Country.IT =>
+        string.alphabetic(1).map(_.toUpperCase).zip(string.numeric(22)).map { case (check, digits) => s"IT60$check$digits" }
+      case Country.RU => string.numeric(29).map(value => s"RU33$value")
+      case Country.BR => string.numeric(23).map(value => s"BR18$value")
       case _          => string.alphanumeric(20).map(value => s"${country.iso2}00${value.toUpperCase}")
     }
 
@@ -334,7 +433,10 @@ object Faker {
       finance.money(min, max, "USD")
   }
 
-  /** Phone generators. Country metadata is intentionally compact and will be expanded. */
+  /** Phone generators with configurable formatting for all supported countries.
+    *
+    * Supports 16 countries out of the box. Custom formats can be provided via `fromFormats` or `builder`.
+    */
   object phone {
     def mobile(country: Country, format: PhoneFormatMode = PhoneFormatMode.E164): Generator[String] =
       Generator.delay(RandomPhoneGenerator.randomPhone(countryFormats(country), toLegacyPhoneType(format)))
@@ -342,8 +444,13 @@ object Faker {
     def tollFree(country: Country = Country.US): Generator[String] =
       Generator.delay(RandomPhoneGenerator.randomPhone(countryFormats(country), TypePhone.TollFreePhoneNumber))
 
-    def fromFormats(format: PhoneFormatMode, formats: PhoneFormat*): Generator[String] =
+    def fromFormats(format: PhoneFormatMode, formats: PhoneFormat*): Generator[String] = {
+      require(formats.nonEmpty, "At least one phone format must be provided")
       Generator.delay(RandomPhoneGenerator.randomPhone(formats, toLegacyPhoneType(format)))
+    }
+
+    /** Fluent builder for custom phone number configuration. */
+    def builder: PhoneBuilder = PhoneBuilder()
 
     private def toLegacyPhoneType(format: PhoneFormatMode): TypePhone.TypePhone = format match {
       case PhoneFormatMode.E164          => TypePhone.E164PhoneNumber
@@ -352,8 +459,11 @@ object Faker {
       case PhoneFormatMode.TollFree      => TypePhone.TollFreePhoneNumber
     }
 
-    private def countryFormats(country: Country): Seq[PhoneFormat] =
-      FakerData.phoneFormatsByCountry.getOrElse(country, Seq.empty)
+    private[faker] def countryFormats(country: Country): Seq[PhoneFormat] = {
+      val formats = FakerData.phoneFormatsByCountry.getOrElse(country, Seq.empty)
+      require(formats.nonEmpty, s"No phone formats configured for country ${country.iso2}")
+      formats
+    }
   }
 
   /** Passport generators. */
@@ -410,6 +520,122 @@ object Faker {
       }
   }
 
+  /** Spanish identifiers. */
+  object es {
+
+    /** Generates a NIF (Número de Identificación Fiscal) with a valid check letter.
+      *
+      * Format: 8 digits + 1 letter. The letter is computed as `digits % 23` mapped to the standard NIF letter table.
+      */
+    def nif(): Generator[String] =
+      Generator.delay {
+        val digits  = ThreadLocalRandom.current().nextInt(10000000, 100000000)
+        val letters = "TRWAGMYFPDXBNJZSQVHLCKE"
+        f"$digits%08d${letters.charAt(digits % 23)}"
+      }
+  }
+
+  /** Italian identifiers. */
+  object it {
+
+    /** Generates a structurally valid Codice Fiscale (16 alphanumeric characters).
+      *
+      * The generated value follows the correct format (6 letters + 2 digits + 1 letter + 2 digits + 1 letter + 3 digits + 1
+      * letter) but uses random data rather than real name/date derivation. Suitable for load-test payloads where format matters
+      * more than semantic correctness.
+      */
+    def codiceFiscale(): Generator[String] =
+      for {
+        surname  <- string.alphabetic(3).map(_.toUpperCase)
+        name     <- string.alphabetic(3).map(_.toUpperCase)
+        year     <- string.numeric(2)
+        month    <- oneOf("A", "B", "C", "D", "E", "H", "L", "M", "P", "R", "S", "T")
+        day      <- number.int(1, 71).map(d => f"$d%02d")
+        town     <- string.alphabetic(1).map(_.toUpperCase)
+        townCode <- string.numeric(3)
+        check    <- string.alphabetic(1).map(_.toUpperCase)
+      } yield s"$surname$name$year$month$day$town$townCode$check"
+  }
+
+  /** German identifiers. */
+  object de {
+
+    /** Generates a Steuerliche Identifikationsnummer (11 digits). Uses a simplified generation that produces structurally
+      * valid-looking values — real TIN validation is more complex and not needed for load tests.
+      */
+    def steueridentifikationsnummer(): Generator[String] =
+      Generator.delay {
+        val first = ThreadLocalRandom.current().nextInt(1, 10)
+        val rest  = (1 to 10).map(_ => ThreadLocalRandom.current().nextInt(0, 10))
+        (first +: rest).mkString
+      }
+  }
+
+  /** United States identifiers. */
+  object us {
+
+    /** Generates a Social Security Number (SSN) in format XXX-XX-XXXX. Area numbers 000, 666, and 900-999 are excluded. */
+    def ssn(formatted: Boolean = true): Generator[String] =
+      Generator.delay {
+        val area   = {
+          var a = 0
+          while (a == 0 || a == 666 || a >= 900) a = ThreadLocalRandom.current().nextInt(1, 1000)
+          a
+        }
+        val group  = ThreadLocalRandom.current().nextInt(1, 100)
+        val serial = ThreadLocalRandom.current().nextInt(1, 10000)
+        if (formatted) f"$area%03d-$group%02d-$serial%04d" else f"$area%03d$group%02d$serial%04d"
+      }
+  }
+
+  /** United Kingdom identifiers. */
+  object gb {
+
+    /** Generates a National Insurance Number (NINO) in format AB123456C.
+      *
+      * Excludes disallowed prefix combinations (BG, GB, NK, KN, TN, NT, ZZ) and invalid first letters (D, F, I, Q, U, V).
+      */
+    def nino(): Generator[String] =
+      Generator.delay {
+        val disallowed    = Set("BG", "GB", "NK", "KN", "TN", "NT", "ZZ")
+        val invalidFirst  = "DFIQUV"
+        val invalidSecond = "DFIQUVO"
+        val letters       = ('A' to 'Z').filterNot(ch => invalidFirst.contains(ch))
+        val secondLetters = ('A' to 'Z').filterNot(ch => invalidSecond.contains(ch))
+        var prefix        = ""
+        do {
+          val first  = letters(ThreadLocalRandom.current().nextInt(letters.size))
+          val second = secondLetters(ThreadLocalRandom.current().nextInt(secondLetters.size))
+          prefix = s"$first$second"
+        } while (disallowed.contains(prefix))
+        val digits        = (1 to 6).map(_ => ThreadLocalRandom.current().nextInt(10)).mkString
+        val suffix        = ('A' to 'D')(ThreadLocalRandom.current().nextInt(4))
+        s"$prefix$digits$suffix"
+      }
+  }
+
+  /** French identifiers. */
+  object fr {
+
+    /** Generates a NIR (Numéro d'Inscription au Répertoire) — French social security number.
+      *
+      * Format: 1 digit sex + 2 digit year + 2 digit month + 5 digit department/commune + 3 digit order + 2 digit key. Key is
+      * computed as 97 - (first 13 digits mod 97).
+      */
+    def nir(): Generator[String] =
+      Generator.delay {
+        val sex        = ThreadLocalRandom.current().nextInt(1, 3)
+        val year       = ThreadLocalRandom.current().nextInt(0, 100)
+        val month      = ThreadLocalRandom.current().nextInt(1, 13)
+        val department = ThreadLocalRandom.current().nextInt(1, 96)
+        val commune    = ThreadLocalRandom.current().nextInt(1, 1000)
+        val order      = ThreadLocalRandom.current().nextInt(1, 1000)
+        val base       = f"$sex%01d$year%02d$month%02d$department%02d$commune%03d$order%03d"
+        val key        = 97 - (base.toLong % 97)
+        f"$base$key%02d"
+      }
+  }
+
   /** Weather values for synthetic telemetry and environment-like payloads. */
   object weather {
     def condition(): Generator[String] =
@@ -432,7 +658,8 @@ object Faker {
 
     def words(count: Int): Generator[String] = {
       require(count > 0, s"count must be > 0: $count")
-      Generator.delay(Vector.fill(count)(word().sample()).mkString(" "))
+      val data = FakerData.loremWords
+      Generator.delay(Vector.fill(count)(data(ThreadLocalRandom.current().nextInt(data.size))).mkString(" "))
     }
 
     def sentence(wordsCount: Int = 8): Generator[String] =

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -1,0 +1,515 @@
+package org.galaxio.gatling.feeders.faker
+
+import org.galaxio.gatling.utils.{RandomDataGenerators, RandomPhoneGenerator}
+import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
+
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.util.UUID
+import java.util.concurrent.ThreadLocalRandom
+import scala.math.BigDecimal.RoundingMode
+
+/** Faker facade for generating load-test data.
+  *
+  * The API is intentionally domain-oriented: use `Faker.internet.email()` or
+  * `Faker.ru.inn.person()` in scenarios, then pass generators into
+  * `GeneratedFeeder` when Gatling needs session records.
+  */
+object Faker {
+
+  /** UUID generators. */
+  object uuid {
+    def value: Generator[UUID]   = Generator.delay(UUID.randomUUID())
+    def string: Generator[String] = value.map(_.toString)
+  }
+
+  /** Primitive and JVM-friendly number generators. */
+  object number {
+    def int(min: Int, max: Int): Generator[Int] = {
+      require(min <= max, s"min must be <= max: $min > $max")
+      Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextInt(min, max + 1))
+    }
+
+    def long(min: Long, max: Long): Generator[Long] = {
+      require(min <= max, s"min must be <= max: $min > $max")
+      Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextLong(min, max + 1))
+    }
+
+    def double(min: Double, max: Double): Generator[Double] = {
+      require(min <= max, s"min must be <= max: $min > $max")
+      Generator.delay(if (min == max) min else ThreadLocalRandom.current().nextDouble(min, max))
+    }
+
+    def float(min: Float, max: Float): Generator[Float] =
+      double(min.toDouble, max.toDouble).map(_.toFloat)
+
+    def boolean: Generator[Boolean] =
+      Generator.delay(ThreadLocalRandom.current().nextBoolean())
+  }
+
+  /** String generators for identifiers, payload fields, and templates. */
+  object string {
+    def alphabetic(length: Int): Generator[String] =
+      Generator.delay(RandomDataGenerators.lettersString(length))
+
+    def alphanumeric(length: Int): Generator[String] =
+      Generator.delay(RandomDataGenerators.alphanumericString(length))
+
+    def numeric(length: Int): Generator[String] =
+      Generator.delay(RandomDataGenerators.digitString(length))
+
+    def hex(length: Int): Generator[String] =
+      Generator.delay(RandomDataGenerators.hexString(length))
+
+    def cyrillic(length: Int): Generator[String] =
+      Generator.delay(RandomDataGenerators.cyrillicString(length))
+
+    def fromAlphabet(alphabet: String, length: Int): Generator[String] =
+      Generator.delay(RandomDataGenerators.randomString(alphabet)(length))
+
+    def lengthBetween(min: Int, max: Int, alphabet: String): Generator[String] =
+      number.int(min, max).flatMap(fromAlphabet(alphabet, _))
+  }
+
+  /** Person data generators. */
+  object person {
+    private val MaleFirstNames =
+      Vector("Ivan", "Alexey", "Dmitry", "Sergey", "Nicolas", "John", "Pedro", "Lucas", "Martin", "Andres")
+    private val FemaleFirstNames =
+      Vector("Anna", "Maria", "Elena", "Sofia", "Camila", "Julia", "Lucia", "Valentina", "Fernanda", "Olga")
+    private val LastNames =
+      Vector("Ivanov", "Petrov", "Sidorov", "Garcia", "Silva", "Smith", "Brown", "Martinez", "Fernandez", "Volkov")
+    private val JobTitles =
+      Vector(
+        "Performance Engineer",
+        "QA Engineer",
+        "Backend Developer",
+        "SRE",
+        "Product Analyst",
+        "Data Engineer",
+        "Security Engineer",
+      )
+    private val Prefixes = Vector("Mr.", "Mrs.", "Ms.", "Dr.")
+
+    def gender(): Generator[Gender] =
+      oneOf(Gender.Male, Gender.Female, Gender.Unspecified)
+
+    def firstName(gender: Gender = Gender.Unspecified): Generator[String] = gender match {
+      case Gender.Male        => oneOf(MaleFirstNames)
+      case Gender.Female      => oneOf(FemaleFirstNames)
+      case Gender.Unspecified => oneOf(MaleFirstNames ++ FemaleFirstNames)
+    }
+
+    def lastName(): Generator[String] =
+      oneOf(LastNames)
+
+    def prefix(): Generator[String] =
+      oneOf(Prefixes)
+
+    def fullName(gender: Gender = Gender.Unspecified): Generator[String] =
+      for {
+        first <- firstName(gender)
+        last  <- lastName()
+      } yield s"$first $last"
+
+    def jobTitle(): Generator[String] =
+      oneOf(JobTitles)
+
+    def companyEmailName(): Generator[String] =
+      fullName().map(_.toLowerCase.replaceAll("[^a-z0-9]+", ".").stripPrefix(".").stripSuffix("."))
+  }
+
+  /** Internet-oriented generators. */
+  object internet {
+    private val Domains = Vector("example.com", "test.local", "load.test", "picatinny.dev")
+    private val UserAgents = Vector(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15",
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
+    )
+
+    def domain(): Generator[String] =
+      oneOf(Domains)
+
+    def email(domain: String = "example.com"): Generator[String] =
+      for {
+        name <- person.fullName()
+        suffix <- string.alphanumeric(6)
+      } yield emailFromName(name, domain, suffix)
+
+    def email(name: String, domain: String): Generator[String] =
+      string.alphanumeric(6).map(emailFromName(name, domain, _))
+
+    def username(): Generator[String] =
+      person.fullName().map(_.toLowerCase.replace(' ', '.'))
+
+    def url(protocol: String = "https"): Generator[String] =
+      for {
+        host <- domain()
+        path <- string.alphanumeric(12)
+      } yield s"$protocol://$host/$path"
+
+    def password(length: Int = 16): Generator[String] =
+      string.fromAlphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*", length)
+
+    def userAgent(): Generator[String] =
+      oneOf(UserAgents)
+
+    def ipv4(): Generator[String] =
+      (number.int(1, 254), number.int(0, 255), number.int(0, 255), number.int(1, 254)).mapN { (a, b, c, d) =>
+        s"$a.$b.$c.$d"
+      }
+
+    def ipv6(): Generator[String] =
+      Generator.delay(Vector.fill(8)(RandomDataGenerators.hexString(4)).mkString(":"))
+
+    private def emailFromName(name: String, domain: String, suffix: String): String = {
+      require(domain.nonEmpty, "Email domain must be non-empty")
+      val localPart = name.toLowerCase.replaceAll("[^a-z0-9]+", ".").stripPrefix(".").stripSuffix(".")
+      val normalizedLocalPart = if (localPart.isEmpty) "user" else localPart
+      s"$normalizedLocalPart.$suffix@$domain"
+    }
+  }
+
+  /** Location and address generators for common payload fields. */
+  object location {
+    private val Cities: Map[Country, Vector[String]] = Map(
+      Country.RU -> Vector("Moscow", "Saint Petersburg", "Kazan", "Novosibirsk"),
+      Country.AR -> Vector("Buenos Aires", "Cordoba", "Rosario", "Mendoza"),
+      Country.BR -> Vector("Sao Paulo", "Rio de Janeiro", "Brasilia", "Curitiba"),
+      Country.US -> Vector("New York", "Austin", "Seattle", "Chicago"),
+      Country.DE -> Vector("Berlin", "Munich", "Hamburg", "Frankfurt"),
+    )
+    private val Streets = Vector("Main Street", "Performance Avenue", "Load Test Road", "Central Boulevard", "Liberty Street")
+
+    def country(): Generator[Country] =
+      oneOf(Country.RU, Country.AR, Country.BR, Country.US, Country.GB, Country.DE, Country.FR, Country.ES, Country.IT, Country.AE)
+
+    def countryCode(): Generator[String] =
+      country().map(_.iso2)
+
+    def city(country: Country = Country.US): Generator[String] =
+      oneOf(Cities.getOrElse(country, Cities(Country.US)))
+
+    def streetName(): Generator[String] =
+      oneOf(Streets)
+
+    def streetAddress(country: Country = Country.US): Generator[String] =
+      for {
+        number <- number.int(1, 9999)
+        street <- streetName()
+      } yield s"$number $street"
+
+    def postalCode(country: Country = Country.US): Generator[String] = country match {
+      case Country.RU => string.numeric(6)
+      case Country.AR => string.numeric(4)
+      case Country.BR => string.numeric(8)
+      case Country.US => string.numeric(5)
+      case Country.DE => string.numeric(5)
+      case _          => string.alphanumeric(6)
+    }
+
+    def latitude(): Generator[Double] =
+      number.double(-90.0, 90.0)
+
+    def longitude(): Generator[Double] =
+      number.double(-180.0, 180.0)
+  }
+
+  /** Localization helpers for locale-sensitive test data choices. */
+  object localization {
+    def country(): Generator[Country] =
+      location.country()
+
+    def currency(country: Country): Generator[String] = country match {
+      case Country.RU => Generator.const("RUB")
+      case Country.AR => Generator.const("ARS")
+      case Country.BR => Generator.const("BRL")
+      case Country.GB => Generator.const("GBP")
+      case Country.AE => Generator.const("AED")
+      case Country.DE | Country.FR | Country.ES | Country.IT => Generator.const("EUR")
+      case _ => Generator.const("USD")
+    }
+
+    def languageCode(country: Country): Generator[String] = country match {
+      case Country.RU => Generator.const("ru")
+      case Country.AR => Generator.const("es")
+      case Country.BR => Generator.const("pt")
+      case Country.DE => Generator.const("de")
+      case Country.FR => Generator.const("fr")
+      case Country.ES => Generator.const("es")
+      case Country.IT => Generator.const("it")
+      case _ => Generator.const("en")
+    }
+  }
+
+  /** Date and time generators. */
+  object date {
+    def today(zone: ZoneId = ZoneId.systemDefault()): Generator[LocalDate] =
+      Generator.delay(LocalDate.now(zone))
+
+    def now(zone: ZoneId = ZoneId.systemDefault()): Generator[LocalDateTime] =
+      Generator.delay(LocalDateTime.now(zone))
+
+    def between(from: LocalDate, to: LocalDate): Generator[LocalDate] = {
+      require(!from.isAfter(to), s"from must be <= to: $from > $to")
+      val days = ChronoUnit.DAYS.between(from, to)
+      number.long(0L, days).map(from.plusDays)
+    }
+
+    def between(from: LocalDateTime, to: LocalDateTime): Generator[LocalDateTime] = {
+      require(!from.isAfter(to), s"from must be <= to: $from > $to")
+      val seconds = ChronoUnit.SECONDS.between(from, to)
+      number.long(0L, seconds).map(from.plusSeconds)
+    }
+
+    def past(days: Long, from: LocalDate = LocalDate.now()): Generator[LocalDate] = {
+      require(days >= 0, s"days must be >= 0: $days")
+      between(from.minusDays(days), from)
+    }
+
+    def future(days: Long, from: LocalDate = LocalDate.now()): Generator[LocalDate] = {
+      require(days >= 0, s"days must be >= 0: $days")
+      between(from, from.plusDays(days))
+    }
+
+    def offset(from: LocalDate, minDays: Long, maxDays: Long): Generator[LocalDate] = {
+      require(minDays <= maxDays, s"minDays must be <= maxDays: $minDays > $maxDays")
+      number.long(minDays, maxDays).map(from.plusDays)
+    }
+
+    def range(
+        from: LocalDate,
+        to: LocalDate,
+        minLengthDays: Long = 0L,
+        maxLengthDays: Long = 30L,
+    ): Generator[(LocalDate, LocalDate)] = {
+      require(minLengthDays >= 0, s"minLengthDays must be >= 0: $minLengthDays")
+      require(minLengthDays <= maxLengthDays, s"minLengthDays must be <= maxLengthDays")
+      for {
+        start  <- between(from, to)
+        length <- number.long(minLengthDays, maxLengthDays)
+      } yield {
+        val end = start.plusDays(length)
+        start -> (if (end.isAfter(to)) to else end)
+      }
+    }
+
+    def formatDate(localDate: Generator[LocalDate], pattern: String): Generator[String] = {
+      val formatter = DateTimeFormatter.ofPattern(pattern)
+      localDate.map(_.format(formatter))
+    }
+
+    def formatDateTime(localDateTime: Generator[LocalDateTime], pattern: String): Generator[String] = {
+      val formatter = DateTimeFormatter.ofPattern(pattern)
+      localDateTime.map(_.format(formatter))
+    }
+  }
+
+  /** Finance and commerce-friendly generators. */
+  object finance {
+    def pan(bins: String*): Generator[String] =
+      Generator.delay(RandomDataGenerators.randomPAN(bins: _*))
+
+    def amount(min: BigDecimal, max: BigDecimal, scale: Int = 2): Generator[BigDecimal] = {
+      require(min <= max, s"min must be <= max: $min > $max")
+      number.double(min.toDouble, max.toDouble).map(value => BigDecimal(value).setScale(scale, RoundingMode.HALF_UP))
+    }
+
+    def money(min: BigDecimal, max: BigDecimal, currency: String = "USD"): Generator[Money] =
+      amount(min, max).map(Money(_, currency))
+
+    def currency(): Generator[String] =
+      oneOf("USD", "EUR", "RUB", "BRL", "ARS", "GBP", "AED")
+
+    def accountNumber(length: Int = 20): Generator[String] =
+      string.numeric(length)
+
+    def bic(): Generator[String] =
+      for {
+        bank <- string.alphabetic(4).map(_.toUpperCase)
+        country <- location.countryCode()
+        locationCode <- string.alphanumeric(2).map(_.toUpperCase)
+        branch <- string.alphanumeric(3).map(_.toUpperCase)
+      } yield s"$bank$country$locationCode$branch"
+
+    def iban(country: Country = Country.DE): Generator[String] = country match {
+      case Country.DE => string.numeric(18).map(value => s"DE89$value")
+      case Country.GB => string.alphanumeric(4).map(_.toUpperCase).zip(string.numeric(14)).map { case (bank, digits) => s"GB82$bank$digits" }
+      case Country.FR => string.numeric(23).map(value => s"FR14$value")
+      case _          => string.alphanumeric(20).map(value => s"${country.iso2}00${value.toUpperCase}")
+    }
+
+    def transactionId(prefix: String = "txn"): Generator[String] =
+      string.alphanumeric(18).map(value => s"$prefix-$value")
+  }
+
+  /** Commerce generators for request bodies and order scenarios. */
+  object commerce {
+    private val Products   = Vector("Laptop", "Phone", "Subscription", "Support package", "Gift card")
+    private val Categories = Vector("electronics", "services", "finance", "books", "travel")
+
+    def productName(): Generator[String] = oneOf(Products)
+    def category(): Generator[String]    = oneOf(Categories)
+    def sku(prefix: String = "SKU"): Generator[String] =
+      string.alphanumeric(10).map(value => s"$prefix-$value")
+    def orderId(prefix: String = "ord"): Generator[String] =
+      string.alphanumeric(16).map(value => s"$prefix-$value")
+    def price(min: BigDecimal = BigDecimal(1), max: BigDecimal = BigDecimal(1000)): Generator[Money] =
+      finance.money(min, max, "USD")
+  }
+
+  /** Phone generators. Country metadata is intentionally compact and will be expanded. */
+  object phone {
+    def mobile(country: Country, format: PhoneFormatMode = PhoneFormatMode.E164): Generator[String] =
+      Generator.delay(RandomPhoneGenerator.randomPhone(countryFormats(country), toLegacyPhoneType(format)))
+
+    def tollFree(country: Country = Country.US): Generator[String] =
+      Generator.delay(RandomPhoneGenerator.randomPhone(countryFormats(country), TypePhone.TollFreePhoneNumber))
+
+    def fromFormats(format: PhoneFormatMode, formats: PhoneFormat*): Generator[String] =
+      Generator.delay(RandomPhoneGenerator.randomPhone(formats, toLegacyPhoneType(format)))
+
+    private def toLegacyPhoneType(format: PhoneFormatMode): TypePhone.TypePhone = format match {
+      case PhoneFormatMode.E164          => TypePhone.E164PhoneNumber
+      case PhoneFormatMode.National      => TypePhone.PhoneNumber
+      case PhoneFormatMode.International => TypePhone.PhoneNumber
+      case PhoneFormatMode.TollFree      => TypePhone.TollFreePhoneNumber
+    }
+
+    private def countryFormats(country: Country): Seq[PhoneFormat] = country match {
+      case Country.RU => Seq(PhoneFormat("+7", 10, Seq("903", "906", "908", "926", "999"), "+X XXX XXX-XX-XX"))
+      case Country.AR => Seq(PhoneFormat("+54", 10, Seq("11", "221", "351", "261"), "+XX XXX XXX-XXXX"))
+      case Country.BR => Seq(PhoneFormat("+55", 11, Seq("11", "21", "31", "41"), "+XX XX XXXXX-XXXX"))
+      case Country.GB => Seq(PhoneFormat("+44", 10, Seq("7400", "7500", "7700"), "+XX XXXX XXXXXX"))
+      case Country.DE => Seq(PhoneFormat("+49", 10, Seq("151", "152", "160", "170"), "+XX XXX XXXXXXX"))
+      case Country.FR => Seq(PhoneFormat("+33", 9, Seq("6", "7"), "+XX X XX XX XX XX"))
+      case Country.ES => Seq(PhoneFormat("+34", 9, Seq("6", "7"), "+XX XXX XXX XXX"))
+      case Country.IT => Seq(PhoneFormat("+39", 10, Seq("320", "328", "333"), "+XX XXX XXX XXXX"))
+      case Country.AE => Seq(PhoneFormat("+971", 9, Seq("50", "52", "54", "55"), "+XXX XX XXX XXXX"))
+      case _          => Seq.empty
+    }
+  }
+
+  /** Passport generators. */
+  object passport {
+    def ru(): Generator[String] =
+      Generator.delay(RandomDataGenerators.randomRusPassport())
+
+    def number(country: Country): Generator[String] = country match {
+      case Country.RU => ru()
+      case Country.AR => string.alphanumeric(9).map(_.toUpperCase)
+      case Country.BR => string.alphanumeric(8).map(_.toUpperCase)
+      case Country.US => string.numeric(9)
+      case _          => string.alphanumeric(9).map(_.toUpperCase)
+    }
+  }
+
+  /** Russian government and finance identifiers. */
+  object ru {
+    object inn {
+      def person(): Generator[String]  = Generator.delay(RandomDataGenerators.randomNatITN())
+      def company(): Generator[String] = Generator.delay(RandomDataGenerators.randomJurITN())
+    }
+
+    def kpp(): Generator[String]    = Generator.delay(RandomDataGenerators.randomKPP())
+    def ogrn(): Generator[String]   = Generator.delay(RandomDataGenerators.randomOGRN())
+    def ogrnip(): Generator[String] = Generator.delay(RandomDataGenerators.randomPSRNSP())
+    def snils(): Generator[String]  = Generator.delay(RandomDataGenerators.randomSNILS())
+  }
+
+  /** Brazilian identifiers. */
+  object br {
+    def cpf(formatted: Boolean = false): Generator[String] =
+      Generator.delay {
+        val base   = Vector.fill(9)(ThreadLocalRandom.current().nextInt(10))
+        val first  = cpfDigit(base, 10)
+        val second = cpfDigit(base :+ first, 11)
+        val raw    = (base :+ first :+ second).mkString
+        if (formatted) raw.replaceFirst("(\\d{3})(\\d{3})(\\d{3})(\\d{2})", "$1.$2.$3-$4") else raw
+      }
+
+    private def cpfDigit(digits: Seq[Int], startWeight: Int): Int = {
+      val sum = digits.zip(startWeight to 2 by -1).map { case (digit, weight) => digit * weight }.sum
+      val mod = (sum * 10) % 11
+      if (mod == 10) 0 else mod
+    }
+  }
+
+  /** Argentinian identifiers. */
+  object ar {
+    def dni(formatted: Boolean = false): Generator[String] =
+      number.int(10_000_000, 99_999_999).map { value =>
+        val raw = value.toString
+        if (formatted) raw.replaceFirst("(\\d{2})(\\d{3})(\\d{3})", "$1.$2.$3") else raw
+      }
+  }
+
+  /** Weather values for synthetic telemetry and environment-like payloads. */
+  object weather {
+    private val Conditions = Vector("clear", "cloudy", "rain", "storm", "snow", "fog", "wind")
+
+    def condition(): Generator[String] =
+      oneOf(Conditions)
+
+    def temperatureCelsius(min: Double = -30.0, max: Double = 45.0): Generator[Double] =
+      number.double(min, max).map(value => BigDecimal(value).setScale(1, RoundingMode.HALF_UP).toDouble)
+
+    def humidityPercent(): Generator[Int] =
+      number.int(0, 100)
+
+    def pressureHPa(): Generator[Int] =
+      number.int(950, 1050)
+  }
+
+  /** Lorem ipsum generators for payload text. */
+  object lorem {
+    private val Words = Vector(
+      "lorem",
+      "ipsum",
+      "dolor",
+      "sit",
+      "amet",
+      "consectetur",
+      "adipiscing",
+      "elit",
+      "sed",
+      "do",
+      "eiusmod",
+      "tempor",
+    )
+
+    def word(): Generator[String] =
+      oneOf(Words)
+
+    def words(count: Int): Generator[String] = {
+      require(count > 0, s"count must be > 0: $count")
+      Generator.delay(Vector.fill(count)(word().sample()).mkString(" "))
+    }
+
+    def sentence(wordsCount: Int = 8): Generator[String] =
+      words(wordsCount).map(text => text.capitalize + ".")
+  }
+
+  /** Picks one item from a non-empty sequence. */
+  def oneOf[A](items: Seq[A]): Generator[A] = {
+    require(items.nonEmpty, "oneOf requires at least one item")
+    Generator.delay(items(ThreadLocalRandom.current().nextInt(items.size)))
+  }
+
+  /** Picks one item from a non-empty varargs list. */
+  def oneOf[A](first: A, second: A, rest: A*): Generator[A] =
+    oneOf(first +: second +: rest)
+
+  implicit final class GeneratorTuple4Ops[A, B, C, D](private val tuple: (Generator[A], Generator[B], Generator[C], Generator[D]))
+      extends AnyVal {
+    def mapN[E](f: (A, B, C, D) => E): Generator[E] =
+      for {
+        a <- tuple._1
+        b <- tuple._2
+        c <- tuple._3
+        d <- tuple._4
+      } yield f(a, b, c, d)
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/FakerData.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/FakerData.scala
@@ -175,6 +175,12 @@ object FakerData {
     Country.ES -> Vector("Madrid", "Barcelona", "Valencia", "Seville", "Bilbao", "Malaga", "Zaragoza", "Murcia"),
     Country.IT -> Vector("Rome", "Milan", "Naples", "Turin", "Florence", "Bologna", "Genoa", "Venice"),
     Country.AE -> Vector("Dubai", "Abu Dhabi", "Sharjah", "Ajman", "Ras Al Khaimah", "Fujairah", "Al Ain", "Umm Al Quwain"),
+    Country.JP -> Vector("Tokyo", "Osaka", "Yokohama", "Nagoya", "Sapporo", "Fukuoka", "Kobe", "Kyoto"),
+    Country.CN -> Vector("Beijing", "Shanghai", "Shenzhen", "Guangzhou", "Chengdu", "Hangzhou", "Wuhan", "Nanjing"),
+    Country.IN -> Vector("Mumbai", "Delhi", "Bangalore", "Hyderabad", "Chennai", "Kolkata", "Pune", "Ahmedabad"),
+    Country.CA -> Vector("Toronto", "Vancouver", "Montreal", "Calgary", "Ottawa", "Edmonton", "Winnipeg", "Quebec City"),
+    Country.AU -> Vector("Sydney", "Melbourne", "Brisbane", "Perth", "Adelaide", "Gold Coast", "Canberra", "Hobart"),
+    Country.MX -> Vector("Mexico City", "Guadalajara", "Monterrey", "Puebla", "Tijuana", "Cancun", "Merida", "Queretaro"),
   )
 
   /** Generic street names for address generation. */
@@ -284,5 +290,11 @@ object FakerData {
     Country.ES -> Seq(PhoneFormat("+34", 9, Seq("6", "7"), "+XX XXX XXX XXX")),
     Country.IT -> Seq(PhoneFormat("+39", 10, Seq("320", "328", "333", "347", "349"), "+XX XXX XXX XXXX")),
     Country.AE -> Seq(PhoneFormat("+971", 9, Seq("50", "52", "54", "55", "56", "58"), "+XXX XX XXX XXXX")),
+    Country.JP -> Seq(PhoneFormat("+81", 10, Seq("70", "80", "90"), "+XX XX XXXX XXXX")),
+    Country.CN -> Seq(PhoneFormat("+86", 11, Seq("130", "131", "132", "155", "156", "185", "186"), "+XX XXX XXXX XXXX")),
+    Country.IN -> Seq(PhoneFormat("+91", 10, Seq("70", "80", "90", "98", "99"), "+XX XXXXX XXXXX")),
+    Country.CA -> Seq(PhoneFormat("+1", 10, Seq("204", "226", "236", "249", "289", "306", "343"), "+X XXX XXX-XXXX")),
+    Country.AU -> Seq(PhoneFormat("+61", 9, Seq("4"), "+XX XXX XXX XXX")),
+    Country.MX -> Seq(PhoneFormat("+52", 10, Seq("55", "33", "81", "656", "664"), "+XX XX XXXX XXXX")),
   )
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/FakerData.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/FakerData.scala
@@ -1,0 +1,288 @@
+package org.galaxio.gatling.feeders.faker
+
+import org.galaxio.gatling.utils.phone.PhoneFormat
+
+/** Predefined faker datasets used by [[Faker]].
+  *
+  * These values are public on purpose: projects can reuse the same catalogs for custom generators, assertions, or
+  * scenario-specific filtering.
+  */
+object FakerData {
+
+  /** Common male first names from several supported locales. */
+  val maleFirstNames: Vector[String] = Vector(
+    "Ivan",
+    "Alexey",
+    "Dmitry",
+    "Sergey",
+    "Nicolas",
+    "John",
+    "Pedro",
+    "Lucas",
+    "Martin",
+    "Andres",
+    "Mikhail",
+    "Pavel",
+    "Roman",
+    "Ilya",
+    "Maxim",
+    "Daniel",
+    "Michael",
+    "Robert",
+    "William",
+    "Thomas",
+    "Mateo",
+    "Santiago",
+    "Diego",
+    "Gabriel",
+    "Rafael",
+  )
+
+  /** Common female first names from several supported locales. */
+  val femaleFirstNames: Vector[String] = Vector(
+    "Anna",
+    "Maria",
+    "Elena",
+    "Sofia",
+    "Camila",
+    "Julia",
+    "Lucia",
+    "Valentina",
+    "Fernanda",
+    "Olga",
+    "Daria",
+    "Natalia",
+    "Ekaterina",
+    "Irina",
+    "Polina",
+    "Emma",
+    "Olivia",
+    "Sophia",
+    "Isabella",
+    "Mia",
+    "Martina",
+    "Catalina",
+    "Paula",
+    "Agustina",
+    "Beatriz",
+  )
+
+  /** Common last names for person and account payloads. */
+  val lastNames: Vector[String] = Vector(
+    "Ivanov",
+    "Petrov",
+    "Sidorov",
+    "Smirnov",
+    "Volkov",
+    "Kuznetsov",
+    "Garcia",
+    "Silva",
+    "Smith",
+    "Brown",
+    "Martinez",
+    "Fernandez",
+    "Rodriguez",
+    "Lopez",
+    "Gonzalez",
+    "Santos",
+    "Pereira",
+    "Costa",
+    "Muller",
+    "Schmidt",
+    "Dubois",
+    "Martin",
+    "Rossi",
+    "Bianchi",
+  )
+
+  /** Person name prefixes suitable for synthetic profile data. */
+  val personPrefixes: Vector[String] =
+    Vector("Mr.", "Mrs.", "Ms.", "Miss", "Dr.", "Prof.")
+
+  /** Job titles commonly useful in QA, engineering, and business scenarios. */
+  val jobTitles: Vector[String] = Vector(
+    "Performance Engineer",
+    "QA Engineer",
+    "Backend Developer",
+    "Frontend Developer",
+    "Full Stack Developer",
+    "SRE",
+    "DevOps Engineer",
+    "Platform Engineer",
+    "Product Analyst",
+    "Data Engineer",
+    "Security Engineer",
+    "Mobile Engineer",
+    "Solution Architect",
+    "Technical Lead",
+    "Product Manager",
+    "Business Analyst",
+  )
+
+  /** Safe example-like domains for generated email and internet fields. */
+  val domains: Vector[String] = Vector(
+    "example.com",
+    "test.local",
+    "load.test",
+    "picatinny.dev",
+    "performance.test",
+    "qa.example",
+    "sandbox.internal",
+    "demo.service",
+    "api.test",
+    "mail.test",
+  )
+
+  /** Browser, mobile, and client user-agent values for request headers. */
+  val userAgents: Vector[String] = Vector(
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148",
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/124.0 Mobile Safari/537.36",
+    "Gatling/3.11.5",
+    "Apache-HttpClient/5.3",
+    "okhttp/4.12.0",
+  )
+
+  /** City names grouped by supported country. */
+  val citiesByCountry: Map[Country, Vector[String]] = Map(
+    Country.RU -> Vector(
+      "Moscow",
+      "Saint Petersburg",
+      "Kazan",
+      "Novosibirsk",
+      "Yekaterinburg",
+      "Nizhny Novgorod",
+      "Samara",
+      "Rostov-on-Don",
+    ),
+    Country.AR -> Vector("Buenos Aires", "Cordoba", "Rosario", "Mendoza", "La Plata", "Mar del Plata", "Salta", "Santa Fe"),
+    Country.BR -> Vector(
+      "Sao Paulo",
+      "Rio de Janeiro",
+      "Brasilia",
+      "Curitiba",
+      "Salvador",
+      "Fortaleza",
+      "Belo Horizonte",
+      "Recife",
+    ),
+    Country.US -> Vector("New York", "Austin", "Seattle", "Chicago", "San Francisco", "Boston", "Denver", "Miami"),
+    Country.GB -> Vector("London", "Manchester", "Birmingham", "Leeds", "Glasgow", "Liverpool", "Bristol", "Edinburgh"),
+    Country.DE -> Vector("Berlin", "Munich", "Hamburg", "Frankfurt", "Cologne", "Stuttgart", "Dusseldorf", "Leipzig"),
+    Country.FR -> Vector("Paris", "Lyon", "Marseille", "Toulouse", "Nice", "Nantes", "Bordeaux", "Lille"),
+    Country.ES -> Vector("Madrid", "Barcelona", "Valencia", "Seville", "Bilbao", "Malaga", "Zaragoza", "Murcia"),
+    Country.IT -> Vector("Rome", "Milan", "Naples", "Turin", "Florence", "Bologna", "Genoa", "Venice"),
+    Country.AE -> Vector("Dubai", "Abu Dhabi", "Sharjah", "Ajman", "Ras Al Khaimah", "Fujairah", "Al Ain", "Umm Al Quwain"),
+  )
+
+  /** Generic street names for address generation. */
+  val streetNames: Vector[String] = Vector(
+    "Main Street",
+    "Performance Avenue",
+    "Load Test Road",
+    "Central Boulevard",
+    "Liberty Street",
+    "Market Street",
+    "River Road",
+    "Oak Street",
+    "Maple Avenue",
+    "Industrial Way",
+    "Technology Park",
+    "Green Lane",
+    "North Road",
+    "South Street",
+    "Sunset Boulevard",
+  )
+
+  /** ISO-like currency codes used by finance and commerce generators. */
+  val currencies: Vector[String] =
+    Vector("USD", "EUR", "RUB", "BRL", "ARS", "GBP", "AED", "CHF", "JPY", "CNY", "INR", "KZT")
+
+  /** Product names for cart, order, and catalog payloads. */
+  val products: Vector[String] = Vector(
+    "Laptop",
+    "Phone",
+    "Tablet",
+    "Monitor",
+    "Keyboard",
+    "Mouse",
+    "Headphones",
+    "Subscription",
+    "Support package",
+    "Gift card",
+    "Cloud storage",
+    "API package",
+    "Analytics plan",
+    "Training seat",
+    "Service credit",
+  )
+
+  /** Commerce categories for product and reporting payloads. */
+  val categories: Vector[String] = Vector(
+    "electronics",
+    "services",
+    "finance",
+    "books",
+    "travel",
+    "cloud",
+    "analytics",
+    "education",
+    "security",
+    "support",
+  )
+
+  /** Weather condition labels for telemetry-like payloads. */
+  val weatherConditions: Vector[String] =
+    Vector("clear", "partly cloudy", "cloudy", "rain", "heavy rain", "storm", "snow", "fog", "wind", "drizzle", "hail")
+
+  /** Lorem ipsum vocabulary used by text generators. */
+  val loremWords: Vector[String] = Vector(
+    "lorem",
+    "ipsum",
+    "dolor",
+    "sit",
+    "amet",
+    "consectetur",
+    "adipiscing",
+    "elit",
+    "sed",
+    "do",
+    "eiusmod",
+    "tempor",
+    "incididunt",
+    "ut",
+    "labore",
+    "et",
+    "dolore",
+    "magna",
+    "aliqua",
+    "enim",
+    "minim",
+    "veniam",
+    "quis",
+    "nostrud",
+    "exercitation",
+    "ullamco",
+    "laboris",
+    "nisi",
+    "aliquip",
+    "commodo",
+    "consequat",
+  )
+
+  /** Phone formats grouped by country for locale-aware phone generation. */
+  val phoneFormatsByCountry: Map[Country, Seq[PhoneFormat]] = Map(
+    Country.RU -> Seq(PhoneFormat("+7", 10, Seq("903", "906", "908", "926", "999", "915", "916", "977"), "+X XXX XXX-XX-XX")),
+    Country.AR -> Seq(PhoneFormat("+54", 10, Seq("11", "221", "351", "261", "341", "381"), "+XX XXX XXX-XXXX")),
+    Country.BR -> Seq(PhoneFormat("+55", 11, Seq("11", "21", "31", "41", "51", "61"), "+XX XX XXXXX-XXXX")),
+    Country.US -> Seq(PhoneFormat("+1", 10, Seq("201", "212", "305", "415", "646", "718", "917"), "+X XXX XXX-XXXX")),
+    Country.GB -> Seq(PhoneFormat("+44", 10, Seq("7400", "7500", "7700", "7800", "7900"), "+XX XXXX XXXXXX")),
+    Country.DE -> Seq(PhoneFormat("+49", 10, Seq("151", "152", "160", "170", "171", "172"), "+XX XXX XXXXXXX")),
+    Country.FR -> Seq(PhoneFormat("+33", 9, Seq("6", "7"), "+XX X XX XX XX XX")),
+    Country.ES -> Seq(PhoneFormat("+34", 9, Seq("6", "7"), "+XX XXX XXX XXX")),
+    Country.IT -> Seq(PhoneFormat("+39", 10, Seq("320", "328", "333", "347", "349"), "+XX XXX XXX XXXX")),
+    Country.AE -> Seq(PhoneFormat("+971", 9, Seq("50", "52", "54", "55", "56", "58"), "+XXX XX XXX XXXX")),
+  )
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/GeneratedFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/GeneratedFeeder.scala
@@ -44,6 +44,14 @@ object GeneratedFeeder {
     feeder.map(record => record.asInstanceOf[Map[String, Any]] + (name -> generator.sample()))
   }
 
+  /** Adds several generated fields to every record produced by an existing Gatling feeder. */
+  def withGenerated[A](feeder: Feeder[A], fields: Field[_]*): Feeder[Any] = {
+    require(fields.nonEmpty, "Generated feeder requires at least one field")
+    feeder.map { record =>
+      record.asInstanceOf[Map[String, Any]] ++ fields.map(_.sampleAny)
+    }
+  }
+
   /** Materializes records so Gatling's built-in feeder strategies can be used. */
   def recordsFrom(records: Iterable[Map[String, Any]]): IndexedSeq[Record[Any]] = {
     val vector = records.map(_.toMap).toIndexedSeq

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/GeneratedFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/GeneratedFeeder.scala
@@ -1,0 +1,55 @@
+package org.galaxio.gatling.feeders.faker
+
+import io.gatling.core.feeder.{Feeder, Record}
+
+/** Gatling feeder bridge for faker generators.
+  *
+  * Use this object when generated values need to become Gatling session
+  * variables. Heterogeneous records are represented as `Feeder[Any]`, matching
+  * how Gatling scenarios usually combine strings, numbers, booleans, and dates
+  * in the same session map.
+  */
+object GeneratedFeeder {
+
+  /** Builds an infinite feeder from named generators.
+    *
+    * @example
+    *   {{{
+    *   val users = GeneratedFeeder(
+    *     "email" -> Faker.internet.email(),
+    *     "amount" -> Faker.finance.amount(100, 5000)
+    *   )
+    *   }}}
+    */
+  def apply(fields: Field[_]*): Feeder[Any] = {
+    require(fields.nonEmpty, "Generated feeder requires at least one field")
+    Iterator.continually(fields.map(_.sampleAny).toMap)
+  }
+
+  /** Alias for `GeneratedFeeder(...)` when named construction reads better. */
+  def generated(fields: Field[_]*): Feeder[Any] =
+    apply(fields: _*)
+
+  /** Builds an infinite single-field feeder without widening the generated value type. */
+  def single[A](name: String, generator: Generator[A]): Feeder[A] = {
+    require(name.nonEmpty, "Generated feeder field name must be non-empty")
+    Iterator.continually(Map(name -> generator.sample()))
+  }
+
+  /** Builds an infinite feeder from a whole-record generator. */
+  def records(generator: Generator[Map[String, Any]]): Feeder[Any] =
+    Iterator.continually(generator.sample())
+
+  /** Adds one generated field to every record produced by an existing Gatling feeder. */
+  def withGenerated[A, B](feeder: Feeder[A], name: String, generator: Generator[B]): Feeder[Any] = {
+    require(name.nonEmpty, "Generated feeder field name must be non-empty")
+    feeder.map(record => record.asInstanceOf[Map[String, Any]] + (name -> generator.sample()))
+  }
+
+  /** Materializes records so Gatling's built-in feeder strategies can be used. */
+  def recordsFrom(records: Iterable[Map[String, Any]]): IndexedSeq[Record[Any]] = {
+    val vector = records.map(_.toMap).toIndexedSeq
+    require(vector.nonEmpty, "Materialized feeder requires at least one record")
+    vector
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/GeneratedFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/GeneratedFeeder.scala
@@ -4,10 +4,8 @@ import io.gatling.core.feeder.{Feeder, Record}
 
 /** Gatling feeder bridge for faker generators.
   *
-  * Use this object when generated values need to become Gatling session
-  * variables. Heterogeneous records are represented as `Feeder[Any]`, matching
-  * how Gatling scenarios usually combine strings, numbers, booleans, and dates
-  * in the same session map.
+  * Use this object when generated values need to become Gatling session variables. Heterogeneous records are represented as
+  * `Feeder[Any]`, matching how Gatling scenarios usually combine strings, numbers, booleans, and dates in the same session map.
   */
 object GeneratedFeeder {
 

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Generator.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Generator.scala
@@ -2,11 +2,9 @@ package org.galaxio.gatling.feeders.faker
 
 /** A lazy, composable description of how to produce a value.
   *
-  * `Generator` is intentionally small: it gives load-test code the useful
-  * functional operations (`map`, `flatMap`, `zip`) without exposing Cats or
-  * implementation details in the public API. Values are generated only when
-  * `sample()` is called directly or when a Gatling feeder asks for the next
-  * record.
+  * `Generator` is intentionally small: it gives load-test code the useful functional operations (`map`, `flatMap`, `zip`)
+  * without exposing Cats or implementation details in the public API. Values are generated only when `sample()` is called
+  * directly or when a Gatling feeder asks for the next record.
   *
   * @tparam A
   *   generated value type

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Generator.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Generator.scala
@@ -9,7 +9,7 @@ package org.galaxio.gatling.feeders.faker
   * @tparam A
   *   generated value type
   */
-final case class Generator[+A](private val run: () => A) {
+final class Generator[+A] private (private val run: () => A) {
 
   /** Generates one value. */
   def sample(): A = run()
@@ -25,15 +25,51 @@ final case class Generator[+A](private val run: () => A) {
   /** Combines two independent generated values into a tuple. */
   def zip[B](other: Generator[B]): Generator[(A, B)] =
     Generator.delay((sample(), other.sample()))
+
+  /** Filters generated values, retrying until predicate is satisfied. Use with caution — infinite loop if predicate is never
+    * true.
+    */
+  def filter(predicate: A => Boolean): Generator[A] =
+    Generator.delay {
+      var value = sample()
+      while (!predicate(value)) value = sample()
+      value
+    }
+
+  def withFilter(predicate: A => Boolean): Generator[A] = filter(predicate)
+
+  override def toString: String = s"Generator(<lazy>)"
 }
 
 object Generator {
 
   /** Creates a generator from a by-name expression. */
   def delay[A](value: => A): Generator[A] =
-    Generator(() => value)
+    new Generator(() => value)
 
   /** Creates a generator that always returns the same value. */
   def const[A](value: A): Generator[A] =
-    Generator(() => value)
+    new Generator(() => value)
+
+  /** Samples each generator once and collects results into a Vector. */
+  def sequence[A](generators: Seq[Generator[A]]): Generator[Vector[A]] =
+    Generator.delay(generators.map(_.sample()).toVector)
+
+  /** Generates a list of `n` values from a single generator. */
+  def listOf[A](n: Int, generator: Generator[A]): Generator[Vector[A]] = {
+    require(n >= 0, s"n must be >= 0: $n")
+    Generator.delay(Vector.fill(n)(generator.sample()))
+  }
+
+  /** Generates a Map from key-value generator pairs. */
+  def mapOf[K, V](entries: (Generator[K], Generator[V])*): Generator[Map[K, V]] =
+    Generator.delay(entries.map { case (kg, vg) => kg.sample() -> vg.sample() }.toMap)
+
+  /** Generates a tuple of two independent values. */
+  def tupleOf[A, B](ga: Generator[A], gb: Generator[B]): Generator[(A, B)] =
+    ga.zip(gb)
+
+  /** Generates a tuple of three independent values. */
+  def tupleOf[A, B, C](ga: Generator[A], gb: Generator[B], gc: Generator[C]): Generator[(A, B, C)] =
+    Generator.delay((ga.sample(), gb.sample(), gc.sample()))
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Generator.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Generator.scala
@@ -1,0 +1,41 @@
+package org.galaxio.gatling.feeders.faker
+
+/** A lazy, composable description of how to produce a value.
+  *
+  * `Generator` is intentionally small: it gives load-test code the useful
+  * functional operations (`map`, `flatMap`, `zip`) without exposing Cats or
+  * implementation details in the public API. Values are generated only when
+  * `sample()` is called directly or when a Gatling feeder asks for the next
+  * record.
+  *
+  * @tparam A
+  *   generated value type
+  */
+final case class Generator[+A](private val run: () => A) {
+
+  /** Generates one value. */
+  def sample(): A = run()
+
+  /** Transforms generated values while keeping generation lazy. */
+  def map[B](f: A => B): Generator[B] =
+    Generator.delay(f(sample()))
+
+  /** Builds dependent generators where the next value depends on the previous one. */
+  def flatMap[B](f: A => Generator[B]): Generator[B] =
+    Generator.delay(f(sample()).sample())
+
+  /** Combines two independent generated values into a tuple. */
+  def zip[B](other: Generator[B]): Generator[(A, B)] =
+    Generator.delay((sample(), other.sample()))
+}
+
+object Generator {
+
+  /** Creates a generator from a by-name expression. */
+  def delay[A](value: => A): Generator[A] =
+    Generator(() => value)
+
+  /** Creates a generator that always returns the same value. */
+  def const[A](value: A): Generator[A] =
+    Generator(() => value)
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Model.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Model.scala
@@ -4,8 +4,7 @@ import java.math.{BigDecimal => JBigDecimal}
 
 /** A generated Gatling field with a stable session key and typed value generator.
   *
-  * Heterogeneous records are widened to `Any` only at the feeder boundary, where
-  * Gatling itself stores session values in a map.
+  * Heterogeneous records are widened to `Any` only at the feeder boundary, where Gatling itself stores session values in a map.
   */
 final case class Field[+A](name: String, generator: Generator[A]) {
   require(name.nonEmpty, "Generated feeder field name must be non-empty")
@@ -16,8 +15,7 @@ final case class Field[+A](name: String, generator: Generator[A]) {
 
 /** ISO-like country identifiers supported by the faker API.
   *
-  * The catalog will grow over time. Unknown countries can still be represented
-  * with `Country.custom`.
+  * The catalog will grow over time. Unknown countries can still be represented with `Country.custom`.
   */
 sealed abstract class Country(val iso2: String, val displayName: String)
 

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Model.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Model.scala
@@ -1,0 +1,71 @@
+package org.galaxio.gatling.feeders.faker
+
+import java.math.{BigDecimal => JBigDecimal}
+
+/** A generated Gatling field with a stable session key and typed value generator.
+  *
+  * Heterogeneous records are widened to `Any` only at the feeder boundary, where
+  * Gatling itself stores session values in a map.
+  */
+final case class Field[+A](name: String, generator: Generator[A]) {
+  require(name.nonEmpty, "Generated feeder field name must be non-empty")
+
+  private[faker] def sampleAny: (String, Any) =
+    name -> generator.sample()
+}
+
+/** ISO-like country identifiers supported by the faker API.
+  *
+  * The catalog will grow over time. Unknown countries can still be represented
+  * with `Country.custom`.
+  */
+sealed abstract class Country(val iso2: String, val displayName: String)
+
+object Country {
+  case object RU extends Country("RU", "Russia")
+  case object AR extends Country("AR", "Argentina")
+  case object BR extends Country("BR", "Brazil")
+  case object US extends Country("US", "United States")
+  case object GB extends Country("GB", "United Kingdom")
+  case object DE extends Country("DE", "Germany")
+  case object FR extends Country("FR", "France")
+  case object ES extends Country("ES", "Spain")
+  case object IT extends Country("IT", "Italy")
+  case object AE extends Country("AE", "United Arab Emirates")
+
+  final case class Custom private[faker] (override val iso2: String, override val displayName: String)
+      extends Country(iso2, displayName)
+
+  /** Creates a custom country identifier for projects that need a country before Picatinny ships built-in metadata. */
+  def custom(iso2: String, displayName: String = ""): Country = {
+    require(iso2.nonEmpty, "Country iso2 must be non-empty")
+    Custom(iso2.toUpperCase, if (displayName.nonEmpty) displayName else iso2.toUpperCase)
+  }
+}
+
+/** Gender value used by person-oriented generators. */
+sealed abstract class Gender(val value: String)
+
+object Gender {
+  case object Male        extends Gender("male")
+  case object Female      extends Gender("female")
+  case object Unspecified extends Gender("unspecified")
+}
+
+/** Phone number formatting modes exposed by the faker API. */
+sealed abstract class PhoneFormatMode
+
+object PhoneFormatMode {
+  case object E164          extends PhoneFormatMode
+  case object National      extends PhoneFormatMode
+  case object International extends PhoneFormatMode
+  case object TollFree      extends PhoneFormatMode
+}
+
+/** Generated money amount with explicit ISO currency. */
+final case class Money(amount: BigDecimal, currency: String) {
+  require(currency.nonEmpty, "Currency must be non-empty")
+
+  /** Java-friendly amount accessor. */
+  def javaAmount: JBigDecimal = amount.bigDecimal
+}

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Model.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Model.scala
@@ -30,6 +30,12 @@ object Country {
   case object ES extends Country("ES", "Spain")
   case object IT extends Country("IT", "Italy")
   case object AE extends Country("AE", "United Arab Emirates")
+  case object JP extends Country("JP", "Japan")
+  case object CN extends Country("CN", "China")
+  case object IN extends Country("IN", "India")
+  case object CA extends Country("CA", "Canada")
+  case object AU extends Country("AU", "Australia")
+  case object MX extends Country("MX", "Mexico")
 
   final case class Custom private[faker] (override val iso2: String, override val displayName: String)
       extends Country(iso2, displayName)
@@ -58,6 +64,58 @@ object PhoneFormatMode {
   case object National      extends PhoneFormatMode
   case object International extends PhoneFormatMode
   case object TollFree      extends PhoneFormatMode
+}
+
+/** Fluent builder for constructing custom phone number generators. */
+final case class PhoneBuilder(
+    private val country: Option[Country] = None,
+    private val formatMode: PhoneFormatMode = PhoneFormatMode.E164,
+    private val customCountryCode: Option[String] = None,
+    private val customAreaCodes: Seq[String] = Seq.empty,
+    private val customLength: Option[Int] = None,
+    private val customFormat: Option[String] = None,
+) {
+  import org.galaxio.gatling.utils.phone.PhoneFormat
+
+  def forCountry(c: Country): PhoneBuilder         = copy(country = Some(c))
+  def withFormat(f: PhoneFormatMode): PhoneBuilder = copy(formatMode = f)
+  def withCountryCode(cc: String): PhoneBuilder    = copy(customCountryCode = Some(cc))
+  def withAreaCodes(codes: String*): PhoneBuilder  = copy(customAreaCodes = codes)
+  def withLength(len: Int): PhoneBuilder           = copy(customLength = Some(len))
+  def withTemplate(tmpl: String): PhoneBuilder     = copy(customFormat = Some(tmpl))
+
+  def build: Generator[String] = {
+    val formats = (country, customCountryCode) match {
+      case (Some(c), _)  =>
+        val base = Faker.phone.countryFormats(c)
+        applyOverrides(base)
+      case (_, Some(cc)) =>
+        Seq(PhoneFormat(cc, customLength.getOrElse(10), customAreaCodes, customFormat.getOrElse("+XXXXXXXXXXX")))
+      case _             =>
+        Seq(
+          PhoneFormat(
+            "+1",
+            customLength.getOrElse(10),
+            if (customAreaCodes.nonEmpty) customAreaCodes else Seq("201", "212"),
+            customFormat.getOrElse("+X XXX XXX-XXXX"),
+          ),
+        )
+    }
+    Faker.phone.fromFormats(formatMode, formats: _*)
+  }
+
+  private def applyOverrides(base: Seq[PhoneFormat]): Seq[PhoneFormat] = {
+    if (customAreaCodes.isEmpty && customLength.isEmpty && customFormat.isEmpty) base
+    else
+      base.map { pf =>
+        PhoneFormat(
+          pf.countryCode,
+          customLength.getOrElse(pf.length),
+          if (customAreaCodes.nonEmpty) customAreaCodes else pf.areaCodes,
+          customFormat.getOrElse(pf.format),
+        )
+      }
+  }
 }
 
 /** Generated money amount with explicit ISO currency. */

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Predef.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Predef.scala
@@ -1,0 +1,4 @@
+package org.galaxio.gatling.feeders.faker
+
+/** Imports the faker and generated feeder DSL. */
+object Predef extends Syntax

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Syntax.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Syntax.scala
@@ -59,6 +59,10 @@ object Syntax {
     def withGenerated[B](name: String, generator: Generator[B]): Feeder[Any] =
       GeneratedFeeder.withGenerated(feeder, name, generator)
 
+    /** Adds several generated fields to each record emitted by this feeder. */
+    def withGenerated(fields: Field[_]*): Feeder[Any] =
+      GeneratedFeeder.withGenerated(feeder, fields: _*)
+
     /** Renames a key in each feeder record when the key is present. */
     def rename(from: String, to: String): Feeder[Any] =
       feeder.map { record =>
@@ -66,9 +70,46 @@ object Syntax {
         asAny.get(from).fold(asAny)(value => asAny - from + (to -> value))
       }
 
+    /** Renames several keys in each feeder record when those keys are present. */
+    def renameKeys(mapping: Map[String, String]): Feeder[Any] =
+      feeder.map { record =>
+        mapping.foldLeft(record.asInstanceOf[Map[String, Any]]) { case (current, (from, to)) =>
+          current.get(from).fold(current)(value => current - from + (to -> value))
+        }
+      }
+
     /** Prefixes every key in every feeder record. */
     def prefixKeys(prefix: String): Feeder[Any] =
       feeder.map(record => record.asInstanceOf[Map[String, Any]].map { case (key, value) => s"$prefix$key" -> value })
+
+    /** Suffixes every key in every feeder record. */
+    def suffixKeys(suffix: String): Feeder[Any] =
+      feeder.map(record => record.asInstanceOf[Map[String, Any]].map { case (key, value) => s"$key$suffix" -> value })
+
+    /** Drops keys from each feeder record. */
+    def dropKeys(keys: String*): Feeder[Any] = {
+      val keySet = keys.toSet
+      feeder.map(record => record.asInstanceOf[Map[String, Any]] -- keySet)
+    }
+
+    /** Keeps only selected keys from each feeder record. */
+    def selectKeys(keys: String*): Feeder[Any] = {
+      val keySet = keys.toSet
+      feeder.map(record => record.asInstanceOf[Map[String, Any]].view.filterKeys(keySet.contains).toMap)
+    }
+
+    /** Adds default values when keys are missing from a feeder record. */
+    def withDefaults(defaults: (String, Any)*): Feeder[Any] =
+      feeder.map(record => defaults.toMap ++ record.asInstanceOf[Map[String, Any]])
+
+    /** Fails fast when a feeder record does not contain all required keys. */
+    def requireKeys(keys: String*): Feeder[A] =
+      feeder.map { record =>
+        val asAny   = record.asInstanceOf[Map[String, Any]]
+        val missing = keys.filterNot(asAny.contains)
+        require(missing.isEmpty, s"Feeder record is missing required keys: ${missing.mkString(", ")}")
+        record
+      }
 
     /** Applies a typed transformation at the record boundary. */
     def mapRecord(f: Map[String, Any] => Map[String, Any]): Feeder[Any] =

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Syntax.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Syntax.scala
@@ -1,0 +1,101 @@
+package org.galaxio.gatling.feeders.faker
+
+import io.gatling.core.feeder.{Feeder, Record}
+
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, LocalDateTime}
+
+/** User-facing syntax for faker generators and generated feeders. */
+trait Syntax {
+
+  implicit final def tupleToField[A](field: (String, Generator[A])): Field[A] =
+    Field(field._1, field._2)
+
+  implicit final def generatorOps[A](generator: Generator[A]): Syntax.GeneratorOps[A] =
+    new Syntax.GeneratorOps(generator)
+
+  implicit final def localDateGeneratorOps(generator: Generator[LocalDate]): Syntax.LocalDateGeneratorOps =
+    new Syntax.LocalDateGeneratorOps(generator)
+
+  implicit final def localDateTimeGeneratorOps(generator: Generator[LocalDateTime]): Syntax.LocalDateTimeGeneratorOps =
+    new Syntax.LocalDateTimeGeneratorOps(generator)
+
+  implicit final def feederOps[A](feeder: Feeder[A]): Syntax.FeederOps[A] =
+    new Syntax.FeederOps(feeder)
+
+  implicit final def iterableOps[A](values: Iterable[A]): Syntax.IterableOps[A] =
+    new Syntax.IterableOps(values)
+
+  implicit final def mapOps(record: Map[String, Any]): Syntax.MapOps =
+    new Syntax.MapOps(record)
+}
+
+object Syntax {
+
+  final class GeneratorOps[A](private val generator: Generator[A]) extends AnyVal {
+
+    /** Turns this generator into a typed single-field Gatling feeder. */
+    def toFeeder(name: String): Feeder[A] =
+      GeneratedFeeder.single(name, generator)
+  }
+
+  final class LocalDateGeneratorOps(private val generator: Generator[LocalDate]) extends AnyVal {
+
+    /** Formats generated local dates with a Java time pattern. */
+    def format(pattern: String): Generator[String] =
+      generator.map(_.format(DateTimeFormatter.ofPattern(pattern)))
+  }
+
+  final class LocalDateTimeGeneratorOps(private val generator: Generator[LocalDateTime]) extends AnyVal {
+
+    /** Formats generated local date-times with a Java time pattern. */
+    def format(pattern: String): Generator[String] =
+      generator.map(_.format(DateTimeFormatter.ofPattern(pattern)))
+  }
+
+  final class FeederOps[A](private val feeder: Feeder[A]) extends AnyVal {
+
+    /** Adds a generated field to each record emitted by this feeder. */
+    def withGenerated[B](name: String, generator: Generator[B]): Feeder[Any] =
+      GeneratedFeeder.withGenerated(feeder, name, generator)
+
+    /** Renames a key in each feeder record when the key is present. */
+    def rename(from: String, to: String): Feeder[Any] =
+      feeder.map { record =>
+        val asAny = record.asInstanceOf[Map[String, Any]]
+        asAny.get(from).fold(asAny)(value => asAny - from + (to -> value))
+      }
+
+    /** Prefixes every key in every feeder record. */
+    def prefixKeys(prefix: String): Feeder[Any] =
+      feeder.map(record => record.asInstanceOf[Map[String, Any]].map { case (key, value) => s"$prefix$key" -> value })
+
+    /** Applies a typed transformation at the record boundary. */
+    def mapRecord(f: Map[String, Any] => Map[String, Any]): Feeder[Any] =
+      feeder.map(record => f(record.asInstanceOf[Map[String, Any]]))
+
+    /** Materializes a finite number of records for assertions or small in-memory feeder sources. */
+    def takeRecords(n: Int): Vector[Map[String, Any]] = {
+      require(n >= 0, s"n must be >= 0: $n")
+      feeder.take(n).map(_.asInstanceOf[Map[String, Any]]).toVector
+    }
+  }
+
+  final class IterableOps[A](private val values: Iterable[A]) extends AnyVal {
+
+    /** Converts collection items into single-field records compatible with Gatling feeder strategies. */
+    def toFeeder(name: String): IndexedSeq[Record[Any]] =
+      GeneratedFeeder.recordsFrom(values.map(value => Map(name -> value)))
+
+    /** Converts collection items into records compatible with Gatling feeder strategies. */
+    def toFeeder(mapping: A => Map[String, Any]): IndexedSeq[Record[Any]] =
+      GeneratedFeeder.recordsFrom(values.map(mapping))
+  }
+
+  final class MapOps(private val record: Map[String, Any]) extends AnyVal {
+
+    /** Converts one map into a one-record feeder builder. */
+    def toSingleRecordFeeder: IndexedSeq[Record[Any]] =
+      GeneratedFeeder.recordsFrom(Vector(record))
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
@@ -1,12 +1,17 @@
 package org.galaxio.gatling.feeders.faker
 
+import org.galaxio.gatling.feeders.LuhnValidator
 import org.galaxio.gatling.feeders.faker.Predef._
+import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import java.time.LocalDate
 
-class GeneratedFeederSpec extends AnyWordSpec with Matchers {
+class GeneratedFeederSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  private val sampleCount = 50
 
   "GeneratedFeeder" should {
     "create a heterogeneous Gatling feeder from generators" in {
@@ -20,7 +25,20 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers {
 
       record("email") shouldBe a[String]
       record("amount") shouldBe a[BigDecimal]
-      record("active") shouldBe a[Boolean]
+      record("active") shouldBe a[java.lang.Boolean]
+    }
+
+    "produce multiple distinct records" in {
+      val feeder  = GeneratedFeeder("id" -> Faker.uuid.string)
+      val records = (1 to sampleCount).map(_ => feeder.next()("id").toString)
+
+      records.distinct.size should be > 1
+    }
+
+    "reject empty field list" in {
+      assertThrows[IllegalArgumentException] {
+        GeneratedFeeder()
+      }
     }
 
     "support dependent fields through record generators" in {
@@ -34,6 +52,59 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers {
 
       record("name").toString should not be empty
       record("email").toString should endWith("@example.com")
+    }
+
+    "build single-field typed feeder" in {
+      val feeder = GeneratedFeeder.single("n", Faker.number.int(1, 10))
+      val record = feeder.next()
+      val value  = record("n").asInstanceOf[Int]
+      value should (be >= 1 and be <= 10)
+    }
+
+    "reject empty field name" in {
+      assertThrows[IllegalArgumentException] {
+        GeneratedFeeder.single("", Faker.uuid.string)
+      }
+    }
+  }
+
+  "Generator" should {
+    "map preserves laziness" in {
+      val gen    = Faker.number.int(1, 100).map(_ * 2)
+      val values = (1 to sampleCount).map(_ => gen.sample())
+      values.distinct.size should be > 1
+      all(values) should (be >= 2 and be <= 200)
+    }
+
+    "flatMap chains generators correctly" in {
+      forAll(Gen.choose(1, 10)) { n =>
+        val s = Faker.number.int(1, n).flatMap(i => Faker.string.alphabetic(i)).sample()
+        s.length should (be >= 1 and be <= n)
+      }
+    }
+
+    "zip combines two generators" in {
+      val gen    = Faker.number.int(0, 100).zip(Faker.number.boolean)
+      val (n, b) = gen.sample()
+      n should (be >= 0 and be <= 100)
+      b shouldBe a[java.lang.Boolean]
+    }
+
+    "const always returns same value" in {
+      forAll(Gen.alphaNumStr) { s =>
+        Generator.const(s).sample() shouldBe s
+      }
+    }
+
+    "filter retries until predicate matches" in {
+      val even = Faker.number.int(1, 100).filter(_ % 2 == 0)
+      (1 to sampleCount).foreach { _ =>
+        even.sample() % 2 shouldBe 0
+      }
+    }
+
+    "toString is readable" in {
+      Generator.const(42).toString shouldBe "Generator(<lazy>)"
     }
   }
 
@@ -55,6 +126,12 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers {
 
       records.head shouldBe Map("id" -> "1", "email" -> "a@example.com")
     }
+
+    "convert single map to one-record feeder" in {
+      val records = Map("key" -> "value").toSingleRecordFeeder
+      records should have size 1
+      records.head shouldBe Map("key" -> "value")
+    }
   }
 
   "Feeder enrichment syntax" should {
@@ -67,6 +144,434 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers {
       record("id") shouldBe "42"
       record("traceId").toString should fullyMatch regex "[a-f0-9\\-]{36}"
     }
+
+    "add several generated fields to an existing feeder" in {
+      val existing = Iterator.single(Map("id" -> "42"))
+      val enriched = existing.withGenerated(
+        "active"   -> Generator.const(true),
+        "currency" -> Generator.const("USD"),
+      )
+
+      enriched.next() shouldBe Map("id" -> "42", "active" -> true, "currency" -> "USD")
+    }
+
+    "rename feeder keys" in {
+      val feeder  = Iterator.single(Map("old_name" -> "value"))
+      val renamed = feeder.rename("old_name", "new_name")
+      val record  = renamed.next()
+
+      record should contain key "new_name"
+      record should not contain key("old_name")
+      record("new_name") shouldBe "value"
+    }
+
+    "rename non-existent key is no-op" in {
+      val feeder = Iterator.single(Map("key" -> "value"))
+      val result = feeder.rename("missing", "new").next()
+      result shouldBe Map("key" -> "value")
+    }
+
+    "rename several feeder keys" in {
+      val feeder = Iterator.single(Map("first_name" -> "Ada", "last_name" -> "Lovelace", "age" -> 36))
+      val result = feeder.renameKeys(Map("first_name" -> "firstName", "last_name" -> "lastName")).next()
+
+      result shouldBe Map("firstName" -> "Ada", "lastName" -> "Lovelace", "age" -> 36)
+    }
+
+    "prefix all keys" in {
+      val feeder   = Iterator.single(Map("name" -> "Alice", "age" -> 30))
+      val prefixed = feeder.prefixKeys("user_")
+      val record   = prefixed.next()
+
+      record should contain key "user_name"
+      record should contain key "user_age"
+      record should not contain key("name")
+    }
+
+    "suffix all keys" in {
+      val feeder = Iterator.single(Map("name" -> "Alice", "age" -> 30))
+      val record = feeder.suffixKeys("_value").next()
+
+      record shouldBe Map("name_value" -> "Alice", "age_value" -> 30)
+    }
+
+    "drop selected keys" in {
+      val feeder = Iterator.single(Map("id" -> "42", "debug" -> true, "email" -> "a@example.com"))
+      feeder.dropKeys("debug").next() shouldBe Map("id" -> "42", "email" -> "a@example.com")
+    }
+
+    "select selected keys" in {
+      val feeder = Iterator.single(Map("id" -> "42", "debug" -> true, "email" -> "a@example.com"))
+      feeder.selectKeys("id", "email").next() shouldBe Map("id" -> "42", "email" -> "a@example.com")
+    }
+
+    "add defaults without overriding existing values" in {
+      val feeder = Iterator.single(Map("currency" -> "EUR"))
+      feeder.withDefaults("currency" -> "USD", "active" -> true).next() shouldBe Map("currency" -> "EUR", "active" -> true)
+    }
+
+    "require keys before records are consumed by scenarios" in {
+      val valid = Iterator.single(Map("id" -> "42", "email" -> "a@example.com")).requireKeys("id", "email")
+      valid.next() shouldBe Map("id" -> "42", "email" -> "a@example.com")
+
+      assertThrows[IllegalArgumentException] {
+        Iterator.single(Map("id" -> "42")).requireKeys("id", "email").next()
+      }
+    }
+
+    "apply record transformation" in {
+      val feeder = Iterator.single(Map("x" -> 1, "y" -> 2))
+      val mapped = feeder.mapRecord(r => r + ("sum" -> (r("x").asInstanceOf[Int] + r("y").asInstanceOf[Int])))
+      val record = mapped.next()
+
+      record("sum") shouldBe 3
+    }
+
+    "take finite records" in {
+      forAll(Gen.choose(0, 100)) { n =>
+        val records = Iterator.continually(Map("n" -> 1)).takeRecords(n)
+        records should have size n
+      }
+    }
+
+    "takeRecords rejects negative" in {
+      assertThrows[IllegalArgumentException] {
+        Iterator.continually(Map("n" -> 1)).takeRecords(-1)
+      }
+    }
+  }
+
+  "Faker.number" should {
+    "generate ints within range" in {
+      forAll(Gen.choose(-1000, 1000), Gen.choose(0, 2000)) { (base, span) =>
+        whenever(span > 0) {
+          val min = base
+          val max = base + span
+          val v   = Faker.number.int(min, max).sample()
+          v should (be >= min and be <= max)
+        }
+      }
+    }
+
+    "handle min == max for int" in {
+      forAll(Gen.choose(-100, 100)) { n =>
+        Faker.number.int(n, n).sample() shouldBe n
+      }
+    }
+
+    "handle Int.MaxValue as an inclusive upper bound" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.int(Int.MaxValue - 10, Int.MaxValue).sample()
+        v should (be >= Int.MaxValue - 10 and be <= Int.MaxValue)
+      }
+    }
+
+    "reject min > max for int" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.number.int(10, 5)
+      }
+    }
+
+    "generate longs within range" in {
+      forAll(Gen.choose(0L, 10000L)) { span =>
+        whenever(span > 0) {
+          val v = Faker.number.long(0L, span).sample()
+          v should (be >= 0L and be <= span)
+        }
+      }
+    }
+
+    "handle Long.MaxValue as an inclusive upper bound" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.long(Long.MaxValue - 10L, Long.MaxValue).sample()
+        v should (be >= Long.MaxValue - 10L and be <= Long.MaxValue)
+      }
+    }
+
+    "generate doubles within range" in {
+      forAll(Gen.choose(0.0, 1000.0)) { max =>
+        whenever(max > 0.01) {
+          val v = Faker.number.double(0.0, max).sample()
+          v should (be >= 0.0 and be < max)
+        }
+      }
+    }
+
+    "generate floats within range" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.float(0.0f, 1.0f).sample()
+        v should (be >= 0.0f and be < 1.0f)
+      }
+    }
+
+    "generate booleans with both values" in {
+      val values = (1 to 100).map(_ => Faker.number.boolean.sample())
+      values should contain(true)
+      values should contain(false)
+    }
+
+    "generate bytes within range" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.byte(0, 100).sample()
+        v should (be >= 0.toByte and be <= 100.toByte)
+      }
+    }
+
+    "generate shorts within range" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.short(0, 1000).sample()
+        v should (be >= 0.toShort and be <= 1000.toShort)
+      }
+    }
+
+    "generate chars within range" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.char('A', 'Z').sample()
+        v should (be >= 'A' and be <= 'Z')
+      }
+    }
+
+    "generate bigDecimal within range" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.bigDecimal(BigDecimal(0), BigDecimal(100), 3).sample()
+        v should (be >= BigDecimal(0) and be <= BigDecimal(100))
+        v.scale shouldBe 3
+      }
+    }
+
+    "generate BigInt beyond Long range" in {
+      val min = BigInt(Long.MaxValue) + 1
+      val max = min + 100
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.bigInt(min, max).sample()
+        v should (be >= min and be <= max)
+      }
+    }
+
+    "generate positive and negative ints" in {
+      Faker.number.positiveInt.sample() should be > 0
+      Faker.number.negativeInt.sample() should be < 0
+    }
+
+    "generate percentage 0-100" in {
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.percentage.sample()
+        v should (be >= 0 and be <= 100)
+      }
+    }
+  }
+
+  "Faker.string" should {
+    "generate alphabetic strings of exact length" in {
+      forAll(Gen.choose(1, 50)) { len =>
+        val s = Faker.string.alphabetic(len).sample()
+        s should have length len
+        s should fullyMatch regex s"[a-zA-Z]{$len}"
+      }
+    }
+
+    "generate alphanumeric strings" in {
+      forAll(Gen.choose(1, 50)) { len =>
+        val s = Faker.string.alphanumeric(len).sample()
+        s should have length len
+      }
+    }
+
+    "generate numeric strings" in {
+      forAll(Gen.choose(1, 20)) { len =>
+        val s = Faker.string.numeric(len).sample()
+        s should have length len
+        s should fullyMatch regex s"\\d{$len}"
+      }
+    }
+
+    "generate hex strings" in {
+      val s = Faker.string.hex(12).sample()
+      s should have length 12
+      s should fullyMatch regex "[a-fA-F0-9]{12}"
+    }
+
+    "generate cyrillic strings" in {
+      val s = Faker.string.cyrillic(10).sample()
+      s should have length 10
+    }
+
+    "generate strings from custom alphabet" in {
+      val s = Faker.string.fromAlphabet("abc", 20).sample()
+      s should have length 20
+      s.toSet.subsetOf(Set('a', 'b', 'c')) shouldBe true
+    }
+
+    "generate strings with length between min and max" in {
+      forAll(Gen.choose(1, 10), Gen.choose(1, 20)) { (min, extra) =>
+        val max = min + extra
+        val s   = Faker.string.lengthBetween(min, max, "abcdef").sample()
+        s.length should (be >= min and be <= max)
+      }
+    }
+  }
+
+  "Faker.uuid" should {
+    "generate valid UUID strings" in {
+      forAll(Gen.const(())) { _ =>
+        Faker.uuid.string.sample() should fullyMatch regex "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+      }
+    }
+
+    "generate distinct UUIDs" in {
+      val uuids = (1 to sampleCount).map(_ => Faker.uuid.string.sample())
+      uuids.distinct.size shouldBe sampleCount
+    }
+  }
+
+  "Faker.person" should {
+    "generate gender values" in {
+      val genders = (1 to 100).map(_ => Faker.person.gender().sample()).toSet
+      genders should contain(Gender.Male)
+      genders should contain(Gender.Female)
+      genders should contain(Gender.Unspecified)
+    }
+
+    "generate non-empty first names" in {
+      Faker.person.firstName().sample() should not be empty
+    }
+
+    "generate gendered first names" in {
+      val maleName = Faker.person.firstName(Gender.Male).sample()
+      FakerData.maleFirstNames should contain(maleName)
+
+      val femaleName = Faker.person.firstName(Gender.Female).sample()
+      FakerData.femaleFirstNames should contain(femaleName)
+    }
+
+    "generate non-empty last names" in {
+      FakerData.lastNames should contain(Faker.person.lastName().sample())
+    }
+
+    "generate full names with space" in {
+      val name = Faker.person.fullName().sample()
+      name should include(" ")
+    }
+
+    "generate job titles from catalog" in {
+      FakerData.jobTitles should contain(Faker.person.jobTitle().sample())
+    }
+
+    "generate prefixes from catalog" in {
+      FakerData.personPrefixes should contain(Faker.person.prefix().sample())
+    }
+  }
+
+  "Faker.internet" should {
+    "generate emails with default domain" in {
+      Faker.internet.email().sample() should endWith("@example.com")
+    }
+
+    "generate emails with custom domain" in {
+      forAll(Gen.identifier.suchThat(_.nonEmpty)) { domain =>
+        Faker.internet.email(s"$domain.com").sample() should endWith(s"@$domain.com")
+      }
+    }
+
+    "generate emails from name" in {
+      val email = Faker.internet.email("John Smith", "corp.com").sample()
+      email should endWith("@corp.com")
+      email should include("john")
+    }
+
+    "generate usernames" in {
+      val username = Faker.internet.username().sample()
+      username should not be empty
+      username should not contain " "
+    }
+
+    "generate URLs with protocol" in {
+      Faker.internet.url().sample() should startWith("https://")
+      Faker.internet.url("http").sample() should startWith("http://")
+    }
+
+    "generate passwords of specified length" in {
+      forAll(Gen.choose(8, 64)) { len =>
+        Faker.internet.password(len).sample() should have length len
+      }
+    }
+
+    "generate user agents from catalog" in {
+      FakerData.userAgents should contain(Faker.internet.userAgent().sample())
+    }
+
+    "generate valid IPv4 addresses" in {
+      (1 to sampleCount).foreach { _ =>
+        val ip     = Faker.internet.ipv4().sample()
+        val octets = ip.split("\\.").map(_.toInt)
+        octets should have length 4
+        octets(0) should (be >= 1 and be <= 254)
+        octets(1) should (be >= 0 and be <= 255)
+        octets(2) should (be >= 0 and be <= 255)
+        octets(3) should (be >= 1 and be <= 254)
+      }
+    }
+
+    "generate valid IPv6 addresses" in {
+      val ipv6 = Faker.internet.ipv6().sample()
+      ipv6.split(":") should have length 8
+    }
+
+    "generate domains from catalog" in {
+      FakerData.domains should contain(Faker.internet.domain().sample())
+    }
+  }
+
+  "Faker.location" should {
+    "generate countries" in {
+      val country = Faker.location.country().sample()
+      country shouldBe a[Country]
+    }
+
+    "generate country codes" in {
+      val code = Faker.location.countryCode().sample()
+      code should have length 2
+    }
+
+    "generate cities for country" in {
+      val city = Faker.location.city(Country.RU).sample()
+      FakerData.citiesByCountry(Country.RU) should contain(city)
+    }
+
+    "fallback to US cities for unknown country" in {
+      val city = Faker.location.city(Country.custom("XX")).sample()
+      FakerData.citiesByCountry(Country.US) should contain(city)
+    }
+
+    "generate street addresses" in {
+      val addr = Faker.location.streetAddress().sample()
+      addr should not be empty
+      addr should fullyMatch regex "\\d+ .+"
+    }
+
+    "generate postal codes per country" in {
+      Faker.location.postalCode(Country.RU).sample() should fullyMatch regex "\\d{6}"
+      Faker.location.postalCode(Country.US).sample() should fullyMatch regex "\\d{5}"
+      Faker.location.postalCode(Country.BR).sample() should fullyMatch regex "\\d{8}"
+      Faker.location.postalCode(Country.AR).sample() should fullyMatch regex "\\d{4}"
+      Faker.location.postalCode(Country.JP).sample() should fullyMatch regex "\\d{7}"
+      Faker.location.postalCode(Country.AU).sample() should fullyMatch regex "\\d{4}"
+      Faker.location.postalCode(Country.MX).sample() should fullyMatch regex "\\d{5}"
+    }
+
+    "generate latitude within valid range" in {
+      (1 to sampleCount).foreach { _ =>
+        val lat = Faker.location.latitude().sample()
+        lat should (be >= -90.0 and be < 90.0)
+      }
+    }
+
+    "generate longitude within valid range" in {
+      (1 to sampleCount).foreach { _ =>
+        val lon = Faker.location.longitude().sample()
+        lon should (be >= -180.0 and be < 180.0)
+      }
+    }
   }
 
   "Date generators" should {
@@ -78,25 +583,564 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers {
 
       date should fullyMatch regex "2026-01-\\d{2}"
     }
-  }
 
-  "Government identifiers" should {
-    "generate formatted Brazilian CPF values" in {
-      Faker.br.cpf(formatted = true).sample() should fullyMatch regex "\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}"
+    "generate dates between boundaries" in {
+      val from = LocalDate.of(2025, 1, 1)
+      val to   = LocalDate.of(2025, 12, 31)
+      (1 to sampleCount).foreach { _ =>
+        val d = Faker.date.between(from, to).sample()
+        d.isBefore(from) shouldBe false
+        d.isAfter(to) shouldBe false
+      }
     }
 
-    "generate Argentinian DNI values" in {
-      Faker.ar.dni().sample() should fullyMatch regex "\\d{8}"
+    "handle same from and to date" in {
+      val d = LocalDate.of(2025, 6, 15)
+      Faker.date.between(d, d).sample() shouldBe d
+    }
+
+    "reject from after to" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.date.between(LocalDate.of(2026, 1, 1), LocalDate.of(2025, 1, 1))
+      }
+    }
+
+    "generate past dates within bounds" in {
+      forAll(Gen.choose(1L, 365L)) { days =>
+        val today = LocalDate.now()
+        val d     = Faker.date.past(days, today).sample()
+        d.isAfter(today) shouldBe false
+        d.isBefore(today.minusDays(days)) shouldBe false
+      }
+    }
+
+    "generate future dates within bounds" in {
+      forAll(Gen.choose(1L, 365L)) { days =>
+        val today = LocalDate.now()
+        val d     = Faker.date.future(days, today).sample()
+        d.isBefore(today) shouldBe false
+        d.isAfter(today.plusDays(days)) shouldBe false
+      }
+    }
+
+    "generate date offset within bounds" in {
+      val base = LocalDate.of(2025, 6, 1)
+      (1 to sampleCount).foreach { _ =>
+        val d = Faker.date.offset(base, -10, 10).sample()
+        d.isBefore(base.minusDays(10)) shouldBe false
+        d.isAfter(base.plusDays(10)) shouldBe false
+      }
+    }
+
+    "generate date ranges where start <= end" in {
+      val from = LocalDate.of(2025, 1, 1)
+      val to   = LocalDate.of(2025, 12, 31)
+      (1 to sampleCount).foreach { _ =>
+        val (start, end) = Faker.date.range(from, to, 1, 30).sample()
+        start.isAfter(end) shouldBe false
+        start.isBefore(from) shouldBe false
+        end.isAfter(to) shouldBe false
+      }
+    }
+
+    "generate date ranges respecting minimum length" in {
+      val from = LocalDate.of(2025, 1, 1)
+      val to   = LocalDate.of(2025, 1, 10)
+      (1 to sampleCount).foreach { _ =>
+        val (start, end) = Faker.date.range(from, to, minLengthDays = 5, maxLengthDays = 7).sample()
+        java.time.temporal.ChronoUnit.DAYS.between(start, end) should (be >= 5L and be <= 7L)
+      }
+    }
+
+    "reject date ranges where minimum length cannot fit" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.date.range(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 3), minLengthDays = 5)
+      }
     }
   }
 
-  "Additional faker domains" should {
-    "generate internet, location, finance, commerce, and weather values" in {
-      Faker.internet.url().sample() should startWith("https://")
-      Faker.location.postalCode(Country.RU).sample() should fullyMatch regex "\\d{6}"
+  "Faker.finance" should {
+    "generate PAN numbers passing Luhn validation" in {
+      (1 to sampleCount).foreach { _ =>
+        val pan = Faker.finance.pan().sample()
+        withClue(s"PAN $pan failed Luhn: ") {
+          LuhnValidator.validate(pan) shouldBe true
+        }
+      }
+    }
+
+    "generate PAN with specified BINs" in {
+      (1 to sampleCount).foreach { _ =>
+        val pan = Faker.finance.pan("421345", "541673").sample()
+        withClue(s"PAN $pan failed Luhn: ") {
+          LuhnValidator.validate(pan) shouldBe true
+        }
+        pan should (startWith("421345") or startWith("541673"))
+      }
+    }
+
+    "generate amounts within range" in {
+      (1 to sampleCount).foreach { _ =>
+        val amt = Faker.finance.amount(BigDecimal(10), BigDecimal(100)).sample()
+        amt should (be >= BigDecimal(10) and be <= BigDecimal(100))
+        amt.scale shouldBe 2
+      }
+    }
+
+    "generate money with currency" in {
+      val m = Faker.finance.money(BigDecimal(1), BigDecimal(10), "EUR").sample()
+      m.currency shouldBe "EUR"
+      m.amount should (be >= BigDecimal(1) and be <= BigDecimal(10))
+    }
+
+    "generate currencies from catalog" in {
+      FakerData.currencies should contain(Faker.finance.currency().sample())
+    }
+
+    "generate account numbers of specified length" in {
+      forAll(Gen.choose(10, 30)) { len =>
+        Faker.finance.accountNumber(len).sample() should fullyMatch regex s"\\d{$len}"
+      }
+    }
+
+    "generate BIC codes" in {
+      val bic = Faker.finance.bic().sample()
+      bic.length should (be >= 8 and be <= 11)
+    }
+
+    "generate IBAN for multiple countries" in {
       Faker.finance.iban(Country.DE).sample() should startWith("DE89")
-      Faker.commerce.orderId().sample() should startWith("ord-")
-      Faker.weather.humidityPercent().sample() should (be >= 0 and be <= 100)
+      Faker.finance.iban(Country.GB).sample() should startWith("GB82")
+      Faker.finance.iban(Country.FR).sample() should startWith("FR14")
+      Faker.finance.iban(Country.ES).sample() should startWith("ES91")
+      Faker.finance.iban(Country.IT).sample() should startWith("IT60")
+      Faker.finance.iban(Country.RU).sample() should startWith("RU33")
+      Faker.finance.iban(Country.BR).sample() should startWith("BR18")
     }
+
+    "generate transaction IDs with prefix" in {
+      Faker.finance.transactionId("pay").sample() should startWith("pay-")
+    }
+  }
+
+  "Faker.commerce" should {
+    "generate product names from catalog" in {
+      FakerData.products should contain(Faker.commerce.productName().sample())
+    }
+
+    "generate categories from catalog" in {
+      FakerData.categories should contain(Faker.commerce.category().sample())
+    }
+
+    "generate SKUs with prefix" in {
+      Faker.commerce.sku("ITEM").sample() should startWith("ITEM-")
+    }
+
+    "generate order IDs" in {
+      Faker.commerce.orderId().sample() should startWith("ord-")
+    }
+  }
+
+  "Russian government identifiers" should {
+    "generate INN (person) with correct format" in {
+      (1 to sampleCount).foreach { _ =>
+        val inn = Faker.ru.inn.person().sample()
+        inn should fullyMatch regex "[0-9][1-9]\\d{8}|[1-9][0-9]\\d{8}"
+      }
+    }
+
+    "generate INN (company) with correct format" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.ru.inn.company().sample() should fullyMatch regex "\\d{12}"
+      }
+    }
+
+    "generate KPP with correct format" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.ru.kpp().sample() should fullyMatch regex "\\d{9}"
+      }
+    }
+
+    "generate OGRN with valid checksum" in {
+      (1 to sampleCount).foreach { _ =>
+        val ogrn = Faker.ru.ogrn().sample()
+        ogrn should have length 13
+        withClue(s"OGRN $ogrn checksum: ") {
+          ogrn.substring(0, 12).toLong % 11 % 10 shouldBe ogrn.substring(12, 13).toInt
+        }
+      }
+    }
+
+    "generate OGRNIP with valid checksum" in {
+      (1 to sampleCount).foreach { _ =>
+        val ogrnip = Faker.ru.ogrnip().sample()
+        ogrnip should have length 15
+        withClue(s"OGRNIP $ogrnip checksum: ") {
+          ogrnip.substring(0, 14).toLong % 13 % 10 shouldBe ogrnip.substring(14, 15).toInt
+        }
+      }
+    }
+
+    "generate SNILS with correct format" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.ru.snils().sample() should fullyMatch regex "\\d{11}"
+      }
+    }
+
+    "generate passport with correct format" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.passport.ru().sample() should fullyMatch regex "\\d{10}"
+      }
+    }
+  }
+
+  "Brazilian identifiers" should {
+    "generate formatted CPF" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.br.cpf(formatted = true).sample() should fullyMatch regex "\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}"
+      }
+    }
+
+    "generate raw CPF with valid checksum" in {
+      (1 to sampleCount).foreach { _ =>
+        val cpf = Faker.br.cpf().sample()
+        cpf should fullyMatch regex "\\d{11}"
+        withClue(s"CPF $cpf checksum: ") {
+          validateCpf(cpf) shouldBe true
+        }
+      }
+    }
+  }
+
+  "Argentinian identifiers" should {
+    "generate DNI values" in {
+      (1 to sampleCount).foreach { _ =>
+        val dni = Faker.ar.dni().sample()
+        dni should fullyMatch regex "\\d{8}"
+        dni.toInt should (be >= 10000000 and be <= 99999999)
+      }
+    }
+
+    "generate formatted DNI" in {
+      Faker.ar.dni(formatted = true).sample() should fullyMatch regex "\\d{2}\\.\\d{3}\\.\\d{3}"
+    }
+  }
+
+  "US identifiers" should {
+    "generate SSN with valid format" in {
+      (1 to sampleCount).foreach { _ =>
+        val ssn  = Faker.us.ssn().sample()
+        ssn should fullyMatch regex "\\d{3}-\\d{2}-\\d{4}"
+        val area = ssn.take(3).toInt
+        area should not be 0
+        area should not be 666
+        area should be < 900
+      }
+    }
+
+    "generate raw SSN without dashes" in {
+      Faker.us.ssn(formatted = false).sample() should fullyMatch regex "\\d{9}"
+    }
+  }
+
+  "UK identifiers" should {
+    "generate NINO with valid format" in {
+      (1 to sampleCount).foreach { _ =>
+        val nino   = Faker.gb.nino().sample()
+        nino should fullyMatch regex "[A-Z]{2}\\d{6}[A-D]"
+        val prefix = nino.take(2)
+        Set("BG", "GB", "NK", "KN", "TN", "NT", "ZZ") should not contain prefix
+        "DFIQUV".toSet should not contain nino.head
+      }
+    }
+  }
+
+  "French identifiers" should {
+    "generate NIR with valid key" in {
+      (1 to sampleCount).foreach { _ =>
+        val nir  = Faker.fr.nir().sample()
+        nir should fullyMatch regex "\\d{15}"
+        val base = nir.take(13).toLong
+        val key  = nir.takeRight(2).toInt
+        key shouldBe (97 - (base % 97)).toInt
+      }
+    }
+  }
+
+  "Spanish identifiers" should {
+    "generate NIF with valid check letter" in {
+      (1 to sampleCount).foreach { _ =>
+        val nif     = Faker.es.nif().sample()
+        nif should fullyMatch regex "\\d{8}[A-Z]"
+        val digits  = nif.take(8).toInt
+        val letters = "TRWAGMYFPDXBNJZSQVHLCKE"
+        nif.last shouldBe letters.charAt(digits % 23)
+      }
+    }
+  }
+
+  "Italian identifiers" should {
+    "generate Codice Fiscale with correct structure" in {
+      (1 to sampleCount).foreach { _ =>
+        val cf = Faker.it.codiceFiscale().sample()
+        cf should have length 16
+        cf should fullyMatch regex "[A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z]"
+      }
+    }
+  }
+
+  "German identifiers" should {
+    "generate Steueridentifikationsnummer" in {
+      (1 to sampleCount).foreach { _ =>
+        val tin = Faker.de.steueridentifikationsnummer().sample()
+        tin should fullyMatch regex "[1-9]\\d{10}"
+      }
+    }
+  }
+
+  "Passport for various countries" should {
+    "generate correct formats" in {
+      Faker.passport.number(Country.US).sample() should fullyMatch regex "\\d{9}"
+      Faker.passport.number(Country.AR).sample() should fullyMatch regex "[A-Z0-9]{9}"
+      Faker.passport.number(Country.BR).sample() should fullyMatch regex "[A-Z0-9]{8}"
+    }
+  }
+
+  "Faker.phone" should {
+    "generate Russian mobile phones" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.phone.mobile(Country.RU).sample() should startWith("+7")
+      }
+    }
+
+    "generate US mobile phones" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.phone.mobile(Country.US).sample() should startWith("+1")
+      }
+    }
+
+    "generate phones for all 16 supported countries" in {
+      val countries = Seq(
+        Country.RU,
+        Country.AR,
+        Country.BR,
+        Country.US,
+        Country.GB,
+        Country.DE,
+        Country.FR,
+        Country.ES,
+        Country.IT,
+        Country.AE,
+        Country.JP,
+        Country.CN,
+        Country.IN,
+        Country.CA,
+        Country.AU,
+        Country.MX,
+      )
+      countries.foreach { c =>
+        noException should be thrownBy Faker.phone.mobile(c).sample()
+      }
+    }
+
+    "build phones via builder" in {
+      val phone = Faker.phone.builder
+        .forCountry(Country.RU)
+        .withFormat(PhoneFormatMode.E164)
+        .build
+        .sample()
+      phone should startWith("+7")
+    }
+
+    "build custom phones with builder" in {
+      val phone = Faker.phone.builder
+        .withCountryCode("+7")
+        .withAreaCodes("999")
+        .withLength(10)
+        .build
+        .sample()
+      phone should include("999")
+    }
+
+    "fail clearly for unsupported country phone metadata" in {
+      val error = intercept[IllegalArgumentException] {
+        Faker.phone.mobile(Country.custom("ZZ")).sample()
+      }
+      error.getMessage should include("No phone formats configured")
+    }
+  }
+
+  "Faker.weather" should {
+    "generate conditions from catalog" in {
+      FakerData.weatherConditions should contain(Faker.weather.condition().sample())
+    }
+
+    "generate temperature within range" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.weather.temperatureCelsius().sample() should (be >= -30.0 and be <= 45.0)
+      }
+    }
+
+    "generate humidity 0-100" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.weather.humidityPercent().sample() should (be >= 0 and be <= 100)
+      }
+    }
+
+    "generate pressure in realistic range" in {
+      (1 to sampleCount).foreach { _ =>
+        Faker.weather.pressureHPa().sample() should (be >= 950 and be <= 1050)
+      }
+    }
+  }
+
+  "Faker.lorem" should {
+    "generate words from catalog" in {
+      FakerData.loremWords should contain(Faker.lorem.word().sample())
+    }
+
+    "generate word sequences of exact count" in {
+      forAll(Gen.choose(1, 20)) { n =>
+        Faker.lorem.words(n).sample().split(" ") should have length n
+      }
+    }
+
+    "generate sentences with capitalization and period" in {
+      val sentence = Faker.lorem.sentence(4).sample()
+      sentence.head.isUpper shouldBe true
+      sentence should endWith(".")
+    }
+
+    "reject zero word count" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.lorem.words(0)
+      }
+    }
+  }
+
+  "Faker.localization" should {
+    "map countries to currencies" in {
+      Faker.localization.currency(Country.RU).sample() shouldBe "RUB"
+      Faker.localization.currency(Country.US).sample() shouldBe "USD"
+      Faker.localization.currency(Country.DE).sample() shouldBe "EUR"
+      Faker.localization.currency(Country.GB).sample() shouldBe "GBP"
+      Faker.localization.currency(Country.JP).sample() shouldBe "JPY"
+      Faker.localization.currency(Country.CN).sample() shouldBe "CNY"
+      Faker.localization.currency(Country.IN).sample() shouldBe "INR"
+      Faker.localization.currency(Country.CA).sample() shouldBe "CAD"
+      Faker.localization.currency(Country.AU).sample() shouldBe "AUD"
+      Faker.localization.currency(Country.MX).sample() shouldBe "MXN"
+    }
+
+    "map countries to language codes" in {
+      Faker.localization.languageCode(Country.RU).sample() shouldBe "ru"
+      Faker.localization.languageCode(Country.BR).sample() shouldBe "pt"
+      Faker.localization.languageCode(Country.FR).sample() shouldBe "fr"
+      Faker.localization.languageCode(Country.JP).sample() shouldBe "ja"
+      Faker.localization.languageCode(Country.CN).sample() shouldBe "zh"
+    }
+  }
+
+  "Faker.oneOf" should {
+    "pick from sequence" in {
+      val items  = Vector("a", "b", "c")
+      val picked = (1 to 100).map(_ => Faker.oneOf(items).sample()).toSet
+      picked.subsetOf(items.toSet) shouldBe true
+      picked.size should be > 1
+    }
+
+    "pick from varargs" in {
+      val picked = Faker.oneOf("x", "y", "z").sample()
+      Set("x", "y", "z") should contain(picked)
+    }
+
+    "reject empty sequence" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.oneOf(Vector.empty[String])
+      }
+    }
+  }
+
+  "Generator combinators" should {
+    "sequence collects results" in {
+      val gens   = Seq(Generator.const(1), Generator.const(2), Generator.const(3))
+      val result = Generator.sequence(gens).sample()
+      result shouldBe Vector(1, 2, 3)
+    }
+
+    "listOf generates n values" in {
+      forAll(Gen.choose(0, 50)) { n =>
+        val result = Generator.listOf(n, Faker.number.int(1, 10)).sample()
+        result should have size n
+        all(result) should (be >= 1 and be <= 10)
+      }
+    }
+
+    "mapOf generates key-value pairs" in {
+      val result = Generator
+        .mapOf(
+          (Generator.const("a"), Faker.number.int(1, 10)),
+          (Generator.const("b"), Faker.number.int(1, 10)),
+        )
+        .sample()
+      result should contain key "a"
+      result should contain key "b"
+    }
+
+    "tupleOf combines generators" in {
+      val (a, b) = Generator.tupleOf(Generator.const(1), Generator.const("x")).sample()
+      a shouldBe 1
+      b shouldBe "x"
+    }
+
+    "tupleOf3 combines three generators" in {
+      val (a, b, c) = Generator.tupleOf(Generator.const(1), Generator.const("x"), Generator.const(true)).sample()
+      a shouldBe 1
+      b shouldBe "x"
+      c shouldBe true
+    }
+  }
+
+  "Model classes" should {
+    "reject empty field name" in {
+      assertThrows[IllegalArgumentException] {
+        Field("", Generator.const("x"))
+      }
+    }
+
+    "reject empty currency in Money" in {
+      assertThrows[IllegalArgumentException] {
+        Money(BigDecimal(1), "")
+      }
+    }
+
+    "reject empty iso2 in custom Country" in {
+      assertThrows[IllegalArgumentException] {
+        Country.custom("")
+      }
+    }
+
+    "provide Java-friendly BigDecimal in Money" in {
+      val m = Money(BigDecimal("19.99"), "USD")
+      m.javaAmount shouldBe new java.math.BigDecimal("19.99")
+    }
+  }
+
+  "toFeeder syntax on Generator" should {
+    "create single-field feeder" in {
+      val feeder = Faker.number.int(1, 10).toFeeder("num")
+      val record = feeder.next()
+      record should contain key "num"
+    }
+  }
+
+  private def validateCpf(cpf: String): Boolean = {
+    val digits                 = cpf.map(_.asDigit)
+    def check(count: Int): Int = {
+      val sum = digits.take(count).zip((count + 1) to 2 by -1).map { case (d, w) => d * w }.sum
+      val mod = (sum * 10) % 11
+      if (mod == 10) 0 else mod
+    }
+    digits(9) == check(9) && digits(10) == check(10)
   }
 }

--- a/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
@@ -1,0 +1,102 @@
+package org.galaxio.gatling.feeders.faker
+
+import org.galaxio.gatling.feeders.faker.Predef._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.LocalDate
+
+class GeneratedFeederSpec extends AnyWordSpec with Matchers {
+
+  "GeneratedFeeder" should {
+    "create a heterogeneous Gatling feeder from generators" in {
+      val feeder = GeneratedFeeder(
+        "email"  -> Faker.internet.email(),
+        "amount" -> Faker.finance.amount(BigDecimal(10), BigDecimal(20)),
+        "active" -> Faker.number.boolean,
+      )
+
+      val record = feeder.next()
+
+      record("email") shouldBe a[String]
+      record("amount") shouldBe a[BigDecimal]
+      record("active") shouldBe a[Boolean]
+    }
+
+    "support dependent fields through record generators" in {
+      val userRecord = for {
+        gender <- Faker.person.gender()
+        name   <- Faker.person.fullName(gender)
+        email  <- Faker.internet.email(name, "example.com")
+      } yield Map("gender" -> gender.value, "name" -> name, "email" -> email)
+
+      val record = GeneratedFeeder.records(userRecord).next()
+
+      record("name").toString should not be empty
+      record("email").toString should endWith("@example.com")
+    }
+  }
+
+  "Collection syntax" should {
+    "convert collections into Gatling-compatible records" in {
+      val records = List("RU", "AR", "BR").toFeeder("country")
+
+      records shouldBe Vector(
+        Map("country" -> "RU"),
+        Map("country" -> "AR"),
+        Map("country" -> "BR"),
+      )
+    }
+
+    "convert domain objects into records" in {
+      final case class User(id: String, email: String)
+
+      val records = List(User("1", "a@example.com")).toFeeder(user => Map("id" -> user.id, "email" -> user.email))
+
+      records.head shouldBe Map("id" -> "1", "email" -> "a@example.com")
+    }
+  }
+
+  "Feeder enrichment syntax" should {
+    "add generated fields to an existing feeder" in {
+      val existing = Iterator.single(Map("id" -> "42"))
+      val enriched = existing.withGenerated("traceId", Faker.uuid.string)
+
+      val record = enriched.next()
+
+      record("id") shouldBe "42"
+      record("traceId").toString should fullyMatch regex "[a-f0-9\\-]{36}"
+    }
+  }
+
+  "Date generators" should {
+    "format generated local dates for Gatling session values" in {
+      val date = Faker.date
+        .between(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31))
+        .format("yyyy-MM-dd")
+        .sample()
+
+      date should fullyMatch regex "2026-01-\\d{2}"
+    }
+  }
+
+  "Government identifiers" should {
+    "generate formatted Brazilian CPF values" in {
+      Faker.br.cpf(formatted = true).sample() should fullyMatch regex "\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}"
+    }
+
+    "generate Argentinian DNI values" in {
+      Faker.ar.dni().sample() should fullyMatch regex "\\d{8}"
+    }
+  }
+
+  "Additional faker domains" should {
+    "generate internet, location, finance, commerce, and weather values" in {
+      Faker.internet.url().sample() should startWith("https://")
+      Faker.location.postalCode(Country.RU).sample() should fullyMatch regex "\\d{6}"
+      Faker.finance.iban(Country.DE).sample() should startWith("DE89")
+      Faker.commerce.orderId().sample() should startWith("ord-")
+      Faker.weather.humidityPercent().sample() should (be >= 0 and be <= 100)
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Added a new `org.galaxio.gatling.feeders.faker` API with `Faker`, `Generator`, `GeneratedFeeder`, and user-facing syntax.
- Added generated-data domains for person, location, localization, internet, date, finance, commerce, phone, passport, RU identifiers, CPF, DNI, weather, lorem, primitives, and strings.
- Added collection-to-feeder helpers that return Gatling-compatible records and enrichment syntax for existing Gatling feeders.
- Deprecated legacy `Random*Feeder` objects with migration messages to the new faker API.
- Added user documentation, a focused Scala example, and tests for the generated feeder API.

## Why

Performance test scenarios need a richer, composable faker layer that works naturally with Gatling feeders without duplicating Gatling built-in feeder sources or strategies.

## Validation

- `sbt test`
