### PR TITLE
revert: restore pre-rollback state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@
 /results/
 **/.gradle/
 **/build/
-
-# Local Codex guidance
-agents.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Use AGENTS.md as the primary repository instruction file for this project.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,83 @@
+# Agents
+
+Local-only instructions for agents working in `gatling-picatinny`.
+
+## Role
+- Act as a Principal Engineer in software development and performance testing.
+- Bring strong Scala, Java, Kotlin, Gatling DSL, and performance testing expertise.
+- Prefer small, clear, backward-compatible changes unless the task explicitly requires otherwise.
+
+## Stack
+- Scala 2.13.18 core on SBT, Gatling 3.13.5 on `main`, Java 17+.
+- HTTP and Redis Gatling protocols (`gatling-http`, `gatling-redis`).
+- Java API facade with Kotlin-compatible usage and tests.
+- PureConfig 0.17.x + circe 0.15.x + json4s 4.1.x for config and template rendering.
+- jwt-scala 11.x for JWT generation (RSA/EC + HMAC), generex for regex-based data generation.
+- ScalaTest 3.2.x, ScalaCheck 1.19.x, ScalaMock 7.x, JUnit Jupiter 6.x, AssertJ 3.x.
+- Testcontainers (Redis, Vault) for integration tests, JMH for microbenchmarks.
+- GitHub Actions, Scala Steward, Codecov, Sonatype.
+
+## Installed Skills
+- Use the installed Scala, Java, Kotlin, TDD, and unit-test skills for tasks in this repo when they apply.
+- Default skill set for this repository: `scala-pro`, `java-best-practices`, `kotlin-patterns`, `kotlin-testing`, `tdd-workflow`, `unit-test-utility-methods`.
+- When working on Scala core code, prefer Scala skill guidance first.
+- When changing `src/main/java/.../javaapi`, apply Java best practices explicitly.
+- When reviewing Kotlin tests or examples, apply Kotlin and Kotlin testing guidance.
+- For bug fixes and new behavior, prefer TDD and focused regression/unit coverage instead of ad hoc changes.
+
+## Structure
+- `config/`: SimulationConfig — base URL, intensity, ramp duration, custom param readers.
+- `feeders/`: legacy feeders, Faker-based GeneratedFeeder, FakerApi facade, feeder DSL ops (zip, rename, select, etc.).
+- `jwt/`: JWT builder DSL, ClaimsBuilder, SigningKey ADT, PEM loaders, Java/Kotlin API.
+- `redis/`: RedisAction, RedisCommand sealed trait, 27 commands across 6 data types, saveAs/requestName.
+- `templates/`: Mustache template rendering, makeJson/makeXml helpers, Java API.
+- `transactions/`: TransactionsActor, startTransaction/endTransaction DSL, Java wrapper.
+- `assertion/`: response-time percentile assertion helpers.
+- `storage/`: SessionStorage — cross-scenario auth token management, pluggable backends (JSON, Redis, JDBC).
+- `src/main/java/.../javaapi`: Java/Kotlin-facing facade for all modules.
+- `src/test/scala`, `src/test/java`, `src/test/kotlin`: unit, integration, and usage coverage.
+- `examples/`: source overlays applied over a galaxio CLI-generated project — not standalone.
+
+## Design Rules
+- Keep architecture simple: SimulationConfig provides shared settings, module DSLs wrap Gatling actions, checks map results back into Gatling sessions.
+- Treat Scala DSL, Java builders, feeder APIs, and plugin defaults as compatibility-sensitive.
+- Feeder and session state can be stateful and concurrency-sensitive: review thread safety, iterator exhaustion, and Gatling session isolation carefully.
+- Apply SOLID when it improves clarity and testability.
+- Prefer KISS and DRY, but avoid premature abstraction in public APIs.
+
+## Working Rules
+- Do not commit or publish this file unless the user explicitly asks.
+- Keep changes scoped to this repo; preserve existing user changes.
+- Prefer `rg` for search and `apply_patch` for edits.
+- Confirm before editing another repo.
+- Avoid opportunistic refactors; prefer real runtime validation over heavy mocking for Gatling/Redis/Vault behavior.
+
+## Quality
+- Format before publishing:
+  - minimum: `sbt scalafmtAll scalafmtSbt`
+  - preferred for Scala/test changes: `sbt --batch "Test / compile" scalafmtAll scalafmtCheckAll`
+- Run `sbt test` for unit suite; `sbt IntegrationTest/test` for Redis and Vault integration tests.
+- Coverage minimum is 45% statement — `sbt coverage test coverageReport` to verify.
+- Follow TDD where practical and add focused regression tests for behavior changes.
+- Prefer integration tests against real services (Testcontainers) when validating runtime behavior.
+- Preserve backward compatibility for published Scala and Java/Kotlin APIs.
+
+## PR Workflow
+1. Branch from `main`.
+2. Run the real repo checks before commit and push.
+3. Keep commits semantic and green; do not knowingly break the target branch.
+4. Prefer rebase-oriented history; avoid merge commits in PR branches.
+5. CI lives in `.github/workflows/ci.yml` and checks formatting, compile, tests, coverage, and template tests.
+6. Releases are driven by pushes to `main` and tags `v*`, with versioning and publishing handled by the same workflow.
+
+## Branch Policy
+- Treat `main` as the only active long-lived branch for plugin development.
+- Do not plan work around stale maintenance branches.
+- Prefer deleting stale branches instead of keeping parallel inactive lines around.
+
+## Repo Notes
+- `build.sbt`, `project/Dependencies.scala`, and `project/plugins.sbt` are the source of truth for build and dependency behavior.
+- Changes in feeder state, session variable naming, or action execution can affect both correctness and observability under load.
+- JMH benchmarks live under `src/test` and run via `sbt "Jmh/run .*"`.
+- `IntegrationTest` scope (`it`) is separate from `test` — Redis and Vault tests live there.
+- Real Redis/Vault behavior is usually more valuable than mocks here.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ def UtilsModule(id: String) = Project(id, file(id))
 lazy val IntegrationTest    = config("it") extend Runtime
 
 lazy val root = (project in file("."))
