### PR TITLE
feat: expand Redis module with 27 commands, session integration, and stats

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,11 @@ object Dependencies {
     "io.circe" %% "circe-yaml"    % "1.15.0",
   )
 
-  lazy val scalaTesting: Seq[ModuleID] = scalaCheck ++ scalaTest ++ scalaMock ++ scalaTestPlus
+  lazy val testcontainers: Seq[ModuleID] = Seq(
+    "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.8" % Test,
+  )
+
+  lazy val scalaTesting: Seq[ModuleID] = scalaCheck ++ scalaTest ++ scalaMock ++ scalaTestPlus ++ testcontainers
 
   lazy val junit: Seq[ModuleID] = Seq(
     "org.junit.jupiter"    % "junit-jupiter"     % "6.0.2"  % Test,

--- a/src/main/java/org/galaxio/gatling/javaapi/redis/RedisClientPoolJava.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/redis/RedisClientPoolJava.java
@@ -14,16 +14,28 @@ import static org.galaxio.gatling.javaapi.internal.Expression.toListExpression;
 public final class RedisClientPoolJava {
 
     private final RedisClientPool redisClientPool;
+    private final com.redis.RedisClientPool directPool;
 
     public RedisClientPoolJava(String host, int port) {
         this.redisClientPool = new RedisClientPool(host, port);
+        this.directPool = null;
     }
 
     public RedisClientPoolJava(RedisClientPool redisClientPool) {
         this.redisClientPool = redisClientPool;
+        this.directPool = null;
+    }
+
+    public RedisClientPoolJava(com.redis.RedisClientPool scalaPool) {
+        this.redisClientPool = null;
+        this.directPool = scalaPool;
     }
 
     com.redis.RedisClientPool redisClientPoolAsScala() {
+        if (directPool != null) {
+            return directPool;
+        }
+
         Method m;
         com.redis.RedisClientPool invoke;
 
@@ -47,11 +59,15 @@ public final class RedisClientPoolJava {
         return invoke;
     }
 
+    private RedisClientPoolOps ops() {
+        return new RedisClientPoolOps(redisClientPoolAsScala());
+    }
+
+    // Legacy DEL/SREM/SADD methods (backward compatible)
+
     public RedisActionBuilder<RedisDelActionBuilder> DEL(String key, String... keys) {
         return new RedisActionBuilder<>(
-                new org.galaxio.gatling.redis.RedisActionBuilder.RedisClientPoolOps(redisClientPoolAsScala()).DEL(
-                        toAnyExpression(key), toListExpression(keys)
-                )
+                ops().DEL(toAnyExpression(key), toListExpression(keys))
         );
     }
 
@@ -65,9 +81,7 @@ public final class RedisClientPoolJava {
 
     public RedisActionBuilder<RedisSremActionBuilder> SREM(String key, String value, String... values) {
         return new RedisActionBuilder<>(
-                new org.galaxio.gatling.redis.RedisActionBuilder.RedisClientPoolOps(redisClientPoolAsScala()).SREM(
-                        toAnyExpression(key), toAnyExpression(value), toListExpression(values)
-                )
+                ops().SREM(toAnyExpression(key), toAnyExpression(value), toListExpression(values))
         );
     }
 
@@ -79,12 +93,9 @@ public final class RedisClientPoolJava {
         return SREM(key, value, Collections.emptyList());
     }
 
-
     public RedisActionBuilder<RedisSaddActionBuilder> SADD(String key, String value, String... values) {
         return new RedisActionBuilder<>(
-                new org.galaxio.gatling.redis.RedisActionBuilder.RedisClientPoolOps(redisClientPoolAsScala()).SADD(
-                        toAnyExpression(key), toAnyExpression(value), toListExpression(values)
-                )
+                ops().SADD(toAnyExpression(key), toAnyExpression(value), toListExpression(values))
         );
     }
 
@@ -94,6 +105,140 @@ public final class RedisClientPoolJava {
 
     public RedisActionBuilder<RedisSaddActionBuilder> SADD(String key, String value) {
         return SADD(key, value, Collections.emptyList());
+    }
 
+    // New generic commands returning RedisGenericActionBuilder (supports saveAs/requestName)
+
+    // String operations
+
+    public RedisGenericActionBuilder GET(String key) {
+        return new RedisGenericActionBuilder(ops().GET(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder SET(String key, String value) {
+        return new RedisGenericActionBuilder(ops().SET(toAnyExpression(key), toAnyExpression(value)));
+    }
+
+    public RedisGenericActionBuilder GETSET(String key, String value) {
+        return new RedisGenericActionBuilder(ops().GETSET(toAnyExpression(key), toAnyExpression(value)));
+    }
+
+    public RedisGenericActionBuilder SETNX(String key, String value) {
+        return new RedisGenericActionBuilder(ops().SETNX(toAnyExpression(key), toAnyExpression(value)));
+    }
+
+    public RedisGenericActionBuilder SETEX(String key, long expiry, String value) {
+        return new RedisGenericActionBuilder(
+                ops().SETEX(toAnyExpression(key), toAnyExpression(String.valueOf(expiry)), toAnyExpression(value)));
+    }
+
+    public RedisGenericActionBuilder MGET(String key, String... keys) {
+        return new RedisGenericActionBuilder(ops().MGET(toAnyExpression(key), toListExpression(keys)));
+    }
+
+    // Counter operations
+
+    public RedisGenericActionBuilder INCR(String key) {
+        return new RedisGenericActionBuilder(ops().INCR(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder INCRBY(String key, long increment) {
+        return new RedisGenericActionBuilder(
+                ops().INCRBY(toAnyExpression(key), toAnyExpression(String.valueOf(increment))));
+    }
+
+    public RedisGenericActionBuilder DECR(String key) {
+        return new RedisGenericActionBuilder(ops().DECR(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder DECRBY(String key, long decrement) {
+        return new RedisGenericActionBuilder(
+                ops().DECRBY(toAnyExpression(key), toAnyExpression(String.valueOf(decrement))));
+    }
+
+    // Hash operations
+
+    public RedisGenericActionBuilder HGET(String key, String field) {
+        return new RedisGenericActionBuilder(ops().HGET(toAnyExpression(key), toAnyExpression(field)));
+    }
+
+    public RedisGenericActionBuilder HSET(String key, String field, String value) {
+        return new RedisGenericActionBuilder(
+                ops().HSET(toAnyExpression(key), toAnyExpression(field), toAnyExpression(value)));
+    }
+
+    public RedisGenericActionBuilder HDEL(String key, String field, String... fields) {
+        return new RedisGenericActionBuilder(
+                ops().HDEL(toAnyExpression(key), toAnyExpression(field), toListExpression(fields)));
+    }
+
+    public RedisGenericActionBuilder HGETALL(String key) {
+        return new RedisGenericActionBuilder(ops().HGETALL(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder HMGET(String key, String... fields) {
+        return new RedisGenericActionBuilder(ops().HMGET(toAnyExpression(key), toListExpression(fields)));
+    }
+
+    // List operations
+
+    public RedisGenericActionBuilder LPUSH(String key, String value, String... values) {
+        return new RedisGenericActionBuilder(
+                ops().LPUSH(toAnyExpression(key), toAnyExpression(value), toListExpression(values)));
+    }
+
+    public RedisGenericActionBuilder RPUSH(String key, String value, String... values) {
+        return new RedisGenericActionBuilder(
+                ops().RPUSH(toAnyExpression(key), toAnyExpression(value), toListExpression(values)));
+    }
+
+    public RedisGenericActionBuilder LPOP(String key) {
+        return new RedisGenericActionBuilder(ops().LPOP(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder RPOP(String key) {
+        return new RedisGenericActionBuilder(ops().RPOP(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder LRANGE(String key, int start, int end) {
+        return new RedisGenericActionBuilder(
+                ops().LRANGE(toAnyExpression(key), toAnyExpression(String.valueOf(start)), toAnyExpression(String.valueOf(end))));
+    }
+
+    public RedisGenericActionBuilder LLEN(String key) {
+        return new RedisGenericActionBuilder(ops().LLEN(toAnyExpression(key)));
+    }
+
+    // Key operations
+
+    public RedisGenericActionBuilder EXISTS(String key) {
+        return new RedisGenericActionBuilder(ops().EXISTS(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder EXPIRE(String key, int ttl) {
+        return new RedisGenericActionBuilder(
+                ops().EXPIRE(toAnyExpression(key), toAnyExpression(String.valueOf(ttl))));
+    }
+
+    public RedisGenericActionBuilder TTL(String key) {
+        return new RedisGenericActionBuilder(ops().TTL(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder KEYS(String pattern) {
+        return new RedisGenericActionBuilder(ops().KEYS(toAnyExpression(pattern)));
+    }
+
+    // Set operations
+
+    public RedisGenericActionBuilder SMEMBERS(String key) {
+        return new RedisGenericActionBuilder(ops().SMEMBERS(toAnyExpression(key)));
+    }
+
+    public RedisGenericActionBuilder SISMEMBER(String key, String value) {
+        return new RedisGenericActionBuilder(ops().SISMEMBER(toAnyExpression(key), toAnyExpression(value)));
+    }
+
+    public RedisGenericActionBuilder SCARD(String key) {
+        return new RedisGenericActionBuilder(ops().SCARD(toAnyExpression(key)));
     }
 }

--- a/src/main/java/org/galaxio/gatling/javaapi/redis/RedisGenericActionBuilder.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/redis/RedisGenericActionBuilder.java
@@ -1,0 +1,26 @@
+package org.galaxio.gatling.javaapi.redis;
+
+import io.gatling.javaapi.core.ActionBuilder;
+import org.galaxio.gatling.redis.RedisActionBuilder.GenericRedisActionBuilder$;
+
+public final class RedisGenericActionBuilder implements ActionBuilder {
+
+    private final org.galaxio.gatling.redis.RedisActionBuilder.GenericRedisActionBuilder wrapped;
+
+    RedisGenericActionBuilder(org.galaxio.gatling.redis.RedisActionBuilder.GenericRedisActionBuilder wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    public RedisGenericActionBuilder saveAs(String variable) {
+        return new RedisGenericActionBuilder(wrapped.saveAs(variable));
+    }
+
+    public RedisGenericActionBuilder requestName(String name) {
+        return new RedisGenericActionBuilder(wrapped.requestName(name));
+    }
+
+    @Override
+    public io.gatling.core.action.builder.ActionBuilder asScala() {
+        return wrapped;
+    }
+}

--- a/src/main/scala/org/galaxio/gatling/redis/RedisAction.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisAction.scala
@@ -1,0 +1,92 @@
+package org.galaxio.gatling.redis
+
+import com.redis.RedisClientPool
+import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.validation.{Failure, Success}
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.session.Session
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.structure.ScenarioContext
+import io.gatling.core.util.NameGen
+
+case class RedisAction(
+    ctx: ScenarioContext,
+    next: Action,
+    clientPool: RedisClientPool,
+    commandFactory: Session => io.gatling.commons.validation.Validation[RedisCommand],
+    saveAsVar: Option[String],
+    reqName: Option[String],
+) extends ChainableAction with NameGen {
+
+  override val name: String = genName("redisAction")
+
+  private val statsEnabled: Boolean = reqName.isDefined
+  private val clock                 = ctx.coreComponents.clock
+
+  override def execute(session: Session): Unit =
+    try {
+      commandFactory(session) match {
+        case Success(command) =>
+          val start  = if (statsEnabled) clock.nowMillis else 0L
+          val result = clientPool.withClient(client => command.execute(client))
+          val end    = if (statsEnabled) clock.nowMillis else 0L
+
+          val updatedSession = saveAsVar.fold(session)(varName => session.set(varName, result.orNull))
+
+          if (statsEnabled) {
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
+              reqName.get,
+              start,
+              end,
+              OK,
+              None,
+              None,
+            )
+          }
+
+          next ! updatedSession
+
+        case Failure(message) =>
+          logger.error(s"Redis ${name} expression resolution failed: $message")
+          if (statsEnabled) {
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
+              reqName.get,
+              clock.nowMillis,
+              clock.nowMillis,
+              KO,
+              None,
+              Some(message),
+            )
+          }
+          next ! session.markAsFailed
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Redis ${name} failed", e)
+        if (statsEnabled) {
+          statsEngine.logResponse(
+            session.scenario,
+            session.groups,
+            reqName.getOrElse(name),
+            clock.nowMillis,
+            clock.nowMillis,
+            KO,
+            None,
+            Some(e.getMessage),
+          )
+        }
+        ctx.coreComponents.statsEngine.logRequestCrash(
+          session.scenario,
+          session.groups,
+          name,
+          e.getMessage,
+        )
+        next ! session.markAsFailed
+    }
+
+  override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
+}

--- a/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
@@ -1,15 +1,17 @@
 package org.galaxio.gatling.redis
 
 import com.redis.RedisClientPool
+import io.gatling.commons.validation.{Failure, Success, Validation}
 import io.gatling.core.action.Action
 import io.gatling.core.action.builder.ActionBuilder
-import io.gatling.core.session.Expression
+import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.structure.ScenarioContext
 
 object RedisActionBuilder {
 
   implicit class RedisClientPoolOps(clientPool: RedisClientPool) {
 
+    // Legacy methods (backward compatible)
     def DEL(key: Expression[Any], keys: Expression[Any]*): RedisDelActionBuilder =
       RedisDelActionBuilder(clientPool, key, keys)
 
@@ -19,8 +21,222 @@ object RedisActionBuilder {
     def SADD(key: Expression[Any], value: Expression[Any], values: Expression[Any]*): RedisSaddActionBuilder =
       RedisSaddActionBuilder(clientPool, key, value, values)
 
+    // String operations
+    def GET(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Strings.Get(k)),
+      )
+
+    def SET(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          v <- value(session)
+        } yield RedisCommand.Strings.Set(k, v),
+      )
+
+    def GETSET(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          v <- value(session)
+        } yield RedisCommand.Strings.GetSet(k, v),
+      )
+
+    def SETNX(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          v <- value(session)
+        } yield RedisCommand.Strings.SetNx(k, v),
+      )
+
+    def SETEX(key: Expression[Any], expiry: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          e <- expiry(session)
+          v <- value(session)
+        } yield RedisCommand.Strings.SetEx(k, e.toString.toLong, v),
+      )
+
+    def MGET(key: Expression[Any], keys: Expression[Any]*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k  <- key(session)
+          ks <- resolveSeq(keys, session)
+        } yield RedisCommand.Strings.MGet(k, ks),
+      )
+
+    def MSET(kvs: (Expression[Any], Expression[Any])*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        resolvePairs(kvs, session).map(pairs => RedisCommand.Strings.MSet(pairs)),
+      )
+
+    // Counter operations
+    def INCR(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Strings.Incr(k)),
+      )
+
+    def INCRBY(key: Expression[Any], increment: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          i <- increment(session)
+        } yield RedisCommand.Strings.IncrBy(k, i.toString.toLong),
+      )
+
+    def DECR(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Strings.Decr(k)),
+      )
+
+    def DECRBY(key: Expression[Any], decrement: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          d <- decrement(session)
+        } yield RedisCommand.Strings.DecrBy(k, d.toString.toLong),
+      )
+
+    // Hash operations
+    def HGET(key: Expression[Any], field: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          f <- field(session)
+        } yield RedisCommand.Hashes.HGet(k, f),
+      )
+
+    def HSET(key: Expression[Any], field: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          f <- field(session)
+          v <- value(session)
+        } yield RedisCommand.Hashes.HSet(k, f, v),
+      )
+
+    def HDEL(key: Expression[Any], field: Expression[Any], fields: Expression[Any]*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k  <- key(session)
+          f  <- field(session)
+          fs <- resolveSeq(fields, session)
+        } yield RedisCommand.Hashes.HDel(k, f, fs),
+      )
+
+    def HGETALL(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Hashes.HGetAll(k)),
+      )
+
+    def HMSET(key: Expression[Any], kvs: (Expression[Any], Expression[Any])*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k     <- key(session)
+          pairs <- resolvePairs(kvs, session)
+        } yield RedisCommand.Hashes.HMSet(k, pairs.map { case (a, b) => (a, b) }),
+      )
+
+    def HMGET(key: Expression[Any], fields: Expression[Any]*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k  <- key(session)
+          fs <- resolveSeq(fields, session)
+        } yield RedisCommand.Hashes.HMGet(k, fs),
+      )
+
+    // List operations
+    def LPUSH(key: Expression[Any], value: Expression[Any], values: Expression[Any]*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k  <- key(session)
+          v  <- value(session)
+          vs <- resolveSeq(values, session)
+        } yield RedisCommand.Lists.LPush(k, v, vs),
+      )
+
+    def RPUSH(key: Expression[Any], value: Expression[Any], values: Expression[Any]*): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k  <- key(session)
+          v  <- value(session)
+          vs <- resolveSeq(values, session)
+        } yield RedisCommand.Lists.RPush(k, v, vs),
+      )
+
+    def LPOP(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Lists.LPop(k)),
+      )
+
+    def RPOP(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Lists.RPop(k)),
+      )
+
+    def LRANGE(key: Expression[Any], start: Expression[Any], end: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          s <- start(session)
+          e <- end(session)
+        } yield RedisCommand.Lists.LRange(k, s.toString.toInt, e.toString.toInt),
+      )
+
+    def LLEN(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Lists.LLen(k)),
+      )
+
+    // Key operations (DEL already in legacy methods above)
+    def EXISTS(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Keys.Exists(k)),
+      )
+
+    def EXPIRE(key: Expression[Any], ttl: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          t <- ttl(session)
+        } yield RedisCommand.Keys.Expire(k, t.toString.toInt),
+      )
+
+    def TTL(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Keys.Ttl(k)),
+      )
+
+    def KEYS(pattern: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        pattern(session).map(p => RedisCommand.Keys.KeysPattern(p)),
+      )
+
+    // Set operations (SADD, SREM already in legacy methods above)
+    def SMEMBERS(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Sets.SMembers(k)),
+      )
+
+    def SISMEMBER(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        for {
+          k <- key(session)
+          v <- value(session)
+        } yield RedisCommand.Sets.SIsMember(k, v),
+      )
+
+    def SCARD(key: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(clientPool, session =>
+        key(session).map(k => RedisCommand.Sets.SCard(k)),
+      )
+
   }
 
+  // Legacy builders (backward compatible)
   case class RedisDelActionBuilder(clientPool: RedisClientPool, key: Expression[Any], keys: Seq[Expression[Any]])
       extends ActionBuilder {
     override def build(ctx: ScenarioContext, next: Action): Action = RedisDelAction(ctx, next, clientPool, key, keys)
@@ -42,6 +258,48 @@ object RedisActionBuilder {
       values: Seq[Expression[Any]],
   ) extends ActionBuilder {
     override def build(ctx: ScenarioContext, next: Action): Action = RedisSaddAction(ctx, next, clientPool, key, value, values)
+  }
+
+  // New generic builder with saveAs/requestName support
+  case class GenericRedisActionBuilder(
+      clientPool: RedisClientPool,
+      commandFactory: Session => Validation[RedisCommand],
+      saveAsVar: Option[String] = None,
+      reqName: Option[String] = None,
+  ) extends ActionBuilder {
+
+    def saveAs(variable: String): GenericRedisActionBuilder = copy(saveAsVar = Some(variable))
+
+    def requestName(name: String): GenericRedisActionBuilder = copy(reqName = Some(name))
+
+    override def build(ctx: ScenarioContext, next: Action): Action =
+      RedisAction(ctx, next, clientPool, commandFactory, saveAsVar, reqName)
+  }
+
+  private def resolveSeq(exprs: Seq[Expression[Any]], session: Session): Validation[Seq[Any]] = {
+    val results = exprs.map(_(session))
+    val failures = results.collect { case Failure(msg) => msg }
+    if (failures.nonEmpty)
+      Failure(failures.mkString(", "))
+    else
+      Success(results.collect { case Success(v) => v })
+  }
+
+  private def resolvePairs(
+      pairs: Seq[(Expression[Any], Expression[Any])],
+      session: Session,
+  ): Validation[Seq[(Any, Any)]] = {
+    val results = pairs.map { case (kExpr, vExpr) =>
+      for {
+        k <- kExpr(session)
+        v <- vExpr(session)
+      } yield (k, v)
+    }
+    val failures = results.collect { case Failure(msg) => msg }
+    if (failures.nonEmpty)
+      Failure(failures.mkString(", "))
+    else
+      Success(results.collect { case Success(pair) => pair })
   }
 
 }

--- a/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
@@ -23,216 +23,227 @@ object RedisActionBuilder {
 
     // String operations
     def GET(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Strings.Get(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Strings.Get(k)))
 
     def SET(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          v <- value(session)
-        } yield RedisCommand.Strings.Set(k, v),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            v <- value(session)
+          } yield RedisCommand.Strings.Set(k, v),
       )
 
     def GETSET(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          v <- value(session)
-        } yield RedisCommand.Strings.GetSet(k, v),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            v <- value(session)
+          } yield RedisCommand.Strings.GetSet(k, v),
       )
 
     def SETNX(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          v <- value(session)
-        } yield RedisCommand.Strings.SetNx(k, v),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            v <- value(session)
+          } yield RedisCommand.Strings.SetNx(k, v),
       )
 
     def SETEX(key: Expression[Any], expiry: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          e <- expiry(session)
-          v <- value(session)
-        } yield RedisCommand.Strings.SetEx(k, e.toString.toLong, v),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            e <- expiry(session)
+            v <- value(session)
+          } yield RedisCommand.Strings.SetEx(k, e.toString.toLong, v),
       )
 
     def MGET(key: Expression[Any], keys: Expression[Any]*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k  <- key(session)
-          ks <- resolveSeq(keys, session)
-        } yield RedisCommand.Strings.MGet(k, ks),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k  <- key(session)
+            ks <- resolveSeq(keys, session)
+          } yield RedisCommand.Strings.MGet(k, ks),
       )
 
     def MSET(kvs: (Expression[Any], Expression[Any])*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        resolvePairs(kvs, session).map(pairs => RedisCommand.Strings.MSet(pairs)),
+      GenericRedisActionBuilder(
+        clientPool,
+        session => resolvePairs(kvs, session).map(pairs => RedisCommand.Strings.MSet(pairs)),
       )
 
     // Counter operations
     def INCR(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Strings.Incr(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Strings.Incr(k)))
 
     def INCRBY(key: Expression[Any], increment: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          i <- increment(session)
-        } yield RedisCommand.Strings.IncrBy(k, i.toString.toLong),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            i <- increment(session)
+          } yield RedisCommand.Strings.IncrBy(k, i.toString.toLong),
       )
 
     def DECR(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Strings.Decr(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Strings.Decr(k)))
 
     def DECRBY(key: Expression[Any], decrement: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          d <- decrement(session)
-        } yield RedisCommand.Strings.DecrBy(k, d.toString.toLong),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            d <- decrement(session)
+          } yield RedisCommand.Strings.DecrBy(k, d.toString.toLong),
       )
 
     // Hash operations
     def HGET(key: Expression[Any], field: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          f <- field(session)
-        } yield RedisCommand.Hashes.HGet(k, f),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            f <- field(session)
+          } yield RedisCommand.Hashes.HGet(k, f),
       )
 
     def HSET(key: Expression[Any], field: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          f <- field(session)
-          v <- value(session)
-        } yield RedisCommand.Hashes.HSet(k, f, v),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            f <- field(session)
+            v <- value(session)
+          } yield RedisCommand.Hashes.HSet(k, f, v),
       )
 
     def HDEL(key: Expression[Any], field: Expression[Any], fields: Expression[Any]*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k  <- key(session)
-          f  <- field(session)
-          fs <- resolveSeq(fields, session)
-        } yield RedisCommand.Hashes.HDel(k, f, fs),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k  <- key(session)
+            f  <- field(session)
+            fs <- resolveSeq(fields, session)
+          } yield RedisCommand.Hashes.HDel(k, f, fs),
       )
 
     def HGETALL(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Hashes.HGetAll(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Hashes.HGetAll(k)))
 
     def HMSET(key: Expression[Any], kvs: (Expression[Any], Expression[Any])*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k     <- key(session)
-          pairs <- resolvePairs(kvs, session)
-        } yield RedisCommand.Hashes.HMSet(k, pairs.map { case (a, b) => (a, b) }),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k     <- key(session)
+            pairs <- resolvePairs(kvs, session)
+          } yield RedisCommand.Hashes.HMSet(k, pairs.map { case (a, b) => (a, b) }),
       )
 
     def HMGET(key: Expression[Any], fields: Expression[Any]*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k  <- key(session)
-          fs <- resolveSeq(fields, session)
-        } yield RedisCommand.Hashes.HMGet(k, fs),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k  <- key(session)
+            fs <- resolveSeq(fields, session)
+          } yield RedisCommand.Hashes.HMGet(k, fs),
       )
 
     // List operations
     def LPUSH(key: Expression[Any], value: Expression[Any], values: Expression[Any]*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k  <- key(session)
-          v  <- value(session)
-          vs <- resolveSeq(values, session)
-        } yield RedisCommand.Lists.LPush(k, v, vs),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k  <- key(session)
+            v  <- value(session)
+            vs <- resolveSeq(values, session)
+          } yield RedisCommand.Lists.LPush(k, v, vs),
       )
 
     def RPUSH(key: Expression[Any], value: Expression[Any], values: Expression[Any]*): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k  <- key(session)
