### PR TITLE
fix(ci): remove benchmark jobs from release needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,7 +598,7 @@ jobs:
 
   release:
     name: Release
-    needs: [format, test, template-tests, coverage, redis-integration, benchmarks-current, benchmarks-report]
+    needs: [format, test, template-tests, coverage, redis-integration]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))


### PR DESCRIPTION
## Summary

- Remove `benchmarks-current` and `benchmarks-report` from release job `needs`
- `benchmarks-base` only runs on PRs (`if: github.event_name == 'pull_request'`), causing the entire dependency chain to be skipped on main push: `benchmarks-base` → `benchmarks-report` → `release`
- Benchmarks are informational and should not gate releases

## Test plan

- [ ] Merge to main triggers release job (no longer skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)