### PR TITLE
fix(config): mask common secret keys (#58)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
+++ b/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
@@ -11,6 +11,14 @@ private[config] object ConfigValueMasking {
     "api-key",
     "api_key",
     "credential",
+    "privatekey",
+    "private_key",
+    "clientsecret",
+    "client_secret",
+    "accesskey",
+    "access_key",
+    "secretkey",
+    "secret_key",
   )
 
   def displayValue(path: String, value: Any): String =

--- a/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
@@ -119,11 +119,37 @@ class ConfigValueMaskingSpec extends AnyWordSpec with Matchers {
         "client.api-key",
         "client.api_key",
         "aws.credential",
+        "vault.private_key",
+        "vault.client_secret",
+        "aws.access_key",
+        "secrets.secret_key",
       )
 
       sensitivePaths.foreach { path =>
         ConfigValueMasking.displayValue(path, "raw-value") shouldBe "******"
         ConfigValueMasking.isSensitive(path) shouldBe true
+      }
+    }
+
+    "mask representative hocon secret keys" in {
+      val config = ConfigFactory.parseString("""
+          |secrets {
+          |  private_key = "private"
+          |  client_secret = "client"
+          |  access_key = "access"
+          |  secret_key = "secret"
+          |}
+          |""".stripMargin)
+
+      val secretPaths = Seq(
+        "secrets.private_key",
+        "secrets.client_secret",
+        "secrets.access_key",
+        "secrets.secret_key",
+      )
+
+      secretPaths.foreach { path =>
+        ConfigValueMasking.displayValue(path, config.getString(path)) shouldBe "******"
       }
     }
 


### PR DESCRIPTION
Reopens #151 against the review-only base branch.

Fixes #58.

This PR restores the original change set so review comments and benchmark feedback can be revisited.