### PR TITLE
feat(feeders): add regex generator to faker api (#62)

### DIFF
--- a/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.java
+++ b/examples/java-maven-example/src/test/java/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.java
@@ -69,6 +69,7 @@ public final class GeneratedPicatinnyFeeders {
         return GeneratedFeeder(
                 field("alphabeticStr", alphabetic(10)),
                 field("alphanumericStr", alphanumeric(12)),
+                field("matchingStr", matching("[A-Z]{2}[0-9]{4}")),
                 field("numericStr", numeric(8)),
                 field("hexStr", hex(16)),
                 field("cyrillicStr", cyrillic(6))

--- a/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.kt
+++ b/examples/kotlin-gradle-example/src/gatling/kotlin/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.kt
@@ -53,6 +53,7 @@ object GeneratedPicatinnyFeeders {
     fun strings() = GeneratedFeeder(
         field("alphabeticStr", alphabetic(10)),
         field("alphanumericStr", alphanumeric(12)),
+        field("matchingStr", matching("[A-Z]{2}[0-9]{4}")),
         field("numericStr", numeric(8)),
         field("hexStr", hex(16)),
         field("cyrillicStr", cyrillic(6)),

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/feeders/GeneratedPicatinnyFeeders.scala
@@ -77,6 +77,7 @@ object GeneratedPicatinnyFeeders {
     GeneratedFeeder(
       "alphabeticStr"     -> Faker.string.alphabetic(10),
       "alphanumericStr"   -> Faker.string.alphanumeric(12),
+      "matchingStr"       -> Faker.string.matching("[A-Z]{2}[0-9]{4}"),
       "numericStr"        -> Faker.string.numeric(8),
       "hexStr"            -> Faker.string.hex(16),
       "cyrillicStr"       -> Faker.string.cyrillic(6),

--- a/src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala
+++ b/src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala
@@ -40,6 +40,7 @@ object FakerApi {
   def numeric(length: Int): Generator[String]      = Faker.string.numeric(length)
   def hex(length: Int): Generator[String]          = Faker.string.hex(length)
   def cyrillic(length: Int): Generator[String]     = Faker.string.cyrillic(length)
+  def matching(pattern: String): Generator[String] = Faker.string.matching(pattern)
 
   // --- Number ---
 

--- a/src/main/java/org/galaxio/gatling/javaapi/Feeders.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/Feeders.java
@@ -171,6 +171,7 @@ public final class Feeders {
         return toJavaFeeder(org.galaxio.gatling.feeders.RandomUUIDFeeder.apply(paramName));
     }
 
+    @Deprecated(since = "faker-api")
     public static Iterator<Map<String, Object>> RegexFeeder(String paramName, String regex) {
         return toJavaFeeder(org.galaxio.gatling.feeders.RegexFeeder.apply(paramName, regex));
     }

--- a/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
@@ -1,13 +1,12 @@
 package org.galaxio.gatling.feeders
 
 import io.gatling.core.feeder.Feeder
-import com.mifmif.common.regex.Generex
+import org.galaxio.gatling.feeders.faker.Faker
 
+@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.string.matching with GeneratedFeeder instead", "faker-api")
 object RegexFeeder {
 
-  def apply(paramName: String, regex: String): Feeder[String] = {
-    val generex = new Generex(regex).iterator()
-    feeder[String](paramName)(generex.next())
-  }
+  def apply(paramName: String, regex: String): Feeder[String] =
+    feeder[String](paramName)(Faker.string.matching(regex).sample())
 
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
@@ -3,10 +3,16 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Feeder
 import org.galaxio.gatling.feeders.faker.Faker
 
-@deprecated("Use org.galaxio.gatling.feeders.faker.Faker.string.matching with GeneratedFeeder instead", "faker-api")
+@deprecated(
+  "Use org.galaxio.gatling.feeders.faker.Faker.string.matching with GeneratedFeeder instead. RegexFeeder now samples random values rather than preserving iterator order.",
+  "faker-api",
+)
 object RegexFeeder {
 
   def apply(paramName: String, regex: String): Feeder[String] =
-    feeder[String](paramName)(Faker.string.matching(regex).sample())
+    {
+      val generator = Faker.string.matching(regex)
+      feeder[String](paramName)(generator.sample())
+    }
 
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/RegexFeeder.scala
@@ -9,10 +9,9 @@ import org.galaxio.gatling.feeders.faker.Faker
 )
 object RegexFeeder {
 
-  def apply(paramName: String, regex: String): Feeder[String] =
-    {
-      val generator = Faker.string.matching(regex)
-      feeder[String](paramName)(generator.sample())
-    }
+  def apply(paramName: String, regex: String): Feeder[String] = {
+    val generator = Faker.string.matching(regex)
+    feeder[String](paramName)(generator.sample())
+  }
 
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -136,9 +136,25 @@ object Faker {
     /** Generates strings matching a finite regex pattern.
       *
       * This is the generator-based replacement for the legacy `RegexFeeder`.
+      * Keep the returned generator in a `val` and reuse it; each generator holds a thread-local automaton instance.
+      *
+      * The pattern must be compatible with `Generex`/dk.brics.automaton syntax. Lookarounds, backreferences, and other
+      * unsupported regex features are rejected.
       */
     def matching(pattern: String): Generator[String] =
       RegexSampler.generator(pattern)
+  }
+
+  private object RegexSampler {
+    def generator(pattern: String): Generator[String] = {
+      val normalizedPattern =
+        Option(pattern).getOrElse(throw new IllegalArgumentException("Regex pattern must be non-null"))
+      require(normalizedPattern.nonEmpty, "Regex pattern must be non-empty")
+      require(Generex.isValidPattern(normalizedPattern), s"Invalid regex pattern: $normalizedPattern")
+
+      val perThread = ThreadLocal.withInitial(() => new Generex(normalizedPattern))
+      Generator.delay(perThread.get().random())
+    }
   }
 
   /** Person data generators. */

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -712,16 +712,3 @@ object Faker {
       } yield f(a, b, c, d)
   }
 }
-
-private object RegexSampler {
-
-  def generator(pattern: String): Generator[String] = {
-    val normalizedPattern =
-      Option(pattern).map(_.trim).getOrElse(throw new IllegalArgumentException("Regex pattern must be non-null"))
-    require(normalizedPattern.nonEmpty, "Regex pattern must be non-empty")
-    require(Generex.isValidPattern(normalizedPattern), s"Invalid regex pattern: $normalizedPattern")
-
-    val perThread = ThreadLocal.withInitial(() => new Generex(normalizedPattern))
-    Generator.delay(perThread.get().random())
-  }
-}

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.feeders.faker
 
+import com.mifmif.common.regex.Generex
 import org.galaxio.gatling.utils.{RandomDataGenerators, RandomPhoneGenerator}
 import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
 
@@ -131,6 +132,13 @@ object Faker {
 
     def lengthBetween(min: Int, max: Int, alphabet: String): Generator[String] =
       number.int(min, max).flatMap(fromAlphabet(alphabet, _))
+
+    /** Generates strings matching a finite regex pattern.
+      *
+      * This is the generator-based replacement for the legacy `RegexFeeder`.
+      */
+    def matching(pattern: String): Generator[String] =
+      RegexSampler.generator(pattern)
   }
 
   /** Person data generators. */
@@ -686,5 +694,18 @@ object Faker {
         c <- tuple._3
         d <- tuple._4
       } yield f(a, b, c, d)
+  }
+}
+
+private object RegexSampler {
+
+  def generator(pattern: String): Generator[String] = {
+    val normalizedPattern =
+      Option(pattern).map(_.trim).getOrElse(throw new IllegalArgumentException("Regex pattern must be non-null"))
+    require(normalizedPattern.nonEmpty, "Regex pattern must be non-empty")
+    require(Generex.isValidPattern(normalizedPattern), s"Invalid regex pattern: $normalizedPattern")
+
+    val perThread = ThreadLocal.withInitial(() => new Generex(normalizedPattern))
+    Generator.delay(perThread.get().random())
   }
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -135,8 +135,8 @@ object Faker {
 
     /** Generates strings matching a finite regex pattern.
       *
-      * This is the generator-based replacement for the legacy `RegexFeeder`.
-      * Keep the returned generator in a `val` and reuse it; each generator holds a thread-local automaton instance.
+      * This is the generator-based replacement for the legacy `RegexFeeder`. Keep the returned generator in a `val` and reuse
+      * it; each generator holds a thread-local automaton instance.
       *
       * The pattern must be compatible with `Generex`/dk.brics.automaton syntax. Lookarounds, backreferences, and other
       * unsupported regex features are rejected.

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaApiExampleSmokeTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaApiExampleSmokeTest.java
@@ -248,6 +248,7 @@ class JavaApiExampleSmokeTest {
             return Stream.of(
                     Arguments.of("alpha", alphabetic(10), 10, "[a-zA-Z]+"),
                     Arguments.of("alphanum", alphanumeric(12), 12, "[a-zA-Z0-9]+"),
+                    Arguments.of("matching", matching("[A-Z]{2}[0-9]{4}"), 6, "[A-Z]{2}[0-9]{4}"),
                     Arguments.of("num", numeric(8), 8, "\\d+"),
                     Arguments.of("hex", hex(16), 16, "[0-9a-f]+"),
                     Arguments.of("cyr", cyrillic(6), 6, ".+")
@@ -260,6 +261,17 @@ class JavaApiExampleSmokeTest {
         void stringGeneratorHasExactLength(String name, org.galaxio.gatling.feeders.faker.Generator<?> generator, int length, String regex) {
             var value = next(GeneratedFeeder(field("v", (org.galaxio.gatling.feeders.faker.Generator<Object>) generator))).get("v").toString();
             assertThat(value).hasSize(length).matches(regex);
+        }
+
+        @Test
+        void regexGeneratorProducesFreshValues() {
+            var feeder = GeneratedFeeder(field("rx", matching("[A-Z]{2}[0-9]{4}")));
+            var values = new LinkedHashSet<String>();
+            for (int i = 0; i < 20; i++) {
+                values.add(next(feeder).get("rx").toString());
+            }
+            assertThat(values).hasSizeGreaterThan(1);
+            assertThat(values).allMatch(value -> value.matches("[A-Z]{2}[0-9]{4}"));
         }
 
         @Test

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java
@@ -140,6 +140,7 @@ public class JavaFeedersTest extends Simulation {
     Iterator<Map<String, Object>> strings = GeneratedFeeder(
             field("alphabeticStr", alphabetic(10)),
             field("alphanumericStr", alphanumeric(12)),
+            field("matchingStr", matching("[A-Z]{2}[0-9]{4}")),
             field("numericStr", numeric(8)),
             field("hexStr", hex(16)),
             field("cyrillicStr", cyrillic(6))

--- a/src/test/scala/org/galaxio/gatling/examples/ExampleSmokeSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/examples/ExampleSmokeSpec.scala
@@ -241,6 +241,7 @@ class ExampleSmokeSpec extends AnyWordSpec with Matchers with CoreDsl with Table
       ("field", "generator", "length", "regex"),
       ("alpha", Faker.string.alphabetic(10), 10, "[a-zA-Z]{10}"),
       ("alphanum", Faker.string.alphanumeric(12), 12, "[a-zA-Z0-9]{12}"),
+      ("matching", Faker.string.matching("[A-Z]{2}[0-9]{4}"), 6, "[A-Z]{2}[0-9]{4}"),
       ("hex", Faker.string.hex(16), 16, "[0-9a-f]{16}"),
       ("cyrillic", Faker.string.cyrillic(6), 6, ".*"),
     )
@@ -251,6 +252,12 @@ class ExampleSmokeSpec extends AnyWordSpec with Matchers with CoreDsl with Table
         value should have length expectedLen.toLong
         value should fullyMatch regex regex
       }
+    }
+
+    "produce fresh values from regex generator through GeneratedFeeder" in {
+      val values = GeneratedFeeder("rx" -> Faker.string.matching("[A-Z]{2}[0-9]{4}")).take(20).map(_("rx").toString).toList
+      values.distinct.size should be > 1
+      values.foreach(_ should fullyMatch regex "[A-Z]{2}[0-9]{4}")
     }
 
     "produce person names with at least 2 characters" in {

--- a/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
@@ -181,6 +181,14 @@ class RandomFeedersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
       }
     }
 
+    "preserve surrounding spaces in regex patterns" in {
+      val value = Faker.string.matching(" [A-Z]{2} ").sample()
+
+      value should startWith(" ")
+      value should endWith(" ")
+      value should have length 4
+    }
+
     "create SequentialFeeder" in {
       forAll(rndString, positiveInt, positiveInt) { (paramName, start, step) =>
         val list = SequentialFeeder(paramName, start, step).take(50).toList.flatten

--- a/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.feeders
 
+import org.galaxio.gatling.feeders.faker.Faker
 import org.scalacheck._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -165,6 +166,18 @@ class RandomFeedersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
               record(paramName) should fullyMatch regex regexPattern
             },
           )
+      }
+    }
+
+    "create RegexFeeder with fresh values on each record" in {
+      val values = RegexFeeder("rx", "[A-Z]{2}[0-9]{4}").take(20).map(_("rx").toString).toList
+      values.distinct.size should be > 1
+      values.foreach(_ should fullyMatch regex "[A-Z]{2}[0-9]{4}")
+    }
+
+    "fail fast for invalid regex generator patterns" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.string.matching("[A-Z").sample()
       }
     }
 

--- a/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
@@ -175,6 +175,14 @@ class RandomFeedersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
       values.foreach(_ should fullyMatch regex "[A-Z]{2}[0-9]{4}")
     }
 
+    "preserve surrounding spaces through RegexFeeder" in {
+      val value = RegexFeeder("rx", " [A-Z]{2} ").next()("rx").toString
+
+      value should startWith(" ")
+      value should endWith(" ")
+      value should have length 4
+    }
+
     "fail fast for invalid regex generator patterns" in {
       assertThrows[IllegalArgumentException] {
         Faker.string.matching("[A-Z").sample()


### PR DESCRIPTION
Reopens #148 against the review-only base branch.

Fixes #62.

This PR restores the original change set so review comments and benchmark feedback can be revisited.