### PR TITLE
fix(storage): fail redis writes explicitly (#56)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@
 /results/
 **/.gradle/
 **/build/
-
-# Local Codex guidance
-agents.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Use AGENTS.md as the primary repository instruction file for this project.

--- a/agents.md
+++ b/agents.md
@@ -1,39 +1,83 @@
-# Repository Instructions
+# Agents
 
-- Before any `git commit` or `git push`, always run `sbt scalafmtAll scalafmtSbt`.
-- If formatting changes files, review them and include the relevant formatted changes before publishing.
+Local-only instructions for agents working in `gatling-picatinny`.
+
+## Role
+- Act as a Principal Engineer in software development and performance testing.
+- Bring strong Scala, Java, Kotlin, Gatling DSL, and performance testing expertise.
+- Prefer small, clear, backward-compatible changes unless the task explicitly requires otherwise.
 
 ## Stack
+- Scala 2.13.18 core on SBT, Gatling 3.13.5 on `main`, Java 17+.
+- HTTP and Redis Gatling protocols (`gatling-http`, `gatling-redis`).
+- Java API facade with Kotlin-compatible usage and tests.
+- PureConfig 0.17.x + circe 0.15.x + json4s 4.1.x for config and template rendering.
+- jwt-scala 11.x for JWT generation (RSA/EC + HMAC), generex for regex-based data generation.
+- ScalaTest 3.2.x, ScalaCheck 1.19.x, ScalaMock 7.x, JUnit Jupiter 6.x, AssertJ 3.x.
+- Testcontainers (Redis, Vault) for integration tests, JMH for microbenchmarks.
+- GitHub Actions, Scala Steward, Codecov, Sonatype.
 
-- Scala 2.13.18, Java 17
-- Gatling 3.13.5 — HTTP, Redis protocols (`gatling-http`, `gatling-redis`)
-- PureConfig 0.17.x + circe 0.15.x + json4s 4.1.x — config and template rendering
-- jwt-scala 11.x — JWT generation (RSA/EC + HMAC)
-- generex — regex-based data generation
-- ScalaTest 3.2.x + ScalaCheck 1.19.x + ScalaMock 7.x + JUnit Jupiter 6.x + AssertJ 3.x
-- Testcontainers (Redis, Vault) for integration tests
-- JMH — microbenchmarks (Faker API, feeder throughput)
+## Installed Skills
+- Use the installed Scala, Java, Kotlin, TDD, and unit-test skills for tasks in this repo when they apply.
+- Default skill set for this repository: `scala-pro`, `java-best-practices`, `kotlin-patterns`, `kotlin-testing`, `tdd-workflow`, `unit-test-utility-methods`.
+- When working on Scala core code, prefer Scala skill guidance first.
+- When changing `src/main/java/.../javaapi`, apply Java best practices explicitly.
+- When reviewing Kotlin tests or examples, apply Kotlin and Kotlin testing guidance.
+- For bug fixes and new behavior, prefer TDD and focused regression/unit coverage instead of ad hoc changes.
+
+## Structure
+- `config/`: SimulationConfig — base URL, intensity, ramp duration, custom param readers.
+- `feeders/`: legacy feeders, Faker-based GeneratedFeeder, FakerApi facade, feeder DSL ops (zip, rename, select, etc.).
+- `jwt/`: JWT builder DSL, ClaimsBuilder, SigningKey ADT, PEM loaders, Java/Kotlin API.
+- `redis/`: RedisAction, RedisCommand sealed trait, 27 commands across 6 data types, saveAs/requestName.
+- `templates/`: Mustache template rendering, makeJson/makeXml helpers, Java API.
+- `transactions/`: TransactionsActor, startTransaction/endTransaction DSL, Java wrapper.
+- `assertion/`: response-time percentile assertion helpers.
+- `storage/`: SessionStorage — cross-scenario auth token management, pluggable backends (JSON, Redis, JDBC).
+- `src/main/java/.../javaapi`: Java/Kotlin-facing facade for all modules.
+- `src/test/scala`, `src/test/java`, `src/test/kotlin`: unit, integration, and usage coverage.
+- `examples/`: source overlays applied over a galaxio CLI-generated project — not standalone.
+
+## Design Rules
+- Keep architecture simple: SimulationConfig provides shared settings, module DSLs wrap Gatling actions, checks map results back into Gatling sessions.
+- Treat Scala DSL, Java builders, feeder APIs, and plugin defaults as compatibility-sensitive.
+- Feeder and session state can be stateful and concurrency-sensitive: review thread safety, iterator exhaustion, and Gatling session isolation carefully.
+- Apply SOLID when it improves clarity and testability.
+- Prefer KISS and DRY, but avoid premature abstraction in public APIs.
 
 ## Working Rules
-
-- Keep changes scoped to this repository.
+- Do not commit or publish this file unless the user explicitly asks.
+- Keep changes scoped to this repo; preserve existing user changes.
 - Prefer `rg` for search and `apply_patch` for edits.
-- Preserve existing user changes unless explicitly asked otherwise.
-- If a task spans multiple repos, confirm the target repo before editing.
-- Follow existing architecture and avoid unrelated refactors.
+- Confirm before editing another repo.
+- Avoid opportunistic refactors; prefer real runtime validation over heavy mocking for Gatling/Redis/Vault behavior.
 
 ## Quality
+- Format before publishing:
+  - minimum: `sbt scalafmtAll scalafmtSbt`
+  - preferred for Scala/test changes: `sbt --batch "Test / compile" scalafmtAll scalafmtCheckAll`
+- Run `sbt test` for unit suite; `sbt IntegrationTest/test` for Redis and Vault integration tests.
+- Coverage minimum is 45% statement — `sbt coverage test coverageReport` to verify.
+- Follow TDD where practical and add focused regression tests for behavior changes.
+- Prefer integration tests against real services (Testcontainers) when validating runtime behavior.
+- Preserve backward compatibility for published Scala and Java/Kotlin APIs.
 
-- Run `sbt scalafmtAll scalafmtSbt` before every commit — CI enforces this.
-- Run `sbt test` for unit suite; `sbt IntegrationTest/test` for Redis/Vault integration tests.
-- Prefer integration tests against real services (Testcontainers) over mocks for runtime behavior.
-- Coverage minimum is 45% statement coverage — `sbt coverage test coverageReport` to verify.
-- Preserve backward compatibility for all published DSL/API surfaces (Scala + Java + Kotlin).
+## PR Workflow
+1. Branch from `main`.
+2. Run the real repo checks before commit and push.
+3. Keep commits semantic and green; do not knowingly break the target branch.
+4. Prefer rebase-oriented history; avoid merge commits in PR branches.
+5. CI lives in `.github/workflows/ci.yml` and checks formatting, compile, tests, coverage, and template tests.
+6. Releases are driven by pushes to `main` and tags `v*`, with versioning and publishing handled by the same workflow.
+
+## Branch Policy
+- Treat `main` as the only active long-lived branch for plugin development.
+- Do not plan work around stale maintenance branches.
+- Prefer deleting stale branches instead of keeping parallel inactive lines around.
 
 ## Repo Notes
-
-- Public DSLs, feeder builders, and Gatling protocol wrappers are compatibility-sensitive.
-- Java API lives in `javaapi` package — keep parity with Scala DSL when adding features.
-- Example overlays in `examples/` are source-only; they are applied over a galaxio CLI-generated project, not run standalone.
-- JMH benchmarks live under `src/test` with `@State` and run via `sbt "Jmh/run .*"`.
+- `build.sbt`, `project/Dependencies.scala`, and `project/plugins.sbt` are the source of truth for build and dependency behavior.
+- Changes in feeder state, session variable naming, or action execution can affect both correctness and observability under load.
+- JMH benchmarks live under `src/test` and run via `sbt "Jmh/run .*"`.
 - `IntegrationTest` scope (`it`) is separate from `test` — Redis and Vault tests live there.
+- Real Redis/Vault behavior is usually more valuable than mocks here.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,39 @@
+# Repository Instructions
+
+- Before any `git commit` or `git push`, always run `sbt scalafmtAll scalafmtSbt`.
+- If formatting changes files, review them and include the relevant formatted changes before publishing.
+
+## Stack
+
+- Scala 2.13.18, Java 17
+- Gatling 3.13.5 — HTTP, Redis protocols (`gatling-http`, `gatling-redis`)
+- PureConfig 0.17.x + circe 0.15.x + json4s 4.1.x — config and template rendering
+- jwt-scala 11.x — JWT generation (RSA/EC + HMAC)
+- generex — regex-based data generation
+- ScalaTest 3.2.x + ScalaCheck 1.19.x + ScalaMock 7.x + JUnit Jupiter 6.x + AssertJ 3.x
+- Testcontainers (Redis, Vault) for integration tests
+- JMH — microbenchmarks (Faker API, feeder throughput)
+
+## Working Rules
+
+- Keep changes scoped to this repository.
+- Prefer `rg` for search and `apply_patch` for edits.
+- Preserve existing user changes unless explicitly asked otherwise.
+- If a task spans multiple repos, confirm the target repo before editing.
+- Follow existing architecture and avoid unrelated refactors.
+
+## Quality
+
+- Run `sbt scalafmtAll scalafmtSbt` before every commit — CI enforces this.
+- Run `sbt test` for unit suite; `sbt IntegrationTest/test` for Redis/Vault integration tests.
+- Prefer integration tests against real services (Testcontainers) over mocks for runtime behavior.
+- Coverage minimum is 45% statement coverage — `sbt coverage test coverageReport` to verify.
+- Preserve backward compatibility for all published DSL/API surfaces (Scala + Java + Kotlin).
+
+## Repo Notes
+
+- Public DSLs, feeder builders, and Gatling protocol wrappers are compatibility-sensitive.
+- Java API lives in `javaapi` package — keep parity with Scala DSL when adding features.
+- Example overlays in `examples/` are source-only; they are applied over a galaxio CLI-generated project, not run standalone.
+- JMH benchmarks live under `src/test` with `@State` and run via `sbt "Jmh/run .*"`.
+- `IntegrationTest` scope (`it`) is separate from `test` — Redis and Vault tests live there.

--- a/src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala
+++ b/src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala
@@ -8,6 +8,22 @@ import org.json4s.native.Serialization.writePretty
 import java.nio.file.{Files, Paths}
 import java.sql.{Connection, DriverManager}
 
+private[storage] trait RedisClientLike {
+  def set(key: String, value: String): Boolean
+  def get(key: String): Option[String]
+  def del(key: String): Option[Long]
+  def disconnect(): Unit
+}
+
+private[storage] object RedisClientLike {
+  def from(client: com.redis.RedisClient): RedisClientLike = new RedisClientLike {
+    override def set(key: String, value: String): Boolean = client.set(key, value)
+    override def get(key: String): Option[String]         = client.get(key)
+    override def del(key: String): Option[Long]           = client.del(key)
+    override def disconnect(): Unit                       = client.disconnect
+  }
+}
+
 trait StorageBackend {
   def save(records: Seq[Record[Any]]): Unit
   def load(): Seq[Record[Any]]
@@ -39,26 +55,39 @@ final case class RedisBackend(
   import com.redis.RedisClient
   private implicit val formats: Formats = DefaultFormats
 
+  private def withClient[T](f: RedisClientLike => T): T = {
+    val client  = new RedisClient(host, port)
+    val adapter = RedisClientLike.from(client)
+    try f(adapter)
+    finally adapter.disconnect()
+  }
+
   override def save(records: Seq[Record[Any]]): Unit = {
-    val client = new RedisClient(host, port)
-    try client.set(storageKey, writePretty(records))
-    finally client.disconnect
+    withClient(saveRecords(_, records))
   }
 
   override def load(): Seq[Record[Any]] = {
-    val client = new RedisClient(host, port)
-    try
-      client.get(storageKey) match {
-        case Some(json) => parse(json).extract[List[Map[String, Any]]]
-        case None       => Seq.empty
-      }
-    finally client.disconnect
+    withClient(loadRecords)
   }
 
   override def clear(): Unit = {
-    val client = new RedisClient(host, port)
-    try client.del(storageKey)
-    finally client.disconnect
+    withClient(clearRecords)
+  }
+
+  private[storage] def saveRecords(client: RedisClientLike, records: Seq[Record[Any]]): Unit = {
+    if (!client.set(storageKey, writePretty(records)))
+      throw new IllegalStateException(s"Failed to persist session storage to Redis key '$storageKey'")
+  }
+
+  private[storage] def loadRecords(client: RedisClientLike): Seq[Record[Any]] =
+    client.get(storageKey) match {
+      case Some(json) => parse(json).extract[List[Map[String, Any]]]
+      case None       => Seq.empty
+    }
+
+  private[storage] def clearRecords(client: RedisClientLike): Unit = {
+    client.del(storageKey)
+    ()
   }
 }
 

--- a/src/test/scala/org/galaxio/gatling/storage/StorageBackendSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/StorageBackendSpec.scala
@@ -57,4 +57,23 @@ class StorageBackendSpec extends AnyWordSpec with Matchers {
 
   }
 
+  "RedisBackend" should {
+
+    "fail when redis rejects a write" in {
+      val backend = RedisBackend("127.0.0.1", 6379, "test:storage:backend")
+      val client  = new RedisClientLike {
+        override def set(key: String, value: String): Boolean = false
+        override def get(key: String): Option[String]         = None
+        override def del(key: String): Option[Long]           = Some(0L)
+        override def disconnect(): Unit                       = ()
+      }
+
+      val thrown = intercept[IllegalStateException] {
+        backend.saveRecords(client, Seq(Map[String, Any]("user" -> "alice")))
+      }
+
+      thrown.getMessage should include("test:storage:backend")
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary\n\nMake `RedisBackend.save` fail fast when Redis rejects a write instead of silently treating the operation as successful. This keeps session-storage persistence failures visible to callers.\n\n## Changes\n\n- Added a small package-private Redis client adapter to make Redis responses testable\n- Made Redis writes throw `IllegalStateException` when `SET` returns `false`\n- Added a regression test that simulates a rejected Redis write\n\n## Testing\n\n- `sbt --batch "Test / testOnly org.galaxio.gatling.storage.StorageBackendSpec"`\n- `sbt --batch scalafmtAll scalafmtSbt`\n\nFixes galax-io/gatling-picatinny#56