### PR TITLE
fix(utils): add per-request timeout to THttpClient

### DIFF
--- a/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
@@ -7,12 +7,22 @@ import java.time.Duration
 
 /** Lightweight JDK HttpClient wrapper used by feeders and utility clients.
   *
+  * This client is intended for feeder setup and configuration fetching, not for the Gatling virtual-user hot path.
+  *
   * @param followRedirects
   *   JDK redirect policy name
   * @param connectTimeoutInSeconds
-  *   connection timeout in seconds
+  *   connection timeout in seconds; must be &gt; 0
+  * @param requestTimeoutInSeconds
+  *   per-request read timeout in seconds (0 = no timeout); must be &ge; 0
   */
-case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3) {
+case class THttpClient(
+    followRedirects: String = "NEVER",
+    connectTimeoutInSeconds: Long = 3,
+    requestTimeoutInSeconds: Long = 30,
+) {
+  require(connectTimeoutInSeconds > 0, s"connectTimeoutInSeconds must be > 0, got $connectTimeoutInSeconds")
+  require(requestTimeoutInSeconds >= 0, s"requestTimeoutInSeconds must be >= 0, got $requestTimeoutInSeconds")
 
   private val jsonContentType: String = "application/json"
 
@@ -23,8 +33,12 @@ case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSecond
       .followRedirects(Redirect.valueOf(followRedirects))
       .build()
 
+  private def applyTimeout(builder: HttpRequest.Builder): HttpRequest.Builder =
+    if (requestTimeoutInSeconds > 0) builder.timeout(Duration.ofSeconds(requestTimeoutInSeconds))
+    else builder
+
   def GET(uri: String, headers: Seq[String] = Seq.empty): HttpResponse[String] = {
-    val builder = HttpRequest.newBuilder().uri(URI.create(uri))
+    val builder = applyTimeout(HttpRequest.newBuilder().uri(URI.create(uri)))
     if (headers.nonEmpty) builder.headers(headers: _*)
     client.send(builder.build(), HttpResponse.BodyHandlers.ofString)
   }
@@ -32,13 +46,13 @@ case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSecond
   def POSTJson(uri: String, json: String, headers: Seq[String] = Seq.empty): HttpResponse[String] = {
     val hdrs: Seq[String] = Seq("Content-Type", jsonContentType) ++ headers
 
-    val request: HttpRequest = HttpRequest
-      .newBuilder()
-      .POST(HttpRequest.BodyPublishers.ofString(json))
-      .uri(URI.create(uri))
-      .headers(hdrs: _*)
-      .build()
-
-    client.send(request, HttpResponse.BodyHandlers.ofString)
+    val builder = applyTimeout(
+      HttpRequest
+        .newBuilder()
+        .uri(URI.create(uri))
+        .POST(HttpRequest.BodyPublishers.ofString(json)),
+    )
+    builder.headers(hdrs: _*)
+    client.send(builder.build(), HttpResponse.BodyHandlers.ofString)
   }
 }

--- a/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
@@ -91,5 +91,42 @@ class THttpClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
       val response = client.GET(s"http://localhost:$port/get")
       response.statusCode() shouldBe 200
     }
+
+    "timeout on slow response when requestTimeoutInSeconds is set" in {
+      server.createContext(
+        "/slow",
+        (ex: HttpExchange) => {
+          Thread.sleep(10000) // 10s — well above 2s timeout to avoid CI flakiness
+          val body = "late".getBytes(StandardCharsets.UTF_8)
+          ex.sendResponseHeaders(200, body.length.toLong)
+          val os   = ex.getResponseBody
+          os.write(body)
+          os.close()
+        },
+      )
+
+      val client = THttpClient(requestTimeoutInSeconds = 2)
+      a[java.net.http.HttpTimeoutException] should be thrownBy {
+        client.GET(s"http://localhost:$port/slow")
+      }
+    }
+
+    "allow disabling request timeout with 0" in {
+      val client   = THttpClient(requestTimeoutInSeconds = 0)
+      val response = client.GET(s"http://localhost:$port/get")
+      response.statusCode() shouldBe 200
+    }
+
+    "reject negative requestTimeoutInSeconds" in {
+      an[IllegalArgumentException] should be thrownBy {
+        THttpClient(requestTimeoutInSeconds = -1)
+      }
+    }
+
+    "reject zero connectTimeoutInSeconds" in {
+      an[IllegalArgumentException] should be thrownBy {
+        THttpClient(connectTimeoutInSeconds = 0)
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add `requestTimeoutInSeconds` parameter to `THttpClient` (default: 30s) — sets JDK `HttpRequest.timeout` on every GET and POST call
- Prevents slow/unreachable endpoints from hanging feeder startup indefinitely (e.g. misconfigured Vault hangs CI until job-level kill)
- Set to 0 to disable per-request timeout (only connect timeout applies)
- Add `require` guards: `connectTimeoutInSeconds > 0` and `requestTimeoutInSeconds >= 0` — caught at construction, not at first request
- Document `THttpClient` as feeder-infrastructure (not Gatling hot path) in scaladoc

## ⚠️ Behavior change

**Existing `THttpClient()` callers gain a 30s per-request timeout.** Previously no request timeout — slow Vault/HTTP endpoints would hang. This now fails fast with `HttpTimeoutException`. Callers that need the old behavior can pass `requestTimeoutInSeconds = 0`.

Affected internal call sites:
- `HttpJsonFeeder.sharedClient` — feeds JSON config from HTTP, 30s should cover typical responses
- `VaultFeeder` — Vault GET/POST, 30s should cover any healthy Vault

## Test plan

- [x] `timeout on slow response when requestTimeoutInSeconds is set` — 10s sleep + 2s timeout, verifies `HttpTimeoutException`
- [x] `allow disabling request timeout with 0`
- [x] `reject negative requestTimeoutInSeconds` — validation guard
- [x] `reject zero connectTimeoutInSeconds` — validation guard
- [x] Full suite: 572 tests pass, no regressions

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)