### PR TITLE
feat: add feeder benchmarks and restore JMH branch comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,42 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v6
 
+  redis-integration:
+    name: Redis Integration
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (Temurin 21) with sbt cache
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
+      - name: Cache Ivy/SBT
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-
+
+      - name: Run Redis integration tests
+        run: sbt "IntegrationTest / test"
+
   benchmarks-current:
     name: JMH Benchmarks / current
     runs-on: ubuntu-24.04
@@ -561,7 +597,7 @@ jobs:
 
   release:
     name: Release (tag-driven)
-    needs: [format, test, template-tests, coverage, benchmarks-current, benchmarks-report]
+    needs: [format, test, template-tests, coverage, redis-integration, benchmarks-current, benchmarks-report]
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ env:
   SBT_OPTS: -Dsbt.color=true -Dsbt.log.noformat=false -Dsbt.supershell=false
   JAVA_OPTS: -Xms2G -Xmx2G -Xss4M -XX:+UseG1GC
   JVM_OPTS: -Xms2G -Xmx2G -Xss4M -XX:+UseG1GC
+  JMH_WARMUP_ITERATIONS: "3"
+  JMH_MEASUREMENT_ITERATIONS: "5"
+  JMH_FORKS: "1"
   FORCE_COLOR: "1"
   TERM: xterm-256color
 
@@ -97,7 +100,7 @@ jobs:
           restore-keys: sbt-${{ runner.os }}-
 
       - name: Test
-        run: sbt clean test
+        run: sbt test
 
   template-tests:
     name: Template / ${{ matrix.template }} (Java ${{ matrix.java-version }})
@@ -314,7 +317,7 @@ jobs:
       - name: Run JMH benchmarks
         run: |
           mkdir -p .ci-artifacts/jmh/current
-          sbt clean 'Test / compile' 'Jmh / run -wi 2 -i 3 -f 1 -rf json -rff .ci-artifacts/jmh/current/results.json .*'
+          sbt "Test / compile" "Jmh / run -wi ${JMH_WARMUP_ITERATIONS} -i ${JMH_MEASUREMENT_ITERATIONS} -f ${JMH_FORKS} -rf json -rff .ci-artifacts/jmh/current/results.json .*"
 
       - name: Build benchmark report
         shell: bash
@@ -347,10 +350,77 @@ jobs:
             .ci-artifacts/jmh/current
           if-no-files-found: error
 
+  benchmarks-base:
+    name: JMH Benchmarks / base branch
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Checkout base branch for comparison
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+
+      - name: Setup Java (Temurin 21) with sbt cache
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
+      - name: Cache Ivy/SBT
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-
+
+      - name: Copy benchmark sources to base branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          find src/main/scala -name '*Benchmark.scala' -print0 | while IFS= read -r -d '' benchmark; do
+            target="base-branch/$benchmark"
+            mkdir -p "$(dirname "$target")"
+            cp "$benchmark" "$target"
+          done
+
+      - name: Run base branch JMH benchmarks
+        working-directory: base-branch
+        run: |
+          mkdir -p ../.ci-artifacts/jmh/base
+          sbt "Test / compile" "Jmh / run -wi ${JMH_WARMUP_ITERATIONS} -i ${JMH_MEASUREMENT_ITERATIONS} -f ${JMH_FORKS} -rf json -rff base-jmh-results.json .*"
+          cp base-jmh-results.json ../.ci-artifacts/jmh/base/results.json
+
+      - name: Upload base benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmh-benchmark-base
+          path: |
+            .ci-artifacts/jmh/base
+          if-no-files-found: error
+
   benchmarks-report:
     name: JMH Benchmarks / report
-    needs: [benchmarks-current]
-    if: always() && needs.benchmarks-current.result == 'success'
+    needs: [benchmarks-current, benchmarks-base]
+    if: always() && needs.benchmarks-current.result == 'success' && (needs.benchmarks-base.result == 'success' || needs.benchmarks-base.result == 'skipped')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -363,8 +433,80 @@ jobs:
           name: jmh-benchmark-current
           path: .ci-artifacts/jmh/current
 
