### PR TITLE
fix(storage): copy records when switching backend (#53)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/storage/SessionStorage.scala
+++ b/src/main/scala/org/galaxio/gatling/storage/SessionStorage.scala
@@ -16,7 +16,7 @@ final class SessionStorage(
 
   def withBackend(b: StorageBackend): SessionStorage = {
     val storage = new SessionStorage(Some(b))
-    records.forEach(r => storage.records.add(r))
+    storage.records.addAll(new ConcurrentLinkedQueue[Record[Any]](records))
     storage
   }
 

--- a/src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala
@@ -91,6 +91,22 @@ class SessionStorageSpec extends AnyWordSpec with Matchers {
       withBe.toFeeder.head("key") shouldBe "value"
     }
 
+    "withBackend keeps the original storage isolated from later mutations" in {
+      val storage = SessionStorage()
+      storage.addRecord(Map("key" -> "value"))
+
+      val tmpFile = java.io.File.createTempFile("storage-test3", ".json")
+      tmpFile.deleteOnExit()
+      val withBe  = storage.withBackend(JsonFileBackend(tmpFile.getAbsolutePath))
+
+      withBe.addRecord(Map("key" -> "new-value"))
+
+      storage.size shouldBe 1
+      storage.toFeeder.head("key") shouldBe "value"
+      withBe.size shouldBe 2
+      withBe.toFeeder.last("key") shouldBe "new-value"
+    }
+
   }
 
   implicit class TestHelper(storage: SessionStorage) {


### PR DESCRIPTION
## Summary

Make `SessionStorage.withBackend` create a defensive copy of its record queue so the original storage and the backend-switched storage stay isolated.

## Changes

- Copy the existing records into the new `SessionStorage` instance instead of sharing the same queue reference
- Add a regression test that verifies later mutations on the copied storage do not affect the original

## Testing

- `sbt --batch "testOnly org.galaxio.gatling.storage.SessionStorageSpec"`

Fixes #53