### PR TITLE
fix(utils): correct http timeout default (#50)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
@@ -5,7 +5,14 @@ import java.net.http.HttpClient.Redirect
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.time.Duration
 
-case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3000) {
+/** Lightweight JDK HttpClient wrapper used by feeders and utility clients.
+  *
+  * @param followRedirects
+  *   JDK redirect policy name
+  * @param connectTimeoutInSeconds
+  *   connection timeout in seconds
+  */
+case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3) {
 
   private val jsonContentType: String = "application/json"
   private val client: HttpClient      = buildClient()

--- a/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
@@ -1,0 +1,21 @@
+package org.galaxio.gatling.utils
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class THttpClientSpec extends AnyWordSpec with Matchers {
+
+  "THttpClient" should {
+    "default to a 3 second connection timeout" in {
+      val client = THttpClient().buildClient()
+
+      client.connectTimeout().get().toSeconds shouldBe 3L
+    }
+
+    "respect custom connection timeout values" in {
+      val client = THttpClient(connectTimeoutInSeconds = 5).buildClient()
+
+      client.connectTimeout().get().toSeconds shouldBe 5L
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Fixes the default connection timeout in `THttpClient` from 3000 seconds to 3 seconds so misconfigured downstream hosts fail fast instead of hanging for ~50 minutes.

# Changes

- Updated the default timeout value in `THttpClient`.
- Added scaladoc to make the timeout unit explicit.
- Added regression coverage for the default and custom timeout values.

# Validation

- `sbt --batch "Test/testOnly org.galaxio.gatling.utils.THttpClientSpec"`
- `sbt --batch scalafmtAll`

Fixes https://github.com/galax-io/gatling-picatinny/issues/50