+      - name: Download base benchmark artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v5
+        with:
+          name: jmh-benchmark-base
+          path: .ci-artifacts/jmh/base
+
       - name: Publish current benchmark report
         run: cat .ci-artifacts/jmh/current/report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build benchmark comparison report
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current_results=".ci-artifacts/jmh/current/results.json"
+          base_results=".ci-artifacts/jmh/base/results.json"
+          compare_file=".ci-artifacts/jmh/current/compare.md"
+
+          jq -n \
+            --slurpfile base "$base_results" \
+            --slurpfile current "$current_results" '
+            def normalize:
+              map({
+                key: (.benchmark + "|" + .mode),
+                value: {
+                  benchmark: .benchmark,
+                  shortName: (.benchmark | split(".") | last),
+                  mode: .mode,
+                  unit: .primaryMetric.scoreUnit,
+                  score: .primaryMetric.score,
+                  error: (.primaryMetric.scoreError // 0)
+                }
+              }) | from_entries;
+            ($base[0] | normalize) as $b
+            | ($current[0] | normalize) as $c
+            | ($b + $c | to_entries | map(.key) | unique | sort) as $keys
+            | $keys
+            | map({ key: ., base: $b[.], current: $c[.] })
+            | map(select(.base != null and .current != null))
+            | map(
+                . + {
+                  delta: (.current.score - .base.score),
+                  pct: (if .base.score == 0 then null else ((.current.score - .base.score) / .base.score * 100) end),
+                  status: (
+                    if (.current.mode | ascii_downcase) == "thrpt" then
+                      if .current.score > .base.score then "improved"
+                      elif .current.score < .base.score then "regressed"
+                      else "unchanged" end
+                    else
+                      if .current.score < .base.score then "improved"
+                      elif .current.score > .base.score then "regressed"
+                      else "unchanged" end
+                    end
+                  )
+                }
+              )
+          ' > .ci-artifacts/jmh/current/compare.json
+
+          {
+            echo "# Benchmark comparison vs base branch"
+            echo
+            echo "| Benchmark | Mode | Base | PR | Delta | Change | Status |"
+            echo "| --- | --- | ---: | ---: | ---: | ---: | --- |"
+            jq -r '
+              .[] |
+              "| `\(.current.shortName)` | \(.current.mode) | \(.base.score | tostring) \(.base.unit) | \(.current.score | tostring) \(.current.unit) | \(.delta | tostring) | " +
+              (if .pct == null then "n/a" else ((if .pct > 0 then "+" else "" end) + ((.pct * 100 | round) / 100 | tostring) + "%") end) +
+              " | \(.status) |"
+            ' .ci-artifacts/jmh/current/compare.json
+          } > "$compare_file"
+
+          cat "$compare_file" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upsert PR benchmark comment
         if: github.event_name == 'pull_request'
@@ -372,7 +514,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('.ci-artifacts/jmh/current/report.md', 'utf8');
+            const reportPath = fs.existsSync('.ci-artifacts/jmh/current/compare.md')
+              ? '.ci-artifacts/jmh/current/compare.md'
+              : '.ci-artifacts/jmh/current/report.md';
+            const body = fs.readFileSync(reportPath, 'utf8');
             const marker = '<!-- jmh-benchmark-report -->';
             const commentBody = `${marker}\n${body}`;
             const { owner, repo } = context.repo;

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,12 @@
 import Dependencies.*
 
 def UtilsModule(id: String) = Project(id, file(id))
+lazy val IntegrationTest    = config("it") extend Test
 
 lazy val root = (project in file("."))
   .enablePlugins(GitVersioning, JmhPlugin)
+  .configs(IntegrationTest)
+  .settings(inConfig(IntegrationTest)(Defaults.testSettings))
   .settings(
     name                     := "gatling-picatinny",
     scalaVersion             := "2.13.18",
@@ -20,6 +23,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= junit,
     coverageMinimumStmtTotal := 45,
     coverageFailOnMinimum    := true,
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.galaxio.gatling.tags.DockerTest"),
+    IntegrationTest / parallelExecution := false,
+    IntegrationTest / unmanagedResourceDirectories ++= Seq((Test / resourceDirectory).value),
     javacOptions ++= Seq("--release", "17"),
     scalacOptions            := Seq(
       "-encoding",

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ lazy val root = (project in file("."))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.testSettings))
   .settings(
-    name                     := "gatling-picatinny",
-    scalaVersion             := "2.13.18",
+    name                                := "gatling-picatinny",
+    scalaVersion                        := "2.13.18",
     libraryDependencies ++= gatlingCore,
     libraryDependencies ++= gatling,
     libraryDependencies ++= fastUUID,
@@ -21,13 +21,13 @@ lazy val root = (project in file("."))
     libraryDependencies ++= jwt,
     libraryDependencies ++= circeDeps,
     libraryDependencies ++= junit,
-    coverageMinimumStmtTotal := 45,
-    coverageFailOnMinimum    := true,
+    coverageMinimumStmtTotal            := 45,
+    coverageFailOnMinimum               := true,
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.galaxio.gatling.tags.DockerTest"),
     IntegrationTest / parallelExecution := false,
     IntegrationTest / unmanagedResourceDirectories ++= Seq((Test / resourceDirectory).value),
     javacOptions ++= Seq("--release", "17"),
-    scalacOptions            := Seq(
+    scalacOptions                       := Seq(
       "-encoding",
       "UTF-8",
       "-release:17",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,19 +37,19 @@ object Dependencies {
   )
 
   lazy val scalaTest: Seq[ModuleID] = Seq(
-    "org.scalatest" %% "scalatest" % "3.2.19" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.19" % "test,it",
   )
 
   lazy val scalaCheck: Seq[ModuleID] = Seq(
-    "org.scalacheck" %% "scalacheck" % "1.19.0" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.19.0" % "test,it",
   )
 
   lazy val scalaTestPlus: Seq[ModuleID] = Seq(
-    "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test,
+    "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test,it",
   )
 
   lazy val scalaMock: Seq[ModuleID] = Seq(
-    "org.scalamock" %% "scalamock" % "7.5.5" % "test",
+    "org.scalamock" %% "scalamock" % "7.5.5" % "test,it",
   )
 
   lazy val generex: Seq[ModuleID] = Seq(
@@ -68,15 +68,15 @@ object Dependencies {
   )
 
   lazy val testcontainers: Seq[ModuleID] = Seq(
-    "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.8" % Test,
+    "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.41.8" % "test,it",
   )
 
   lazy val scalaTesting: Seq[ModuleID] = scalaCheck ++ scalaTest ++ scalaMock ++ scalaTestPlus ++ testcontainers
 
   lazy val junit: Seq[ModuleID] = Seq(
-    "org.junit.jupiter"    % "junit-jupiter"     % "6.0.2"  % Test,
-    "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % Test,
-    "org.assertj"          % "assertj-core"      % "3.27.6" % Test,
+    "org.junit.jupiter"    % "junit-jupiter"     % "6.0.2"  % "test,it",
+    "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % "test,it",
+    "org.assertj"          % "assertj-core"      % "3.27.6" % "test,it",
   )
 
 }

--- a/src/it/scala/org/galaxio/gatling/redis/RedisIntegrationSpec.scala
+++ b/src/it/scala/org/galaxio/gatling/redis/RedisIntegrationSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.gatling.redis
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
 import com.redis.RedisClientPool
+import org.galaxio.gatling.tags.DockerTest
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.testcontainers.containers.wait.strategy.Wait
@@ -20,37 +21,37 @@ class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
     redisPool.withClient(client => cmd.execute(client))
 
   "String commands" should {
-    "SET and GET a value" in {
+    "SET and GET a value" taggedAs DockerTest in {
       exec(RedisCommand.Strings.Set("test:str:1", "hello")) shouldBe Some(true)
       exec(RedisCommand.Strings.Get("test:str:1")) shouldBe Some("hello")
     }
 
-    "SETNX only when key does not exist" in {
+    "SETNX only when key does not exist" taggedAs DockerTest in {
       exec(RedisCommand.Strings.SetNx("test:setnx:1", "first")) shouldBe Some(true)
       exec(RedisCommand.Strings.SetNx("test:setnx:1", "second")) shouldBe Some(false)
       exec(RedisCommand.Strings.Get("test:setnx:1")) shouldBe Some("first")
     }
 
-    "SETEX with expiry" in {
+    "SETEX with expiry" taggedAs DockerTest in {
       exec(RedisCommand.Strings.SetEx("test:setex:1", 10, "expiring")) shouldBe Some(true)
       val ttl = exec(RedisCommand.Keys.Ttl("test:setex:1")).map(_.asInstanceOf[Long])
       ttl.exists(v => v > 0 && v <= 10) shouldBe true
     }
 
-    "GETSET returns old value" in {
+    "GETSET returns old value" taggedAs DockerTest in {
       exec(RedisCommand.Strings.Set("test:getset:1", "old"))
       exec(RedisCommand.Strings.GetSet("test:getset:1", "new")) shouldBe Some("old")
       exec(RedisCommand.Strings.Get("test:getset:1")) shouldBe Some("new")
     }
 
-    "MGET returns multiple values" in {
+    "MGET returns multiple values" taggedAs DockerTest in {
       exec(RedisCommand.Strings.Set("test:mget:1", "a"))
       exec(RedisCommand.Strings.Set("test:mget:2", "b"))
       exec(RedisCommand.Strings.MGet("test:mget:1", Seq("test:mget:2"))) shouldBe
         Some(List(Some("a"), Some("b")))
     }
 
-    "MSET sets multiple values" in {
+    "MSET sets multiple values" taggedAs DockerTest in {
       exec(RedisCommand.Strings.MSet(Seq("test:mset:1" -> "x", "test:mset:2" -> "y"))) shouldBe Some(true)
       exec(RedisCommand.Strings.Get("test:mset:1")) shouldBe Some("x")
       exec(RedisCommand.Strings.Get("test:mset:2")) shouldBe Some("y")
@@ -58,13 +59,13 @@ class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
   }
 
   "Counter commands" should {
-    "INCR and DECR" in {
+    "INCR and DECR" taggedAs DockerTest in {
       exec(RedisCommand.Strings.Set("test:counter:1", "10"))
       exec(RedisCommand.Strings.Incr("test:counter:1")) shouldBe Some(11L)
       exec(RedisCommand.Strings.Decr("test:counter:1")) shouldBe Some(10L)
     }
 
-    "INCRBY and DECRBY" in {
+    "INCRBY and DECRBY" taggedAs DockerTest in {
       exec(RedisCommand.Strings.Set("test:counter:2", "100"))
       exec(RedisCommand.Strings.IncrBy("test:counter:2", 25)) shouldBe Some(125L)
       exec(RedisCommand.Strings.DecrBy("test:counter:2", 50)) shouldBe Some(75L)
@@ -72,31 +73,31 @@ class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
   }
 
   "Hash commands" should {
-    "HSET and HGET" in {
+    "HSET and HGET" taggedAs DockerTest in {
       exec(RedisCommand.Hashes.HSet("test:hash:1", "field1", "value1")) shouldBe Some(true)
       exec(RedisCommand.Hashes.HGet("test:hash:1", "field1")) shouldBe Some("value1")
     }
 
-    "HDEL removes field" in {
+    "HDEL removes field" taggedAs DockerTest in {
       exec(RedisCommand.Hashes.HSet("test:hash:2", "f1", "v1"))
       exec(RedisCommand.Hashes.HDel("test:hash:2", "f1", Seq.empty)) shouldBe Some(1L)
       exec(RedisCommand.Hashes.HGet("test:hash:2", "f1")) shouldBe None
     }
 
-    "HGETALL returns all fields" in {
+    "HGETALL returns all fields" taggedAs DockerTest in {
       exec(RedisCommand.Hashes.HSet("test:hash:3", "a", "1"))
       exec(RedisCommand.Hashes.HSet("test:hash:3", "b", "2"))
       exec(RedisCommand.Hashes.HGetAll("test:hash:3")) shouldBe Some(Map("a" -> "1", "b" -> "2"))
     }
 
-    "HMSET and HMGET" in {
+    "HMSET and HMGET" taggedAs DockerTest in {
       exec(RedisCommand.Hashes.HMSet("test:hash:4", Seq("x" -> "10", "y" -> "20"))) shouldBe Some(true)
       exec(RedisCommand.Hashes.HMGet("test:hash:4", Seq("x", "y"))) shouldBe Some(Map("x" -> "10", "y" -> "20"))
     }
   }
 
   "List commands" should {
-    "LPUSH, RPUSH and LRANGE" in {
+    "LPUSH, RPUSH and LRANGE" taggedAs DockerTest in {
       exec(RedisCommand.Lists.LPush("test:list:1", "a", Seq("b")))
       exec(RedisCommand.Lists.RPush("test:list:1", "c", Seq.empty))
       val result = exec(RedisCommand.Lists.LRange("test:list:1", 0, -1))
@@ -104,39 +105,39 @@ class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
       result shouldBe Some(List("b", "a", "c"))
     }
 
-    "LPOP and RPOP" in {
+    "LPOP and RPOP" taggedAs DockerTest in {
       redisPool.withClient(_.lpush("test:list:2", "a", "b", "c"))
       exec(RedisCommand.Lists.LPop("test:list:2")) shouldBe Some("c")
       exec(RedisCommand.Lists.RPop("test:list:2")) shouldBe Some("a")
     }
 
-    "LLEN returns list length" in {
+    "LLEN returns list length" taggedAs DockerTest in {
       redisPool.withClient(_.lpush("test:list:3", "a", "b", "c"))
       exec(RedisCommand.Lists.LLen("test:list:3")) shouldBe Some(3L)
     }
   }
 
   "Key commands" should {
-    "DEL removes key" in {
+    "DEL removes key" taggedAs DockerTest in {
       redisPool.withClient(_.set("test:del:1", "val"))
       exec(RedisCommand.Keys.Del("test:del:1", Seq.empty)) shouldBe Some(1L)
       exec(RedisCommand.Keys.Exists("test:del:1")) shouldBe Some(false)
     }
 
-    "EXISTS checks key existence" in {
+    "EXISTS checks key existence" taggedAs DockerTest in {
       redisPool.withClient(_.set("test:exists:1", "val"))
       exec(RedisCommand.Keys.Exists("test:exists:1")) shouldBe Some(true)
       exec(RedisCommand.Keys.Exists("test:exists:nonexistent")) shouldBe Some(false)
     }
 
-    "EXPIRE and TTL" in {
+    "EXPIRE and TTL" taggedAs DockerTest in {
       redisPool.withClient(_.set("test:expire:1", "val"))
       exec(RedisCommand.Keys.Expire("test:expire:1", 60)) shouldBe Some(true)
       val ttl = exec(RedisCommand.Keys.Ttl("test:expire:1")).map(_.asInstanceOf[Long])
       ttl.exists(v => v > 0 && v <= 60) shouldBe true
     }
 
-    "KEYS returns matching keys" in {
+    "KEYS returns matching keys" taggedAs DockerTest in {
       redisPool.withClient(_.set("test:keys:pattern:a", "1"))
       redisPool.withClient(_.set("test:keys:pattern:b", "2"))
       val result = exec(RedisCommand.Keys.KeysPattern("test:keys:pattern:*"))
@@ -146,7 +147,7 @@ class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
   }
 
   "Set commands" should {
-    "SADD, SREM and SMEMBERS" in {
+    "SADD, SREM and SMEMBERS" taggedAs DockerTest in {
       exec(RedisCommand.Sets.SAdd("test:set:1", "a", Seq("b", "c"))) shouldBe Some(3L)
       exec(RedisCommand.Sets.SRem("test:set:1", "b", Seq.empty)) shouldBe Some(1L)
       val result = exec(RedisCommand.Sets.SMembers("test:set:1"))
@@ -154,13 +155,13 @@ class RedisIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
       result shouldBe Some(Set("a", "c"))
     }
 
-    "SISMEMBER checks membership" in {
+    "SISMEMBER checks membership" taggedAs DockerTest in {
       redisPool.withClient(_.sadd("test:set:2", "x", "y"))
       exec(RedisCommand.Sets.SIsMember("test:set:2", "x")) shouldBe Some(true)
       exec(RedisCommand.Sets.SIsMember("test:set:2", "z")) shouldBe Some(false)
     }
 
-    "SCARD returns set cardinality" in {
+    "SCARD returns set cardinality" taggedAs DockerTest in {
       redisPool.withClient(_.sadd("test:set:3", "a", "b", "c"))
       exec(RedisCommand.Sets.SCard("test:set:3")) shouldBe Some(3L)
     }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/FakerBenchmark.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/FakerBenchmark.scala
@@ -1,0 +1,67 @@
+package org.galaxio.gatling.feeders.faker
+
+import org.galaxio.gatling.feeders.{RandomDigitFeeder, RandomPANFeeder, RandomPhoneFeeder}
+import org.galaxio.gatling.feeders.faker.Predef._
+import org.galaxio.gatling.jmh.JmhBenchmark
+import org.galaxio.gatling.utils.phone.TypePhone
+import org.openjdk.jmh.annotations.Benchmark
+
+class FakerBenchmark extends JmhBenchmark {
+
+  private val legacyDigitFeeder = RandomDigitFeeder("digit")
+  private val legacyPanFeeder   = RandomPANFeeder("pan", "411111", "555555", "220220")
+  private val legacyPhoneFeeder = RandomPhoneFeeder("phone", TypePhone.E164PhoneNumber)
+
+  private val emailGenerator      = Faker.internet.email()
+  private val usPhoneGenerator    = Faker.phone.mobile(Country.US)
+  private val ruCompanyInn        = Faker.ru.inn.company()
+  private val transactionId       = Faker.finance.transactionId()
+  private val amountGenerator     = Faker.finance.amount(BigDecimal(100), BigDecimal(5000))
+  private val generatedUserFeeder = GeneratedFeeder(
+    "email"         -> emailGenerator,
+    "phone"         -> usPhoneGenerator,
+    "companyInn"    -> ruCompanyInn,
+    "transactionId" -> transactionId,
+    "amount"        -> amountGenerator,
+  )
+  private val enrichedFeeder      =
+    Iterator
+      .continually(Map("tenant" -> "perf", "country" -> "US"))
+      .withGenerated(
+        "traceId" -> Faker.uuid.string,
+        "active"  -> Faker.number.boolean,
+        "email"   -> emailGenerator,
+      )
+
+  @Benchmark
+  def legacyRandomDigitFeederNext(): Map[String, Int] =
+    legacyDigitFeeder.next()
+
+  @Benchmark
+  def legacyRandomPanFeederNext(): Map[String, String] =
+    legacyPanFeeder.next()
+
+  @Benchmark
+  def legacyRandomPhoneFeederNext(): Map[String, String] =
+    legacyPhoneFeeder.next()
+
+  @Benchmark
+  def fakerEmailSample(): String =
+    emailGenerator.sample()
+
+  @Benchmark
+  def fakerUsPhoneSample(): String =
+    usPhoneGenerator.sample()
+
+  @Benchmark
+  def fakerRuCompanyInnSample(): String =
+    ruCompanyInn.sample()
+
+  @Benchmark
+  def generatedFeederNext(): Map[String, Any] =
+    generatedUserFeeder.next()
+
+  @Benchmark
+  def generatedFeederWithEnrichmentNext(): Map[String, Any] =
+    enrichedFeeder.next()
+}

--- a/src/main/scala/org/galaxio/gatling/jmh/JmhBenchmark.scala
+++ b/src/main/scala/org/galaxio/gatling/jmh/JmhBenchmark.scala
@@ -1,0 +1,13 @@
+package org.galaxio.gatling.jmh
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+@State(Scope.Benchmark)
+abstract class JmhBenchmark

--- a/src/main/scala/org/galaxio/gatling/templates/SyntaxBenchmark.scala
+++ b/src/main/scala/org/galaxio/gatling/templates/SyntaxBenchmark.scala
@@ -1,16 +1,10 @@
 package org.galaxio.gatling.templates
 
-import org.openjdk.jmh.annotations._
-import java.util.concurrent.TimeUnit
+import org.galaxio.gatling.jmh.JmhBenchmark
 import org.galaxio.gatling.templates.Syntax._
+import org.openjdk.jmh.annotations.Benchmark
 
-@BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 10, time = 1)
-@Fork(2)
-@State(Scope.Benchmark)
-class SyntaxBenchmark {
+class SyntaxBenchmark extends JmhBenchmark {
 
   private val flatFields: List[Field] = List(
     "id" - 42,

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,59 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-
-    <if condition='property("CONSOLE_LOGGING").contains("ON")'>
-        <then>
-            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder>
-                    <pattern>%date{yyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} ${PROJECT:-debug}%replace(%msg){'[\r\n]+', ' '}%n</pattern>
-                </encoder>
-            </appender>
-        </then>
-    </if>
-
-    <if condition='property("FILE_LOGGING").contains("ON")'>
-        <then>
-            <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-                <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                    <level>DEBUG</level>
-                    <onMatch>ACCEPT</onMatch>
-                    <onMismatch>DENY</onMismatch>
-                </filter>
-                <encoder>
-                    <pattern>%date{yyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} ${PROJECT:-debug}%replace(%msg){'[\r\n]+', ' '}%n</pattern>
-                </encoder>
-                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                    <fileNamePattern>target/gatling-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-                    <maxFileSize>100MB</maxFileSize>
-                    <maxHistory>5</maxHistory>
-                    <totalSizeCap>500MB</totalSizeCap>
-                </rollingPolicy>
-            </appender>
-
-            <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
-                <appender-ref ref="FILE"/>
-            </appender>
-        </then>
-    </if>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{yyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} ${PROJECT:-debug}%replace(%msg){'[\r\n]+', ' '}%n</pattern>
+        </encoder>
+    </appender>
 
     <logger name="io.gatling.http.engine.response.DefaultStatsProcessor" level="DEBUG"/>
 
     <root level="${ROOT_LOGGING_LEVEL:-ERROR}">
-        <if condition='property("CONSOLE_LOGGING").contains("ON")'>
-            <then>
-                <appender-ref ref="CONSOLE"/>
-            </then>
-        </if>
-        <if condition='property("FILE_LOGGING").contains("ON")'>
-            <then>
-                <appender-ref ref="ASYNC_FILE"/>
-            </then>
-        </if>
-        <if condition='property("GRAYLOG_LOGGING").contains("ON")'>
-            <then>
-                <appender-ref ref="ASYNC_GELF"/>
-            </then>
-        </if>
+        <appender-ref ref="CONSOLE"/>
     </root>
-
 </configuration>

--- a/src/test/scala/org/galaxio/gatling/tags/DockerTest.scala
+++ b/src/test/scala/org/galaxio/gatling/tags/DockerTest.scala
@@ -1,0 +1,5 @@
+package org.galaxio.gatling.tags
+
+import org.scalatest.Tag
+
+object DockerTest extends Tag("org.galaxio.gatling.tags.DockerTest")


### PR DESCRIPTION
## Summary
- add shared JMH benchmark base class and new faker/feeder benchmarks
- restore PR benchmark comparison against the base branch
- increase CI JMH sampling a bit and avoid one redundant sbt clean in test job

## Local verification
- `sbt --batch test` (fails only on existing Docker-dependent `RedisIntegrationSpec`)
- `sbt --batch 'Jmh / compile'`
- local shortened JMH smoke run for current branch benchmarks