### PR TITLE
fix(config): mask common secret keys (#58)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
+++ b/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
@@ -11,6 +11,14 @@ private[config] object ConfigValueMasking {
     "api-key",
     "api_key",
     "credential",
+    "privatekey",
+    "private_key",
+    "clientsecret",
+    "client_secret",
+    "accesskey",
+    "access_key",
+    "secretkey",
+    "secret_key",
   )
 
   def displayValue(path: String, value: Any): String =

--- a/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
@@ -119,11 +119,37 @@ class ConfigValueMaskingSpec extends AnyWordSpec with Matchers {
         "client.api-key",
         "client.api_key",
         "aws.credential",
+        "vault.private_key",
+        "vault.client_secret",
+        "aws.access_key",
+        "secrets.secret_key",
       )
 
       sensitivePaths.foreach { path =>
         ConfigValueMasking.displayValue(path, "raw-value") shouldBe "******"
         ConfigValueMasking.isSensitive(path) shouldBe true
+      }
+    }
+
+    "mask representative hocon secret keys" in {
+      val config = ConfigFactory.parseString("""
+          |secrets {
+          |  private_key = "private"
+          |  client_secret = "client"
+          |  access_key = "access"
+          |  secret_key = "secret"
+          |}
+          |""".stripMargin)
+
+      val secretPaths = Seq(
+        "secrets.private_key",
+        "secrets.client_secret",
+        "secrets.access_key",
+        "secrets.secret_key",
+      )
+
+      secretPaths.foreach { path =>
+        ConfigValueMasking.displayValue(path, config.getString(path)) shouldBe "******"
       }
     }
 


### PR DESCRIPTION
## Summary

Extend config value masking so common secret keys like `private_key`, `client_secret`, `access_key`, and `secret_key` are redacted in logs.

## Changes

- Expanded the sensitive path vocabulary in `ConfigValueMasking`
- Added regression coverage for representative secret-shaped HOCON keys

## Testing

- Compiled `ConfigValueMasking.scala` with `scalac`
- Verified masking behavior with a small Scala runner
- `sbt testOnly org.galaxio.gatling.config.SimulationConfigUtilsSpec` is blocked in this worktree by the repo’s git-versioning plugin loading under git worktree/JGit

Fixes galax-io/gatling-picatinny#58