### PR TITLE
fix(build): separate unit and integration test scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           restore-keys: sbt-${{ runner.os }}-
 
       - name: Test
-        run: sbt test
+        run: sbt Test/test
 
   template-tests:
     name: Template / ${{ matrix.template }} (Java ${{ matrix.java-version }})

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies.*
 
 def UtilsModule(id: String) = Project(id, file(id))
-lazy val IntegrationTest    = config("it") extend Runtime
+lazy val IntegrationTest    = config("it") extend Test
 
 lazy val root = (project in file("."))
   .enablePlugins(GitVersioning, JmhPlugin)


### PR DESCRIPTION
## Summary

`build.sbt` declared `IntegrationTest = config("it") extend Runtime`, which means IT sources see the runtime classpath but not the test helpers. More importantly, CI ran `sbt test` without an explicit config scope, making the intent ambiguous.

## Changes

- Change `config("it") extend Runtime` → `config("it") extend Test` so the IT config properly inherits test dependencies and compiler options
- Change CI test job command from `sbt test` to `sbt Test/test` to be explicit and prevent accidental co-execution with IntegrationTest tasks

## Testing

Compile confirms the build.sbt change is valid. The separate `IntegrationTest/test` path remains unaffected (still exercised by the `redis-integration` CI job).

Fixes #78