### PR TITLE
fix(ci): include integration tests in coverage measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -276,7 +276,7 @@ jobs:
           restore-keys: sbt-${{ runner.os }}-
 
       - name: Coverage
-        run: sbt clean coverage test coverageOff coverageReport coverageAggregate
+        run: sbt clean coverage test "IntegrationTest/test" coverageOff coverageReport coverageAggregate
 
       - name: Upload coverage reports to Codecov
         if: always()


### PR DESCRIPTION
## Summary

The `coverage` CI job ran `sbt clean coverage test ...` which only instruments `Test` (unit tests). Redis and Vault integration code was never included in scoverage reports, so reported coverage understated real exercise and overstated unit-test isolation.

## Changes

- Add `"IntegrationTest/test"` to the coverage sbt command so both unit and integration suites run under scoverage instrumentation before `coverageReport`/`coverageAggregate`
- Bump coverage job `timeout-minutes` from 30 → 45 to accommodate testcontainers pull + startup on top of the existing unit suite

## Testing

The sequence `coverage test "IntegrationTest/test" coverageOff coverageReport coverageAggregate` follows the standard sbt-scoverage multi-suite pattern. testcontainers (Vault, Redis) are already available on ubuntu-24.04 runners as demonstrated by the `redis-integration` job.

Fixes #77