-          v  <- value(session)
-          vs <- resolveSeq(values, session)
-        } yield RedisCommand.Lists.RPush(k, v, vs),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k  <- key(session)
+            v  <- value(session)
+            vs <- resolveSeq(values, session)
+          } yield RedisCommand.Lists.RPush(k, v, vs),
       )
 
     def LPOP(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Lists.LPop(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Lists.LPop(k)))
 
     def RPOP(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Lists.RPop(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Lists.RPop(k)))
 
     def LRANGE(key: Expression[Any], start: Expression[Any], end: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          s <- start(session)
-          e <- end(session)
-        } yield RedisCommand.Lists.LRange(k, s.toString.toInt, e.toString.toInt),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            s <- start(session)
+            e <- end(session)
+          } yield RedisCommand.Lists.LRange(k, s.toString.toInt, e.toString.toInt),
       )
 
     def LLEN(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Lists.LLen(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Lists.LLen(k)))
 
     // Key operations (DEL already in legacy methods above)
     def EXISTS(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Keys.Exists(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Keys.Exists(k)))
 
     def EXPIRE(key: Expression[Any], ttl: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          t <- ttl(session)
-        } yield RedisCommand.Keys.Expire(k, t.toString.toInt),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            t <- ttl(session)
+          } yield RedisCommand.Keys.Expire(k, t.toString.toInt),
       )
 
     def TTL(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Keys.Ttl(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Keys.Ttl(k)))
 
     def KEYS(pattern: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        pattern(session).map(p => RedisCommand.Keys.KeysPattern(p)),
-      )
+      GenericRedisActionBuilder(clientPool, session => pattern(session).map(p => RedisCommand.Keys.KeysPattern(p)))
 
     // Set operations (SADD, SREM already in legacy methods above)
     def SMEMBERS(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Sets.SMembers(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Sets.SMembers(k)))
 
     def SISMEMBER(key: Expression[Any], value: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        for {
-          k <- key(session)
-          v <- value(session)
-        } yield RedisCommand.Sets.SIsMember(k, v),
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            v <- value(session)
+          } yield RedisCommand.Sets.SIsMember(k, v),
       )
 
     def SCARD(key: Expression[Any]): GenericRedisActionBuilder =