-  .enablePlugins(GitVersioning, JmhPlugin)
+  .enablePlugins(JmhPlugin)
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.testSettings))
   .settings(
@@ -16,6 +16,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= json4s,
     libraryDependencies ++= pureConfig,
     libraryDependencies ++= jackson,
+    libraryDependencies ++= scalaLogging,
     libraryDependencies ++= scalaTesting,
     libraryDependencies ++= generex,
     libraryDependencies ++= jwt,
@@ -39,3 +40,5 @@ lazy val root = (project in file("."))
       "-language:postfixOps",
     ),
   )
+
+ThisBuild / com.github.sbt.git.SbtGit.GitKeys.useConsoleForROGit := true

--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.java
@@ -69,6 +69,7 @@ public final class GeneratedPicatinnyFeeders {
         return GeneratedFeeder(
                 field("alphabeticStr", alphabetic(10)),
                 field("alphanumericStr", alphanumeric(12)),
+                field("matchingStr", matching("[A-Z]{2}[0-9]{4}")),
                 field("numericStr", numeric(8)),
                 field("hexStr", hex(16)),
                 field("cyrillicStr", cyrillic(6))

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.kt
@@ -53,6 +53,7 @@ object GeneratedPicatinnyFeeders {
     fun strings() = GeneratedFeeder(
         field("alphabeticStr", alphabetic(10)),
         field("alphanumericStr", alphanumeric(12)),
+        field("matchingStr", matching("[A-Z]{2}[0-9]{4}")),
         field("numericStr", numeric(8)),
         field("hexStr", hex(16)),
         field("cyrillicStr", cyrillic(6)),

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
@@ -77,6 +77,7 @@ object GeneratedPicatinnyFeeders {
     GeneratedFeeder(
       "alphabeticStr"     -> Faker.string.alphabetic(10),
       "alphanumericStr"   -> Faker.string.alphanumeric(12),
+      "matchingStr"       -> Faker.string.matching("[A-Z]{2}[0-9]{4}"),
       "numericStr"        -> Faker.string.numeric(8),
       "hexStr"            -> Faker.string.hex(16),
       "cyrillicStr"       -> Faker.string.cyrillic(6),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,10 @@ object Dependencies {
     "com.fasterxml.jackson.core"       % "jackson-core"            % "2.21.0",
   )
 
+  lazy val scalaLogging: Seq[ModuleID] = Seq(
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  )
+
   lazy val scalaTest: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.2.19" % "test,it",
   )

--- a/src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala
+++ b/src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala
@@ -40,6 +40,7 @@ object FakerApi {
   def numeric(length: Int): Generator[String]      = Faker.string.numeric(length)
   def hex(length: Int): Generator[String]          = Faker.string.hex(length)
   def cyrillic(length: Int): Generator[String]     = Faker.string.cyrillic(length)
+  def matching(pattern: String): Generator[String] = Faker.string.matching(pattern)
 
   // --- Number ---
 

--- a/src/main/java/org/galaxio/gatling/javaapi/Feeders.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/Feeders.java
@@ -171,6 +171,7 @@ public final class Feeders {
         return toJavaFeeder(org.galaxio.gatling.feeders.RandomUUIDFeeder.apply(paramName));
     }
 
+    @Deprecated(since = "faker-api")
     public static Iterator<Map<String, Object>> RegexFeeder(String paramName, String regex) {
         return toJavaFeeder(org.galaxio.gatling.feeders.RegexFeeder.apply(paramName, regex));
     }

--- a/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
+++ b/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
@@ -11,6 +11,14 @@ private[config] object ConfigValueMasking {
     "api-key",
     "api_key",
     "credential",
+    "privatekey",
+    "private_key",
+    "clientsecret",
+    "client_secret",
+    "accesskey",
+    "access_key",
+    "secretkey",
+    "secret_key",
   )
 
   def displayValue(path: String, value: Any): String =

--- a/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
@@ -1,13 +1,12 @@
 package org.galaxio.gatling.feeders
 
 import io.gatling.core.feeder.Feeder
-import com.mifmif.common.regex.Generex
+import org.galaxio.gatling.feeders.faker.Faker
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.string.matching with GeneratedFeeder instead", "faker-api")
 object RegexFeeder {
 
-  def apply(paramName: String, regex: String): Feeder[String] = {
-    val generex = new Generex(regex).iterator()
-    feeder[String](paramName)(generex.next())
-  }
+  def apply(paramName: String, regex: String): Feeder[String] =
+    feeder[String](paramName)(Faker.string.matching(regex).sample())
 
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.feeders.faker
 
+import com.mifmif.common.regex.Generex
 import org.galaxio.gatling.utils.{RandomDataGenerators, RandomPhoneGenerator}
 import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
 
@@ -131,6 +132,13 @@ object Faker {
 
     def lengthBetween(min: Int, max: Int, alphabet: String): Generator[String] =
       number.int(min, max).flatMap(fromAlphabet(alphabet, _))
+
+    /** Generates strings matching a finite regex pattern.
+      *
+      * This is the generator-based replacement for the legacy `RegexFeeder`.
+      */
+    def matching(pattern: String): Generator[String] =
+      RegexSampler.generator(pattern)
   }
 
   /** Person data generators. */
@@ -686,5 +694,18 @@ object Faker {
         c <- tuple._3
         d <- tuple._4
       } yield f(a, b, c, d)
+  }
+}
+
+private object RegexSampler {
+
+  def generator(pattern: String): Generator[String] = {
+    val normalizedPattern =
+      Option(pattern).map(_.trim).getOrElse(throw new IllegalArgumentException("Regex pattern must be non-null"))
+    require(normalizedPattern.nonEmpty, "Regex pattern must be non-empty")
+    require(Generex.isValidPattern(normalizedPattern), s"Invalid regex pattern: $normalizedPattern")
+
+    val perThread = ThreadLocal.withInitial(() => new Generex(normalizedPattern))
+    Generator.delay(perThread.get().random())
   }
 }

--- a/src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala
+++ b/src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala
@@ -8,6 +8,22 @@ import org.json4s.native.Serialization.writePretty
 import java.nio.file.{Files, Paths}
 import java.sql.{Connection, DriverManager}
 
+private[storage] trait RedisClientLike {
+  def set(key: String, value: String): Boolean
+  def get(key: String): Option[String]
+  def del(key: String): Option[Long]
+  def disconnect(): Unit
+}
+
+private[storage] object RedisClientLike {
+  def from(client: com.redis.RedisClient): RedisClientLike = new RedisClientLike {
+    override def set(key: String, value: String): Boolean = client.set(key, value)
+    override def get(key: String): Option[String]         = client.get(key)
+    override def del(key: String): Option[Long]           = client.del(key)
+    override def disconnect(): Unit                       = client.disconnect
+  }
+}
+
 trait StorageBackend {
   def save(records: Seq[Record[Any]]): Unit
   def load(): Seq[Record[Any]]
@@ -39,26 +55,39 @@ final case class RedisBackend(
   import com.redis.RedisClient
   private implicit val formats: Formats = DefaultFormats
 
+  private def withClient[T](f: RedisClientLike => T): T = {
+    val client  = new RedisClient(host, port)
+    val adapter = RedisClientLike.from(client)
+    try f(adapter)
+    finally adapter.disconnect()
+  }
+
   override def save(records: Seq[Record[Any]]): Unit = {
-    val client = new RedisClient(host, port)
-    try client.set(storageKey, writePretty(records))
-    finally client.disconnect
+    withClient(saveRecords(_, records))
   }
 
   override def load(): Seq[Record[Any]] = {
-    val client = new RedisClient(host, port)
-    try
-      client.get(storageKey) match {
-        case Some(json) => parse(json).extract[List[Map[String, Any]]]
-        case None       => Seq.empty
-      }
-    finally client.disconnect
+    withClient(loadRecords)
   }
 
   override def clear(): Unit = {
-    val client = new RedisClient(host, port)
-    try client.del(storageKey)
-    finally client.disconnect
+    withClient(clearRecords)
+  }
+
+  private[storage] def saveRecords(client: RedisClientLike, records: Seq[Record[Any]]): Unit = {
+    if (!client.set(storageKey, writePretty(records)))
+      throw new IllegalStateException(s"Failed to persist session storage to Redis key '$storageKey'")
+  }
+
+  private[storage] def loadRecords(client: RedisClientLike): Seq[Record[Any]] =
+    client.get(storageKey) match {
+      case Some(json) => parse(json).extract[List[Map[String, Any]]]
+      case None       => Seq.empty
+    }
+
+  private[storage] def clearRecords(client: RedisClientLike): Unit = {
+    client.del(storageKey)
+    ()
   }
 }
 

--- a/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
@@ -5,7 +5,14 @@ import java.net.http.HttpClient.Redirect
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.time.Duration
 
-case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3000) {
+/** Lightweight JDK HttpClient wrapper used by feeders and utility clients.
+  *
+  * @param followRedirects
+  *   JDK redirect policy name
+  * @param connectTimeoutInSeconds
+  *   connection timeout in seconds
+  */
+case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3) {
 
   private val jsonContentType: String = "application/json"
   private val client: HttpClient      = buildClient()

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaApiExampleSmokeTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaApiExampleSmokeTest.java
@@ -248,6 +248,7 @@ class JavaApiExampleSmokeTest {
             return Stream.of(
                     Arguments.of("alpha", alphabetic(10), 10, "[a-zA-Z]+"),
                     Arguments.of("alphanum", alphanumeric(12), 12, "[a-zA-Z0-9]+"),
+                    Arguments.of("matching", matching("[A-Z]{2}[0-9]{4}"), 6, "[A-Z]{2}[0-9]{4}"),
                     Arguments.of("num", numeric(8), 8, "\\d+"),
                     Arguments.of("hex", hex(16), 16, "[0-9a-f]+"),
                     Arguments.of("cyr", cyrillic(6), 6, ".+")
@@ -260,6 +261,17 @@ class JavaApiExampleSmokeTest {
         void stringGeneratorHasExactLength(String name, org.galaxio.gatling.feeders.faker.Generator<?> generator, int length, String regex) {
             var value = next(GeneratedFeeder(field("v", (org.galaxio.gatling.feeders.faker.Generator<Object>) generator))).get("v").toString();
             assertThat(value).hasSize(length).matches(regex);
+        }
+
+        @Test
+        void regexGeneratorProducesFreshValues() {
+            var feeder = GeneratedFeeder(field("rx", matching("[A-Z]{2}[0-9]{4}")));
+            var values = new LinkedHashSet<String>();
+            for (int i = 0; i < 20; i++) {
+                values.add(next(feeder).get("rx").toString());
+            }
+            assertThat(values).hasSizeGreaterThan(1);
+            assertThat(values).allMatch(value -> value.matches("[A-Z]{2}[0-9]{4}"));
         }
 
         @Test

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java
@@ -140,6 +140,7 @@ public class JavaFeedersTest extends Simulation {
     Iterator<Map<String, Object>> strings = GeneratedFeeder(
             field("alphabeticStr", alphabetic(10)),
             field("alphanumericStr", alphanumeric(12)),
+            field("matchingStr", matching("[A-Z]{2}[0-9]{4}")),
             field("numericStr", numeric(8)),
             field("hexStr", hex(16)),
             field("cyrillicStr", cyrillic(6))

--- a/src/test/scala/org/galaxio/gatling/ScalaLoggingDependencySpec.scala
+++ b/src/test/scala/org/galaxio/gatling/ScalaLoggingDependencySpec.scala
@@ -1,0 +1,15 @@
+package org.galaxio.gatling
+
+import com.typesafe.scalalogging.LazyLogging
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ScalaLoggingDependencySpec extends AnyWordSpec with Matchers with LazyLogging {
+
+  "scala-logging" should {
+    "be available on the test classpath" in {
+      logger.info("scala-logging is available for LazyLogging-based code paths")
+      succeed
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
@@ -119,11 +119,37 @@ class ConfigValueMaskingSpec extends AnyWordSpec with Matchers {
         "client.api-key",
         "client.api_key",
         "aws.credential",
+        "vault.private_key",
+        "vault.client_secret",
+        "aws.access_key",
+        "secrets.secret_key",
       )
 
       sensitivePaths.foreach { path =>
         ConfigValueMasking.displayValue(path, "raw-value") shouldBe "******"
         ConfigValueMasking.isSensitive(path) shouldBe true
+      }
+    }
+
+    "mask representative hocon secret keys" in {
+      val config = ConfigFactory.parseString("""
+          |secrets {
+          |  private_key = "private"
+          |  client_secret = "client"
+          |  access_key = "access"
+          |  secret_key = "secret"
+          |}
+          |""".stripMargin)
+
+      val secretPaths = Seq(
+        "secrets.private_key",
+        "secrets.client_secret",
+        "secrets.access_key",
+        "secrets.secret_key",
+      )
+
+      secretPaths.foreach { path =>
+        ConfigValueMasking.displayValue(path, config.getString(path)) shouldBe "******"
       }
     }
 

--- a/src/test/scala/org/galaxio/gatling/examples/ExampleSmokeSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/examples/ExampleSmokeSpec.scala
@@ -241,6 +241,7 @@ class ExampleSmokeSpec extends AnyWordSpec with Matchers with CoreDsl with Table
       ("field", "generator", "length", "regex"),
       ("alpha", Faker.string.alphabetic(10), 10, "[a-zA-Z]{10}"),
       ("alphanum", Faker.string.alphanumeric(12), 12, "[a-zA-Z0-9]{12}"),
+      ("matching", Faker.string.matching("[A-Z]{2}[0-9]{4}"), 6, "[A-Z]{2}[0-9]{4}"),
       ("hex", Faker.string.hex(16), 16, "[0-9a-f]{16}"),
       ("cyrillic", Faker.string.cyrillic(6), 6, ".*"),
     )
@@ -251,6 +252,12 @@ class ExampleSmokeSpec extends AnyWordSpec with Matchers with CoreDsl with Table
         value should have length expectedLen.toLong
         value should fullyMatch regex regex
       }
+    }
+
+    "produce fresh values from regex generator through GeneratedFeeder" in {
+      val values = GeneratedFeeder("rx" -> Faker.string.matching("[A-Z]{2}[0-9]{4}")).take(20).map(_("rx").toString).toList
+      values.distinct.size should be > 1
+      values.foreach(_ should fullyMatch regex "[A-Z]{2}[0-9]{4}")
     }
 
     "produce person names with at least 2 characters" in {

--- a/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.feeders
 
+import org.galaxio.gatling.feeders.faker.Faker
 import org.scalacheck._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -165,6 +166,18 @@ class RandomFeedersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
               record(paramName) should fullyMatch regex regexPattern
             },
           )
+      }
+    }
+
+    "create RegexFeeder with fresh values on each record" in {
+      val values = RegexFeeder("rx", "[A-Z]{2}[0-9]{4}").take(20).map(_("rx").toString).toList
+      values.distinct.size should be > 1
+      values.foreach(_ should fullyMatch regex "[A-Z]{2}[0-9]{4}")
+    }
+
+    "fail fast for invalid regex generator patterns" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.string.matching("[A-Z").sample()
       }
     }
 

--- a/src/test/scala/org/galaxio/gatling/storage/StorageBackendSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/StorageBackendSpec.scala
@@ -57,4 +57,23 @@ class StorageBackendSpec extends AnyWordSpec with Matchers {
 
   }
 
+  "RedisBackend" should {
+
+    "fail when redis rejects a write" in {
+      val backend = RedisBackend("127.0.0.1", 6379, "test:storage:backend")
+      val client  = new RedisClientLike {
+        override def set(key: String, value: String): Boolean = false
+        override def get(key: String): Option[String]         = None
+        override def del(key: String): Option[Long]           = Some(0L)
+        override def disconnect(): Unit                       = ()
+      }
+
+      val thrown = intercept[IllegalStateException] {
+        backend.saveRecords(client, Seq(Map[String, Any]("user" -> "alice")))
+      }
+
+      thrown.getMessage should include("test:storage:backend")
+    }
+  }
+
 }

--- a/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
@@ -1,0 +1,21 @@
+package org.galaxio.gatling.utils
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class THttpClientSpec extends AnyWordSpec with Matchers {
+
+  "THttpClient" should {
+    "default to a 3 second connection timeout" in {
+      val client = THttpClient().buildClient()
+
+      client.connectTimeout().get().toSeconds shouldBe 3L
+    }
+
+    "respect custom connection timeout values" in {
+      val client = THttpClient(connectTimeoutInSeconds = 5).buildClient()
+
+      client.connectTimeout().get().toSeconds shouldBe 5L
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Restore `main` to the state it was in before the accidental rollback PR `#156` was merged.

This is the direct revert of the rollback commit, so the repository returns to the same code state as before that mistake.

## Testing

- Revert applied cleanly on top of the current `main`
- No additional source changes beyond the restoration