### PR TITLE
fix(repo): address critical issue regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,6 +605,7 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -696,6 +697,42 @@ jobs:
             git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
             git push origin "$NEXT_TAG"
           fi
+
+      - name: Run Trivy vulnerability gate
+        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          hide-progress: true
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload Trivy scan results
+        if: always() && (startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag))
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Generate and submit release SBOM
+        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: github
+          output: dependency-results.sbom.json
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release SBOM artifact
+        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-sbom
+          path: dependency-results.sbom.json
 
       - name: Publish to Sonatype via sbt-ci-release
         if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   lazy val scalaTesting: Seq[ModuleID] = scalaCheck ++ scalaTest ++ scalaMock ++ scalaTestPlus ++ testcontainers
 
   lazy val junit: Seq[ModuleID] = Seq(
-    "org.junit.jupiter"    % "junit-jupiter"     % "6.0.2"  % "test,it",
+    "org.junit.jupiter"    % "junit-jupiter"     % "5.10.5" % "test,it",
     "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % "test,it",
     "org.assertj"          % "assertj-core"      % "3.27.6" % "test,it",
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,7 +78,7 @@ object Dependencies {
 
   lazy val junit: Seq[ModuleID] = Seq(
     "org.junit.jupiter"    % "junit-jupiter"     % "5.10.5" % "test,it",
-    "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % "test,it",
+    "com.github.sbt.junit" % "jupiter-interface" % "0.12.0" % "test,it",
     "org.assertj"          % "assertj-core"      % "3.27.6" % "test,it",
   )
 

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -3,7 +3,7 @@ package org.galaxio.gatling.feeders
 import io.gatling.core.feeder.Record
 import org.galaxio.gatling.utils.THttpClient
 import org.json4s.native.JsonMethods
-import org.json4s.{DefaultFormats, JValue}
+import org.json4s.{DefaultFormats, Extraction, JValue}
 
 import java.util.Objects.requireNonNull
 
@@ -21,7 +21,7 @@ object VaultFeeder {
 
     implicit val formats: DefaultFormats = org.json4s.DefaultFormats
 
-    val body: String = s"""{"role_id":"$roleId","secret_id":"$secretId"}"""
+    val body = approleLoginBody(roleId, secretId)
 
     val vaultTokenResponse: String = THttpClient()
       .POSTJson(s"""$vaultUrl/v1/auth/approle/login""", body)
@@ -88,4 +88,7 @@ object VaultFeeder {
     val selectedKeys = keys.toSet
     data.view.filterKeys(selectedKeys.contains).toMap
   }
+
+  private[feeders] def approleLoginBody(roleId: String, secretId: String)(implicit formats: DefaultFormats): String =
+    JsonMethods.compact(JsonMethods.render(Extraction.decompose(Map("role_id" -> roleId, "secret_id" -> secretId))))
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -2,7 +2,7 @@ package org.galaxio.gatling.feeders
 
 import io.gatling.core.feeder.Record
 import org.galaxio.gatling.utils.THttpClient
-import org.json4s.native.JsonMethods
+import org.json4s.native.JsonMethods.{compact, parse, render}
 import org.json4s.{DefaultFormats, Extraction, JValue}
 
 import java.util.Objects.requireNonNull
@@ -27,16 +27,14 @@ object VaultFeeder {
       .POSTJson(s"""$vaultUrl/v1/auth/approle/login""", body)
       .body()
 
-    val vaultTokenJson: JValue = JsonMethods.parse(vaultTokenResponse)
-    val client_token: JValue   = vaultTokenJson \ "auth" \ "client_token"
-    val vaultToken: String     = client_token.values.toString
+    val vaultToken = extractClientToken(parse(vaultTokenResponse))
 
     val getHeaders: Seq[String]   = Seq("X-Vault-Token", s"""$vaultToken""")
     val vaultDataResponse: String = THttpClient()
       .GET(s"""$vaultUrl/v1/$secretPath""", getHeaders)
       .body()
 
-    val vaultDataJson: JValue = JsonMethods.parse(vaultDataResponse)
+    val vaultDataJson: JValue = parse(vaultDataResponse)
     val data: Record[String]  = (vaultDataJson \ "data").extract[Map[String, String]]
 
     IndexedSeq(filterRecord(data, keys))
@@ -78,7 +76,7 @@ object VaultFeeder {
       .GET(s"""$vaultUrl/v1/$secretPath""", getHeaders)
       .body()
 
-    val vaultDataJson: JValue = JsonMethods.parse(vaultDataResponse)
+    val vaultDataJson: JValue = parse(vaultDataResponse)
     val data: Record[String]  = (vaultDataJson \ "data").extract[Map[String, String]]
 
     IndexedSeq(filterRecord(data, keys))
@@ -90,5 +88,8 @@ object VaultFeeder {
   }
 
   private[feeders] def approleLoginBody(roleId: String, secretId: String)(implicit formats: DefaultFormats): String =
-    JsonMethods.compact(JsonMethods.render(Extraction.decompose(Map("role_id" -> roleId, "secret_id" -> secretId))))
+    compact(render(Extraction.decompose(Map("role_id" -> roleId, "secret_id" -> secretId))))
+
+  private[feeders] def extractClientToken(vaultTokenJson: JValue)(implicit formats: DefaultFormats): String =
+    (vaultTokenJson \ "auth" \ "client_token").extract[String]
 }

--- a/src/main/scala/org/galaxio/gatling/redis/RedisAction.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisAction.scala
@@ -31,7 +31,7 @@ case class RedisAction(
           val result = clientPool.withClient(client => command.execute(client))
           val end    = if (statsEnabled) clock.nowMillis else 0L
 
-          val updatedSession = saveAsVar.fold(session)(varName => session.set(varName, result.orNull))
+          val updatedSession = RedisAction.updateSessionWithResult(session, saveAsVar, result)
 
           if (statsEnabled) {
             statsEngine.logResponse(
@@ -89,4 +89,16 @@ case class RedisAction(
     }
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
+}
+
+object RedisAction {
+  private[redis] def updateSessionWithResult(
+      session: Session,
+      saveAsVar: Option[String],
+      result: Option[Any],
+  ): Session =
+    saveAsVar match {
+      case Some(varName) => result.fold(session)(value => session.set(varName, value))
+      case None          => session
+    }
 }

--- a/src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala
@@ -17,4 +17,12 @@ class VaultFeederSpec extends AnyWordSpec with Matchers {
       (parse(body) \ "secret_id").extract[String] shouldBe "secret\nid"
     }
   }
+
+  "VaultFeeder.extractClientToken" should {
+    "extract the raw token string from the auth payload" in {
+      val payload = parse("""{"auth":{"client_token":"vault-token-123"}}""")
+
+      VaultFeeder.extractClientToken(payload) shouldBe "vault-token-123"
+    }
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala
@@ -1,0 +1,20 @@
+package org.galaxio.gatling.feeders
+
+import org.json4s.DefaultFormats
+import org.json4s.native.JsonMethods.parse
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class VaultFeederSpec extends AnyWordSpec with Matchers {
+
+  implicit private val formats: DefaultFormats = DefaultFormats
+
+  "VaultFeeder.approleLoginBody" should {
+    "escape credentials without string interpolation artifacts" in {
+      val body = VaultFeeder.approleLoginBody("role\"id", "secret\nid")
+
+      (parse(body) \ "role_id").extract[String] shouldBe "role\"id"
+      (parse(body) \ "secret_id").extract[String] shouldBe "secret\nid"
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/redis/RedisActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/redis/RedisActionSpec.scala
@@ -1,0 +1,34 @@
+package org.galaxio.gatling.redis
+
+import org.galaxio.gatling.transactions.fixtures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class RedisActionSpec extends AnyWordSpec with Matchers {
+
+  "RedisAction.updateSessionWithResult" should {
+    "store the redis value when a result is present" in {
+      val session = fixtures.emptySession("redis-action")
+
+      val updated = RedisAction.updateSessionWithResult(session, Some("redisValue"), Some("cached-token"))
+
+      updated("redisValue").as[String] shouldBe "cached-token"
+    }
+
+    "leave the session unchanged when the redis result is missing" in {
+      val session = fixtures.emptySession("redis-action")
+
+      val updated = RedisAction.updateSessionWithResult(session, Some("redisValue"), None)
+
+      updated.contains("redisValue") shouldBe false
+    }
+
+    "leave the session unchanged when nothing should be saved" in {
+      val session = fixtures.emptySession("redis-action")
+
+      val updated = RedisAction.updateSessionWithResult(session, None, Some("cached-token"))
+
+      updated.attributes shouldBe session.attributes
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- harden Vault AppRole auth payload construction and typed token extraction
- avoid writing null Redis results into Gatling sessions
- pin junit-jupiter back to 5.10.5 and add release vulnerability/SBOM gates
- add regression coverage for Vault and Redis behavior

Closes #57, closes #49, closes #51, closes #59, closes #60

## Testing
- sbt "testOnly org.galaxio.gatling.feeders.VaultFeederSpec org.galaxio.gatling.redis.RedisActionSpec org.galaxio.gatling.storage.CookieParserSpec org.galaxio.gatling.storage.StorageBackendSpec" 
- sbt "it:testOnly org.galaxio.gatling.feeders.VaultIntegrationSpec"