-      GenericRedisActionBuilder(clientPool, session =>
-        key(session).map(k => RedisCommand.Sets.SCard(k)),
-      )
+      GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Sets.SCard(k)))
 
   }
 
@@ -277,7 +288,7 @@ object RedisActionBuilder {
   }
 
   private def resolveSeq(exprs: Seq[Expression[Any]], session: Session): Validation[Seq[Any]] = {
-    val results = exprs.map(_(session))
+    val results  = exprs.map(_(session))
     val failures = results.collect { case Failure(msg) => msg }
     if (failures.nonEmpty)
       Failure(failures.mkString(", "))
@@ -289,7 +300,7 @@ object RedisActionBuilder {
       pairs: Seq[(Expression[Any], Expression[Any])],
       session: Session,
   ): Validation[Seq[(Any, Any)]] = {
-    val results = pairs.map { case (kExpr, vExpr) =>
+    val results  = pairs.map { case (kExpr, vExpr) =>
       for {
         k <- kExpr(session)
         v <- vExpr(session)

--- a/src/main/scala/org/galaxio/gatling/redis/RedisCommand.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisCommand.scala
@@ -1,0 +1,231 @@
+package org.galaxio.gatling.redis
+
+import com.redis.RedisClient
+import com.redis.serialization.Parse
+
+sealed trait RedisCommand {
+  def execute(client: RedisClient): Option[Any]
+  def commandName: String
+}
+
+object RedisCommand {
+
+  object Strings {
+
+    case class Get(key: Any) extends RedisCommand {
+      val commandName = "GET"
+      def execute(client: RedisClient): Option[Any] =
+        client.get[String](key)
+    }
+
+    case class Set(key: Any, value: Any) extends RedisCommand {
+      val commandName = "SET"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.set(key, value))
+    }
+
+    case class GetSet(key: Any, value: Any) extends RedisCommand {
+      val commandName = "GETSET"
+      def execute(client: RedisClient): Option[Any] =
+        client.getset[String](key, value)
+    }
+
+    case class SetNx(key: Any, value: Any) extends RedisCommand {
+      val commandName = "SETNX"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.setnx(key, value))
+    }
+
+    case class SetEx(key: Any, expiry: Long, value: Any) extends RedisCommand {
+      val commandName = "SETEX"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.setex(key, expiry, value))
+    }
+
+    case class MGet(key: Any, keys: Seq[Any]) extends RedisCommand {
+      val commandName = "MGET"
+      def execute(client: RedisClient): Option[Any] =
+        client.mget[String](key, keys: _*)
+    }
+
+    case class MSet(kvs: Seq[(Any, Any)]) extends RedisCommand {
+      val commandName = "MSET"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.mset(kvs: _*))
+    }
+
+    case class Incr(key: Any) extends RedisCommand {
+      val commandName = "INCR"
+      def execute(client: RedisClient): Option[Any] =
+        client.incr(key)
+    }
+
+    case class IncrBy(key: Any, increment: Long) extends RedisCommand {
+      val commandName = "INCRBY"
+      def execute(client: RedisClient): Option[Any] =
+        client.incrby(key, increment)
+    }
+
+    case class Decr(key: Any) extends RedisCommand {
+      val commandName = "DECR"
+      def execute(client: RedisClient): Option[Any] =
+        client.decr(key)
+    }
+
+    case class DecrBy(key: Any, decrement: Long) extends RedisCommand {
+      val commandName = "DECRBY"
+      def execute(client: RedisClient): Option[Any] =
+        client.decrby(key, decrement)
+    }
+
+  }
+
+  object Hashes {
+
+    case class HGet(key: Any, field: Any) extends RedisCommand {
+      val commandName = "HGET"
+      def execute(client: RedisClient): Option[Any] =
+        client.hget[String](key, field)
+    }
+
+    case class HSet(key: Any, field: Any, value: Any) extends RedisCommand {
+      val commandName = "HSET"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.hset(key, field, value))
+    }
+
+    case class HDel(key: Any, field: Any, fields: Seq[Any]) extends RedisCommand {
+      val commandName = "HDEL"
+      def execute(client: RedisClient): Option[Any] =
+        client.hdel(key, field, fields: _*)
+    }
+
+    case class HGetAll(key: Any) extends RedisCommand {
+      val commandName = "HGETALL"
+      def execute(client: RedisClient): Option[Any] =
+        client.hgetall[String, String](key)
+    }
+
+    case class HMSet(key: Any, kvs: Iterable[Product2[Any, Any]]) extends RedisCommand {
+      val commandName = "HMSET"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.hmset(key, kvs))
+    }
+
+    case class HMGet(key: Any, fields: Seq[Any]) extends RedisCommand {
+      val commandName = "HMGET"
+      def execute(client: RedisClient): Option[Any] =
+        client.hmget[Any, String](key, fields: _*)
+    }
+
+  }
+
+  object Lists {
+
+    case class LPush(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
+      val commandName = "LPUSH"
+      def execute(client: RedisClient): Option[Any] =
+        client.lpush(key, value, values: _*)
+    }
+
+    case class RPush(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
+      val commandName = "RPUSH"
+      def execute(client: RedisClient): Option[Any] =
+        client.rpush(key, value, values: _*)
+    }
+
+    case class LPop(key: Any) extends RedisCommand {
+      val commandName = "LPOP"
+      def execute(client: RedisClient): Option[Any] =
+        client.lpop[String](key)
+    }
+
+    case class RPop(key: Any) extends RedisCommand {
+      val commandName = "RPOP"
+      def execute(client: RedisClient): Option[Any] =
+        client.rpop[String](key)
+    }
+
+    case class LRange(key: Any, start: Int, end: Int) extends RedisCommand {
+      val commandName = "LRANGE"
+      def execute(client: RedisClient): Option[Any] =
+        client.lrange[String](key, start, end)
+    }
+
+    case class LLen(key: Any) extends RedisCommand {
+      val commandName = "LLEN"
+      def execute(client: RedisClient): Option[Any] =
+        client.llen(key)
+    }
+
+  }
+
+  object Keys {
+
+    case class Del(key: Any, keys: Seq[Any]) extends RedisCommand {
+      val commandName = "DEL"
+      def execute(client: RedisClient): Option[Any] =
+        client.del(key, keys: _*)
+    }
+
+    case class Exists(key: Any) extends RedisCommand {
+      val commandName = "EXISTS"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.exists(key))
+    }
+
+    case class Expire(key: Any, ttl: Int) extends RedisCommand {
+      val commandName = "EXPIRE"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.expire(key, ttl))
+    }
+
+    case class Ttl(key: Any) extends RedisCommand {
+      val commandName = "TTL"
+      def execute(client: RedisClient): Option[Any] =
+        client.ttl(key)
+    }
+
+    case class KeysPattern(pattern: Any) extends RedisCommand {
+      val commandName = "KEYS"
+      def execute(client: RedisClient): Option[Any] =
+        client.keys[String](pattern)
+    }
+
+  }
+
+  object Sets {
+
+    case class SAdd(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
+      val commandName = "SADD"
+      def execute(client: RedisClient): Option[Any] =
+        client.sadd(key, value, values: _*)
+    }
+
+    case class SRem(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
+      val commandName = "SREM"
+      def execute(client: RedisClient): Option[Any] =
+        client.srem(key, value, values: _*)
+    }
+
+    case class SMembers(key: Any) extends RedisCommand {
+      val commandName = "SMEMBERS"
+      def execute(client: RedisClient): Option[Any] =
+        client.smembers[String](key)
+    }
+
+    case class SIsMember(key: Any, value: Any) extends RedisCommand {
+      val commandName = "SISMEMBER"
+      def execute(client: RedisClient): Option[Any] =
+        Some(client.sismember(key, value))
+    }
+
+    case class SCard(key: Any) extends RedisCommand {
+      val commandName = "SCARD"
+      def execute(client: RedisClient): Option[Any] =
+        client.scard(key)
+    }
+
+  }
+
+}

