### PR TITLE
ci: convert Kotlin template test to use galaxio template init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,11 @@ jobs:
           gradle-version: '8.6'
 
       - name: Setup Go for galaxio CLI
-        if: matrix.template != 'kotlin-gradle'
         uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Install galaxio CLI from main
-        if: matrix.template != 'kotlin-gradle'
         run: go install github.com/galax-io/galaxio-cli/cmd/galaxio@main
 
       - name: Cache Coursier
@@ -180,9 +178,9 @@ jobs:
           mvn -B -f "$project_dir/pom.xml" clean test-compile
           mvn -B -f "$project_dir/pom.xml" gatling:test
 
-      - name: Kotlin Gradle Gatling Project
+      - name: Kotlin Gradle Gatling project from template main
         if: matrix.template == 'kotlin-gradle'
-        run: gradle -p examples/kotlin-gradle-example clean gatlingRun --all
+        run: scripts/test-kotlin-gradle-template.sh
 
       - name: Scala sbt Gatling project from template main
         if: matrix.template == 'scala-sbt'

--- a/scripts/test-kotlin-gradle-template.sh
+++ b/scripts/test-kotlin-gradle-template.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="${PICATINNY_KOTLIN_GRADLE_TEMPLATE_WORKDIR:-$(mktemp -d)}"
+TEMPLATES_DIR="$WORK_DIR/templates-gatling"
+REGISTRY_DIR="$WORK_DIR/registry"
+PROJECT_DIR="$WORK_DIR/kotlin-gradle-example"
+
+cleanup() {
+  if [[ -z "${PICATINNY_KOTLIN_GRADLE_TEMPLATE_WORKDIR:-}" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v galaxio >/dev/null 2>&1; then
+  echo "galaxio CLI is required on PATH" >&2
+  exit 1
+fi
+
+git clone --depth 1 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
+
+mkdir -p "$REGISTRY_DIR"
+cat > "$REGISTRY_DIR/galaxio-registry.yaml" <<YAML
+apiVersion: galaxio.io/v1
+kind: TemplateRegistry
+packs:
+  - name: gatling
+    source: local:$TEMPLATES_DIR
+    description: Gatling performance testing templates from main
+YAML
+
+galaxio template init gatling/kotlin-gradle \
+  --registry "local:$REGISTRY_DIR" \
+  --destination "$PROJECT_DIR" \
+  --set Name=kotlin-gradle-example \
+  --set NameWord=picatinny \
+  --set Package=org.galaxio.performance \
+  --set PackagePath=org/galaxio/performance \
+  --set GatlingPicatinnyVersion=0.0.0-ci-local \
+  --set BaseUrl=http://localhost \
+  --set BaseAuthUrl=http://localhost/auth \
+  --set WsBaseUrl=ws://localhost/ws \
+  --set Intensity="60 rpm" \
+  --set StagesNumber=2 \
+  --set RampDuration="1 second" \
+  --set StageDuration="1 second" \
+  --set TestDuration="5 seconds" \
+  --set StartupBannerEnabled=true \
+  --set DiagnosticsEnabled=true
+
+rm -rf "$PROJECT_DIR/src/gatling/kotlin/org/galaxio/performance/picatinny"
+cp -R "$ROOT_DIR/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny" \
+  "$PROJECT_DIR/src/gatling/kotlin/org/galaxio/performance/picatinny"
+
+rm -rf "$PROJECT_DIR/src/gatling/resources"
+cp -R "$ROOT_DIR/examples/kotlin-gradle-example/src/gatling/resources" \
+  "$PROJECT_DIR/src/gatling/resources"
+
+(
+  cd "$PROJECT_DIR"
+  gradle clean gatlingRun --all
+)


### PR DESCRIPTION
## Summary

- Kotlin Gradle example now uses `galaxio template init` like Java Maven and Scala SBT
- New `scripts/test-kotlin-gradle-template.sh` — clones template, inits project, overlays example code + resources
- All 3 template tests now consistently use galaxio CLI
- Removed `if` guards on Go/galaxio setup steps since all templates need them now

## Test plan

- [ ] CI template-tests matrix passes for all 3 templates
- [ ] Kotlin template inits and runs gatlingRun successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)