### PR TITLE
fix(ci): resolve template-tests publishM2 cache collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
+          cache: false
 
       - name: Install galaxio CLI from main
         run: go install github.com/galax-io/galaxio-cli/cmd/galaxio@main
@@ -163,7 +164,7 @@ jobs:
           restore-keys: m2-${{ runner.os }}-
 
       - name: Publish local Picatinny artifact
-        run: sbt 'set ThisBuild / version := "0.0.0-ci-local"' publishLocal publishM2
+        run: sbt 'set ThisBuild / version := "0.0.0-ci-local"' 'set ThisBuild / publishM2Configuration := publishM2Configuration.value.withOverwrite(true)' publishLocal publishM2
 
       - name: Java Maven Gatling project from template main
         if: matrix.template == 'java-maven'


### PR DESCRIPTION
## Summary

- Enable `publishM2` overwrite in template-tests CI job — cached M2 repo from prior runs contains `0.0.0-ci-local` artifact, causing `publishM2` to fail with "destination file exists and overwriting is disabled"
- Disable Go module caching in `setup-go` step — this Scala project has no `go.mod`, producing cache restore warnings

Fixes [CI run #25889257811](https://github.com/galax-io/gatling-picatinny/actions/runs/25889257811)

## Test plan

- [ ] Verify template-tests jobs pass in CI
- [ ] Verify no Go cache warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)