### PR TITLE
fix(utils): correct http timeout default (#50)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
@@ -5,7 +5,14 @@ import java.net.http.HttpClient.Redirect
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.time.Duration
 
-case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3000) {
+/** Lightweight JDK HttpClient wrapper used by feeders and utility clients.
+  *
+  * @param followRedirects
+  *   JDK redirect policy name
+  * @param connectTimeoutInSeconds
+  *   connection timeout in seconds
+  */
+case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3) {
 
   private val jsonContentType: String = "application/json"
   private val client: HttpClient      = buildClient()

--- a/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
@@ -1,0 +1,21 @@
+package org.galaxio.gatling.utils
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class THttpClientSpec extends AnyWordSpec with Matchers {
+
+  "THttpClient" should {
+    "default to a 3 second connection timeout" in {
+      val client = THttpClient().buildClient()
+
+      client.connectTimeout().get().toSeconds shouldBe 3L
+    }
+
+    "respect custom connection timeout values" in {
+      val client = THttpClient(connectTimeoutInSeconds = 5).buildClient()
+
+      client.connectTimeout().get().toSeconds shouldBe 5L
+    }
+  }
+}


### PR DESCRIPTION
Reopens #149 against the review-only base branch.

Fixes #50.

This PR restores the original change set so review comments and benchmark feedback can be revisited.