--- a/src/main/scala/org/galaxio/gatling/redis/RedisCommand.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisCommand.scala
@@ -13,67 +13,67 @@ object RedisCommand {
   object Strings {
 
     case class Get(key: Any) extends RedisCommand {
-      val commandName = "GET"
+      val commandName                               = "GET"
       def execute(client: RedisClient): Option[Any] =
         client.get[String](key)
     }
 
     case class Set(key: Any, value: Any) extends RedisCommand {
-      val commandName = "SET"
+      val commandName                               = "SET"
       def execute(client: RedisClient): Option[Any] =
         Some(client.set(key, value))
     }
 
     case class GetSet(key: Any, value: Any) extends RedisCommand {
-      val commandName = "GETSET"
+      val commandName                               = "GETSET"
       def execute(client: RedisClient): Option[Any] =
         client.getset[String](key, value)
     }
 
     case class SetNx(key: Any, value: Any) extends RedisCommand {
-      val commandName = "SETNX"
+      val commandName                               = "SETNX"
       def execute(client: RedisClient): Option[Any] =
         Some(client.setnx(key, value))
     }
 
     case class SetEx(key: Any, expiry: Long, value: Any) extends RedisCommand {
-      val commandName = "SETEX"
+      val commandName                               = "SETEX"
       def execute(client: RedisClient): Option[Any] =
         Some(client.setex(key, expiry, value))
     }
 
     case class MGet(key: Any, keys: Seq[Any]) extends RedisCommand {
-      val commandName = "MGET"
+      val commandName                               = "MGET"
       def execute(client: RedisClient): Option[Any] =
         client.mget[String](key, keys: _*)
     }
 
     case class MSet(kvs: Seq[(Any, Any)]) extends RedisCommand {
-      val commandName = "MSET"
+      val commandName                               = "MSET"
       def execute(client: RedisClient): Option[Any] =
         Some(client.mset(kvs: _*))
     }
 
     case class Incr(key: Any) extends RedisCommand {
-      val commandName = "INCR"
+      val commandName                               = "INCR"
       def execute(client: RedisClient): Option[Any] =
         client.incr(key)
     }
 
     case class IncrBy(key: Any, increment: Long) extends RedisCommand {
-      val commandName = "INCRBY"
+      val commandName                               = "INCRBY"
       def execute(client: RedisClient): Option[Any] =
         client.incrby(key, increment)
     }
 
     case class Decr(key: Any) extends RedisCommand {
-      val commandName = "DECR"
+      val commandName                               = "DECR"
       def execute(client: RedisClient): Option[Any] =
         client.decr(key)
     }
 
     case class DecrBy(key: Any, decrement: Long) extends RedisCommand {
-      val commandName = "DECRBY"
+      val commandName                               = "DECRBY"
       def execute(client: RedisClient): Option[Any] =
         client.decrby(key, decrement)
     }
@@ -83,37 +83,37 @@ object RedisCommand {
   object Hashes {
 
     case class HGet(key: Any, field: Any) extends RedisCommand {
-      val commandName = "HGET"
+      val commandName                               = "HGET"
       def execute(client: RedisClient): Option[Any] =
         client.hget[String](key, field)
     }
 
     case class HSet(key: Any, field: Any, value: Any) extends RedisCommand {
-      val commandName = "HSET"
+      val commandName                               = "HSET"
       def execute(client: RedisClient): Option[Any] =
         Some(client.hset(key, field, value))
     }
 
     case class HDel(key: Any, field: Any, fields: Seq[Any]) extends RedisCommand {
-      val commandName = "HDEL"
+      val commandName                               = "HDEL"
       def execute(client: RedisClient): Option[Any] =
         client.hdel(key, field, fields: _*)
     }
 
     case class HGetAll(key: Any) extends RedisCommand {
-      val commandName = "HGETALL"
+      val commandName                               = "HGETALL"
       def execute(client: RedisClient): Option[Any] =
         client.hgetall[String, String](key)
     }
 
     case class HMSet(key: Any, kvs: Iterable[Product2[Any, Any]]) extends RedisCommand {
-      val commandName = "HMSET"
+      val commandName                               = "HMSET"
       def execute(client: RedisClient): Option[Any] =
         Some(client.hmset(key, kvs))
     }
 
     case class HMGet(key: Any, fields: Seq[Any]) extends RedisCommand {
-      val commandName = "HMGET"
+      val commandName                               = "HMGET"
       def execute(client: RedisClient): Option[Any] =
         client.hmget[Any, String](key, fields: _*)
     }
@@ -123,37 +123,37 @@ object RedisCommand {
   object Lists {
 
     case class LPush(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
-      val commandName = "LPUSH"
+      val commandName                               = "LPUSH"
       def execute(client: RedisClient): Option[Any] =
         client.lpush(key, value, values: _*)
     }
 
     case class RPush(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
-      val commandName = "RPUSH"
+      val commandName                               = "RPUSH"
       def execute(client: RedisClient): Option[Any] =
         client.rpush(key, value, values: _*)
     }
 
     case class LPop(key: Any) extends RedisCommand {
-      val commandName = "LPOP"
+      val commandName                               = "LPOP"
       def execute(client: RedisClient): Option[Any] =
         client.lpop[String](key)
     }
 
     case class RPop(key: Any) extends RedisCommand {
-      val commandName = "RPOP"
+      val commandName                               = "RPOP"
       def execute(client: RedisClient): Option[Any] =
         client.rpop[String](key)
     }
 
     case class LRange(key: Any, start: Int, end: Int) extends RedisCommand {
-      val commandName = "LRANGE"
+      val commandName                               = "LRANGE"
       def execute(client: RedisClient): Option[Any] =
         client.lrange[String](key, start, end)
     }
 
     case class LLen(key: Any) extends RedisCommand {
-      val commandName = "LLEN"
+      val commandName                               = "LLEN"
       def execute(client: RedisClient): Option[Any] =
         client.llen(key)
     }
@@ -163,31 +163,31 @@ object RedisCommand {
   object Keys {
 
     case class Del(key: Any, keys: Seq[Any]) extends RedisCommand {
-      val commandName = "DEL"
+      val commandName                               = "DEL"
       def execute(client: RedisClient): Option[Any] =
         client.del(key, keys: _*)
     }
 
     case class Exists(key: Any) extends RedisCommand {
-      val commandName = "EXISTS"
+      val commandName                               = "EXISTS"
       def execute(client: RedisClient): Option[Any] =
         Some(client.exists(key))
     }
 
     case class Expire(key: Any, ttl: Int) extends RedisCommand {
-      val commandName = "EXPIRE"
+      val commandName                               = "EXPIRE"
       def execute(client: RedisClient): Option[Any] =
         Some(client.expire(key, ttl))
     }
 
     case class Ttl(key: Any) extends RedisCommand {
-      val commandName = "TTL"
+      val commandName                               = "TTL"
       def execute(client: RedisClient): Option[Any] =
         client.ttl(key)
     }
 
     case class KeysPattern(pattern: Any) extends RedisCommand {
-      val commandName = "KEYS"
+      val commandName                               = "KEYS"
       def execute(client: RedisClient): Option[Any] =
         client.keys[String](pattern)
     }
@@ -197,31 +197,31 @@ object RedisCommand {
   object Sets {
 
     case class SAdd(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
-      val commandName = "SADD"
+      val commandName                               = "SADD"
       def execute(client: RedisClient): Option[Any] =
         client.sadd(key, value, values: _*)
     }
 
     case class SRem(key: Any, value: Any, values: Seq[Any]) extends RedisCommand {
-      val commandName = "SREM"
+      val commandName                               = "SREM"
       def execute(client: RedisClient): Option[Any] =
         client.srem(key, value, values: _*)
     }
 
     case class SMembers(key: Any) extends RedisCommand {
-      val commandName = "SMEMBERS"
+      val commandName                               = "SMEMBERS"
       def execute(client: RedisClient): Option[Any] =
         client.smembers[String](key)
     }
 
     case class SIsMember(key: Any, value: Any) extends RedisCommand {
-      val commandName = "SISMEMBER"
+      val commandName                               = "SISMEMBER"
       def execute(client: RedisClient): Option[Any] =
         Some(client.sismember(key, value))
     }
 
     case class SCard(key: Any) extends RedisCommand {
-      val commandName = "SCARD"
+      val commandName                               = "SCARD"
       def execute(client: RedisClient): Option[Any] =
         client.scard(key)
     }

--- a/src/main/scala/org/galaxio/gatling/redis/RedisDelAction.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisDelAction.scala
@@ -8,6 +8,7 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.structure.ScenarioContext
 import io.gatling.core.util.NameGen
 
+@deprecated("Use GenericRedisActionBuilder with RedisCommand.Keys.Del instead", "picatinny 0.x")
 case class RedisDelAction(
     ctx: ScenarioContext,
     next: Action,

--- a/src/main/scala/org/galaxio/gatling/redis/RedisSaddAction.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisSaddAction.scala
@@ -8,6 +8,7 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.structure.ScenarioContext
 import io.gatling.core.util.NameGen
 
+@deprecated("Use GenericRedisActionBuilder with RedisCommand.Sets.SAdd instead", "picatinny 0.x")
 case class RedisSaddAction(
     ctx: ScenarioContext,
     next: Action,

--- a/src/main/scala/org/galaxio/gatling/redis/RedisSremAction.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisSremAction.scala
@@ -8,6 +8,7 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.structure.ScenarioContext
 import io.gatling.core.util.NameGen
 
+@deprecated("Use GenericRedisActionBuilder with RedisCommand.Sets.SRem instead", "picatinny 0.x")
 case class RedisSremAction(
     ctx: ScenarioContext,
     next: Action,

--- a/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
@@ -16,7 +16,7 @@ class RedisActionBuilderSpec extends AnyWordSpec with Matchers {
   private val redisValue: Expression[String]       = "value"
   private val redisValues: Seq[Expression[String]] = Seq("values")
 
-  "RedisActionBuilder syntax" should {
+  "Legacy RedisActionBuilder syntax" should {
     "add DEL builders to Gatling chains" in {
       exec(redisPool.DEL(redisKey, redisKeys: _*)).actionBuilders should contain(
         RedisDelActionBuilder(redisPool, redisKey, redisKeys),
@@ -33,6 +33,190 @@ class RedisActionBuilderSpec extends AnyWordSpec with Matchers {
       exec(redisPool.SADD(redisKey, redisValue, redisValues: _*)).actionBuilders should contain(
         RedisSaddActionBuilder(redisPool, redisKey, redisValue, redisValues),
       )
+    }
+  }
+
+  "String operations" should {
+    "add GET builder to Gatling chains" in {
+      val chain = exec(redisPool.GET(redisKey))
+      chain.actionBuilders should have size 1
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add SET builder to Gatling chains" in {
+      val chain = exec(redisPool.SET(redisKey, redisValue))
+      chain.actionBuilders should have size 1
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add GETSET builder to Gatling chains" in {
+      val chain = exec(redisPool.GETSET(redisKey, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add SETNX builder to Gatling chains" in {
+      val chain = exec(redisPool.SETNX(redisKey, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add SETEX builder to Gatling chains" in {
+      val expiry: Expression[Any] = "60"
+      val chain                   = exec(redisPool.SETEX(redisKey, expiry, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add MGET builder to Gatling chains" in {
+      val chain = exec(redisPool.MGET(redisKey, redisKeys: _*))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add INCR builder to Gatling chains" in {
+      val chain = exec(redisPool.INCR(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add DECR builder to Gatling chains" in {
+      val chain = exec(redisPool.DECR(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add INCRBY builder to Gatling chains" in {
+      val increment: Expression[Any] = "5"
+      val chain                      = exec(redisPool.INCRBY(redisKey, increment))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add DECRBY builder to Gatling chains" in {
+      val decrement: Expression[Any] = "3"
+      val chain                      = exec(redisPool.DECRBY(redisKey, decrement))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+  }
+
+  "Hash operations" should {
+    "add HGET builder to Gatling chains" in {
+      val field: Expression[Any] = "field1"
+      val chain                  = exec(redisPool.HGET(redisKey, field))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add HSET builder to Gatling chains" in {
+      val field: Expression[Any] = "field1"
+      val chain                  = exec(redisPool.HSET(redisKey, field, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add HDEL builder to Gatling chains" in {
+      val field: Expression[Any] = "field1"
+      val chain                  = exec(redisPool.HDEL(redisKey, field))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add HGETALL builder to Gatling chains" in {
+      val chain = exec(redisPool.HGETALL(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add HMGET builder to Gatling chains" in {
+      val field1: Expression[Any] = "f1"
+      val field2: Expression[Any] = "f2"
+      val chain                   = exec(redisPool.HMGET(redisKey, field1, field2))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+  }
+
+  "List operations" should {
+    "add LPUSH builder to Gatling chains" in {
+      val chain = exec(redisPool.LPUSH(redisKey, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add RPUSH builder to Gatling chains" in {
+      val chain = exec(redisPool.RPUSH(redisKey, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add LPOP builder to Gatling chains" in {
+      val chain = exec(redisPool.LPOP(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add RPOP builder to Gatling chains" in {
+      val chain = exec(redisPool.RPOP(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add LRANGE builder to Gatling chains" in {
+      val start: Expression[Any] = "0"
+      val end: Expression[Any]   = "10"
+      val chain                  = exec(redisPool.LRANGE(redisKey, start, end))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add LLEN builder to Gatling chains" in {
+      val chain = exec(redisPool.LLEN(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+  }
+
+  "Key operations" should {
+    "add EXISTS builder to Gatling chains" in {
+      val chain = exec(redisPool.EXISTS(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add EXPIRE builder to Gatling chains" in {
+      val ttl: Expression[Any] = "300"
+      val chain                = exec(redisPool.EXPIRE(redisKey, ttl))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add TTL builder to Gatling chains" in {
+      val chain = exec(redisPool.TTL(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add KEYS builder to Gatling chains" in {
+      val pattern: Expression[Any] = "user:*"
+      val chain                    = exec(redisPool.KEYS(pattern))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+  }
+
+  "Set operations" should {
+    "add SMEMBERS builder to Gatling chains" in {
+      val chain = exec(redisPool.SMEMBERS(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add SISMEMBER builder to Gatling chains" in {
+      val chain = exec(redisPool.SISMEMBER(redisKey, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add SCARD builder to Gatling chains" in {
+      val chain = exec(redisPool.SCARD(redisKey))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+  }
+
+  "GenericRedisActionBuilder" should {
+    "support saveAs chaining" in {
+      val builder = redisPool.GET(redisKey).saveAs("result")
+      builder shouldBe a[GenericRedisActionBuilder]
+      builder.saveAsVar shouldBe Some("result")
+    }
+
+    "support requestName chaining" in {
+      val builder = redisPool.GET(redisKey).requestName("redis-get")
+      builder shouldBe a[GenericRedisActionBuilder]
+      builder.reqName shouldBe Some("redis-get")
+    }
+
+    "support combined saveAs and requestName chaining" in {
+      val builder = redisPool.GET(redisKey).saveAs("result").requestName("redis-get")
+      builder.saveAsVar shouldBe Some("result")
+      builder.reqName shouldBe Some("redis-get")
     }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/redis/RedisIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/redis/RedisIntegrationSpec.scala
@@ -1,0 +1,168 @@
+package org.galaxio.gatling.redis
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import com.redis.RedisClientPool
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.containers.wait.strategy.Wait
+
+class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  override val container: GenericContainer = GenericContainer(
+    dockerImage = "redis:7-alpine",
+    exposedPorts = Seq(6379),
+    waitStrategy = Wait.forListeningPort(),
+  )
+
+  private lazy val redisPool = new RedisClientPool("localhost", container.mappedPort(6379))
+
+  private def exec(cmd: RedisCommand): Option[Any] =
+    redisPool.withClient(client => cmd.execute(client))
+
+  "String commands" should {
+    "SET and GET a value" in {
+      exec(RedisCommand.Strings.Set("test:str:1", "hello")) shouldBe Some(true)
+      exec(RedisCommand.Strings.Get("test:str:1")) shouldBe Some("hello")
+    }
+
+    "SETNX only when key does not exist" in {
+      exec(RedisCommand.Strings.SetNx("test:setnx:1", "first")) shouldBe Some(true)
+      exec(RedisCommand.Strings.SetNx("test:setnx:1", "second")) shouldBe Some(false)
+      exec(RedisCommand.Strings.Get("test:setnx:1")) shouldBe Some("first")
+    }
+
+    "SETEX with expiry" in {
+      exec(RedisCommand.Strings.SetEx("test:setex:1", 10, "expiring")) shouldBe Some(true)
+      val ttl = exec(RedisCommand.Keys.Ttl("test:setex:1")).map(_.asInstanceOf[Long])
+      ttl.exists(v => v > 0 && v <= 10) shouldBe true
+    }
+
+    "GETSET returns old value" in {
+      exec(RedisCommand.Strings.Set("test:getset:1", "old"))
+      exec(RedisCommand.Strings.GetSet("test:getset:1", "new")) shouldBe Some("old")
+      exec(RedisCommand.Strings.Get("test:getset:1")) shouldBe Some("new")
+    }
+
+    "MGET returns multiple values" in {
+      exec(RedisCommand.Strings.Set("test:mget:1", "a"))
+      exec(RedisCommand.Strings.Set("test:mget:2", "b"))
+      exec(RedisCommand.Strings.MGet("test:mget:1", Seq("test:mget:2"))) shouldBe
+        Some(List(Some("a"), Some("b")))
+    }
+
+    "MSET sets multiple values" in {
+      exec(RedisCommand.Strings.MSet(Seq("test:mset:1" -> "x", "test:mset:2" -> "y"))) shouldBe Some(true)
+      exec(RedisCommand.Strings.Get("test:mset:1")) shouldBe Some("x")
+      exec(RedisCommand.Strings.Get("test:mset:2")) shouldBe Some("y")
+    }
+  }
+
+  "Counter commands" should {
+    "INCR and DECR" in {
+      exec(RedisCommand.Strings.Set("test:counter:1", "10"))
+      exec(RedisCommand.Strings.Incr("test:counter:1")) shouldBe Some(11L)
+      exec(RedisCommand.Strings.Decr("test:counter:1")) shouldBe Some(10L)
+    }
+
+    "INCRBY and DECRBY" in {
+      exec(RedisCommand.Strings.Set("test:counter:2", "100"))
+      exec(RedisCommand.Strings.IncrBy("test:counter:2", 25)) shouldBe Some(125L)
+      exec(RedisCommand.Strings.DecrBy("test:counter:2", 50)) shouldBe Some(75L)
+    }
+  }
+
+  "Hash commands" should {
+    "HSET and HGET" in {
+      exec(RedisCommand.Hashes.HSet("test:hash:1", "field1", "value1")) shouldBe Some(true)
+      exec(RedisCommand.Hashes.HGet("test:hash:1", "field1")) shouldBe Some("value1")
+    }
+
+    "HDEL removes field" in {
+      exec(RedisCommand.Hashes.HSet("test:hash:2", "f1", "v1"))
+      exec(RedisCommand.Hashes.HDel("test:hash:2", "f1", Seq.empty)) shouldBe Some(1L)
+      exec(RedisCommand.Hashes.HGet("test:hash:2", "f1")) shouldBe None
+    }
+
+    "HGETALL returns all fields" in {
+      exec(RedisCommand.Hashes.HSet("test:hash:3", "a", "1"))
+      exec(RedisCommand.Hashes.HSet("test:hash:3", "b", "2"))
+      exec(RedisCommand.Hashes.HGetAll("test:hash:3")) shouldBe Some(Map("a" -> "1", "b" -> "2"))
+    }
+
+    "HMSET and HMGET" in {
+      exec(RedisCommand.Hashes.HMSet("test:hash:4", Seq("x" -> "10", "y" -> "20"))) shouldBe Some(true)
+      exec(RedisCommand.Hashes.HMGet("test:hash:4", Seq("x", "y"))) shouldBe Some(Map("x" -> "10", "y" -> "20"))
+    }
+  }
+
+  "List commands" should {
+    "LPUSH, RPUSH and LRANGE" in {
+      exec(RedisCommand.Lists.LPush("test:list:1", "a", Seq("b")))
+      exec(RedisCommand.Lists.RPush("test:list:1", "c", Seq.empty))
+      val result = exec(RedisCommand.Lists.LRange("test:list:1", 0, -1))
+        .map(_.asInstanceOf[List[Option[String]]].flatten)
+      result shouldBe Some(List("b", "a", "c"))
+    }
+
+    "LPOP and RPOP" in {
+      redisPool.withClient(_.lpush("test:list:2", "a", "b", "c"))
+      exec(RedisCommand.Lists.LPop("test:list:2")) shouldBe Some("c")
+      exec(RedisCommand.Lists.RPop("test:list:2")) shouldBe Some("a")
+    }
+
+    "LLEN returns list length" in {
+      redisPool.withClient(_.lpush("test:list:3", "a", "b", "c"))
+      exec(RedisCommand.Lists.LLen("test:list:3")) shouldBe Some(3L)
+    }
+  }
+
+  "Key commands" should {
+    "DEL removes key" in {
+      redisPool.withClient(_.set("test:del:1", "val"))
+      exec(RedisCommand.Keys.Del("test:del:1", Seq.empty)) shouldBe Some(1L)
+      exec(RedisCommand.Keys.Exists("test:del:1")) shouldBe Some(false)
+    }
+
+    "EXISTS checks key existence" in {
+      redisPool.withClient(_.set("test:exists:1", "val"))
+      exec(RedisCommand.Keys.Exists("test:exists:1")) shouldBe Some(true)
+      exec(RedisCommand.Keys.Exists("test:exists:nonexistent")) shouldBe Some(false)
+    }
+
+    "EXPIRE and TTL" in {
+      redisPool.withClient(_.set("test:expire:1", "val"))
+      exec(RedisCommand.Keys.Expire("test:expire:1", 60)) shouldBe Some(true)
+      val ttl = exec(RedisCommand.Keys.Ttl("test:expire:1")).map(_.asInstanceOf[Long])
+      ttl.exists(v => v > 0 && v <= 60) shouldBe true
+    }
+
+    "KEYS returns matching keys" in {
+      redisPool.withClient(_.set("test:keys:pattern:a", "1"))
+      redisPool.withClient(_.set("test:keys:pattern:b", "2"))
+      val result = exec(RedisCommand.Keys.KeysPattern("test:keys:pattern:*"))
+        .map(_.asInstanceOf[List[Option[String]]].flatten.sorted)
+      result shouldBe Some(List("test:keys:pattern:a", "test:keys:pattern:b"))
+    }
+  }
+
+  "Set commands" should {
+    "SADD, SREM and SMEMBERS" in {
+      exec(RedisCommand.Sets.SAdd("test:set:1", "a", Seq("b", "c"))) shouldBe Some(3L)
+      exec(RedisCommand.Sets.SRem("test:set:1", "b", Seq.empty)) shouldBe Some(1L)
+      val result = exec(RedisCommand.Sets.SMembers("test:set:1"))
+        .map(_.asInstanceOf[Set[Option[String]]].flatten)
+      result shouldBe Some(Set("a", "c"))
+    }
+
+    "SISMEMBER checks membership" in {
+      redisPool.withClient(_.sadd("test:set:2", "x", "y"))
+      exec(RedisCommand.Sets.SIsMember("test:set:2", "x")) shouldBe Some(true)
+      exec(RedisCommand.Sets.SIsMember("test:set:2", "z")) shouldBe Some(false)
+    }
+
+    "SCARD returns set cardinality" in {
+      redisPool.withClient(_.sadd("test:set:3", "a", "b", "c"))
+      exec(RedisCommand.Sets.SCard("test:set:3")) shouldBe Some(3L)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Expanded Redis module from 3 commands (DEL, SADD, SREM) to 30 commands covering String, Hash, List, Key, Counter, and Set operations
- Added `saveAs()` to store Redis response in Gatling session variables
- Added `requestName()` to enable Gatling stats tracking (response times) for Redis operations
- Introduced generic `RedisAction` + `RedisCommand` sealed trait, replacing per-command class duplication
- Full Java/Kotlin API via `RedisGenericActionBuilder` with fluent `saveAs`/`requestName` chaining
- Added direct `com.redis.RedisClientPool` constructor in Java wrapper (avoids reflection when possible)
- Old DEL/SADD/SREM API preserved and marked `@deprecated` — 100% backward compatible

### New commands by category

| Category | Commands |
|----------|----------|
| String | GET, SET, MGET, MSET, GETSET, SETNX, SETEX |
| Hash | HGET, HSET, HDEL, HGETALL, HMSET, HMGET |
| List | LPUSH, RPUSH, LPOP, RPOP, LRANGE, LLEN |
| Key | EXISTS, EXPIRE, TTL, KEYS |
| Counter | INCR, DECR, INCRBY, DECRBY |
| Set | SMEMBERS, SISMEMBER, SCARD |

### Usage example (Scala)

```scala
val redisPool = new RedisClientPool("localhost", 6379)

exec(redisPool.GET("myKey").saveAs("result").requestName("redis-get"))
exec(redisPool.SET("myKey", "myValue"))
exec(redisPool.HGETALL("myHash").saveAs("hashResult"))
exec(redisPool.INCR("counter").saveAs("count"))
```

### Usage example (Java/Kotlin)

```java
RedisClientPoolJava redis = new RedisClientPoolJava("localhost", 6379);

exec(redis.GET("myKey").saveAs("result").requestName("redis-get"));
exec(redis.HSET("hash", "field", "value"));
```

## Test plan

- [x] All 34 Redis-specific tests pass (was 3)
- [x] Full test suite: 314 tests pass, 0 failures
- [x] Legacy DEL/SADD/SREM syntax regression tested
- [x] `saveAs` and `requestName` chaining verified
- [ ] Integration test with live Redis (requires Redis instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)