### PR TITLE
test(storage): cover withbackend queue independence

### DIFF
--- a/src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala
@@ -91,6 +91,21 @@ class SessionStorageSpec extends AnyWordSpec with Matchers {
       withBe.toFeeder.head("key") shouldBe "value"
     }
 
+    "withBackend keeps record queues independent after copying" in {
+      val storage = SessionStorage()
+      storage.addRecord(Map("source" -> "original"))
+
+      val tmpFile = java.io.File.createTempFile("storage-test3", ".json")
+      tmpFile.deleteOnExit()
+      val withBe  = storage.withBackend(JsonFileBackend(tmpFile.getAbsolutePath))
+
+      withBe.addRecord(Map("source" -> "backend"))
+      storage.addRecord(Map("source" -> "memory"))
+
+      storage.toFeeder.map(_("source")) should contain theSameElementsInOrderAs Seq("original", "memory")
+      withBe.toFeeder.map(_("source")) should contain theSameElementsInOrderAs Seq("original", "backend")
+    }
+
   }
 
   implicit class TestHelper(storage: SessionStorage) {


### PR DESCRIPTION
## Summary

Adds a regression test around `SessionStorage.withBackend` to verify the new instance gets an independent record queue after copying existing records.

Refs #53.

## Validation

- `sbt --batch 'testOnly org.galaxio.gatling.storage.SessionStorageSpec org.galaxio.gatling.storage.StorageBackendSpec'`
