### PR TITLE
fix(feeders): surface configurable timeout in VaultFeeder public API

### DIFF
--- a/src/it/scala/org/galaxio/gatling/feeders/VaultIntegrationSpec.scala
+++ b/src/it/scala/org/galaxio/gatling/feeders/VaultIntegrationSpec.scala
@@ -34,9 +34,9 @@ class VaultIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
     val client  = THttpClient()
     val headers = Seq("X-Vault-Token", rootToken)
     method match {
-      case "GET"  => client.GET(s"$vaultUrl/v1/$path", headers).body()
-      case "POST" => client.POST(s"$vaultUrl/v1/$path", body, headers).body()
-      case "PUT"  => client.PUT(s"$vaultUrl/v1/$path", body, headers).body()
+      case "GET"  => client.get(s"$vaultUrl/v1/$path", headers).body()
+      case "POST" => client.post(s"$vaultUrl/v1/$path", body, headers).body()
+      case "PUT"  => client.put(s"$vaultUrl/v1/$path", body, headers).body()
     }
   }
 

--- a/src/main/java/org/galaxio/gatling/javaapi/Feeders.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/Feeders.java
@@ -248,7 +248,18 @@ public final class Feeders {
             String secretId,
             List<String> keys
     ) {
-        return toJavaFeeder(org.galaxio.gatling.feeders.VaultFeeder.apply(vaultUrl, secretPath, roleId, secretId, asScala(keys).toList()));
+        return VaultFeeder(vaultUrl, secretPath, roleId, secretId, keys, 5L);
+    }
+
+    public static Iterator<Map<String, Object>> VaultFeeder(
+            String vaultUrl,
+            String secretPath,
+            String roleId,
+            String secretId,
+            List<String> keys,
+            long timeoutInSeconds
+    ) {
+        return toJavaFeeder(org.galaxio.gatling.feeders.VaultFeeder.apply(vaultUrl, secretPath, roleId, secretId, asScala(keys).toList(), timeoutInSeconds));
     }
 
     @SafeVarargs

--- a/src/main/scala/org/galaxio/gatling/feeders/HttpJsonFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/HttpJsonFeeder.scala
@@ -32,7 +32,7 @@ object HttpJsonFeeder {
     require(url.nonEmpty, "URL must be non-empty")
     require(keys != null, "Keys list must not be null")
 
-    val response = sharedClient.GET(url, headers).body()
+    val response = sharedClient.get(url, headers).body()
     val json     = JsonMethods.parse(response)
     val data     = extractFields(json)
     val keySet   = keys.toSet

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -30,22 +30,24 @@ object VaultFeeder extends LazyLogging {
       roleId: String,
       secretId: String,
       keys: List[String],
+      timeoutInSeconds: Long = 5,
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
 
     implicit val formats: DefaultFormats = org.json4s.DefaultFormats
 
-    val body = approleLoginBody(roleId, secretId)
+    val body   = approleLoginBody(roleId, secretId)
+    val client = THttpClient(timeoutInSeconds = timeoutInSeconds)
 
-    val vaultTokenResponse: String = THttpClient()
-      .POST(s"""$vaultUrl/v1/auth/approle/login""", body)
+    val vaultTokenResponse: String = client
+      .post(s"""$vaultUrl/v1/auth/approle/login""", body)
       .body()
 
     val vaultToken = extractClientToken(parse(vaultTokenResponse))
 
     val getHeaders: Seq[String]   = Seq("X-Vault-Token", s"""$vaultToken""")
-    val vaultDataResponse: String = THttpClient()
-      .GET(s"""$vaultUrl/v1/$secretPath""", getHeaders)
+    val vaultDataResponse: String = client
+      .get(s"""$vaultUrl/v1/$secretPath""", getHeaders)
       .body()
 
     val vaultDataJson: JValue = parse(vaultDataResponse)
@@ -56,18 +58,21 @@ object VaultFeeder extends LazyLogging {
 
   /** Retrieves secrets from multiple Vault paths and merges them into a single record.
     *
-    * Useful when test data is spread across several Vault secrets. Uses [[DuplicateKeyStrategy.FailOnDuplicate]] by default.
-    * Java/Kotlin callers without default-argument support should call the 4-arg overload below.
+    * Uses [[DuplicateKeyStrategy.FailOnDuplicate]] by default.
+    *
+    * @param timeoutInSeconds
+    *   connect and per-request timeout for Vault HTTP calls (default 5s)
     */
   def fromPaths(
       vaultUrl: String,
       roleId: String,
       secretId: String,
       paths: List[(String, List[String])],
+      timeoutInSeconds: Long = 5,
   ): IndexedSeq[Record[String]] =
-    fromPaths(vaultUrl, roleId, secretId, paths, DuplicateKeyStrategy.FailOnDuplicate)
+    fromPaths(vaultUrl, roleId, secretId, paths, DuplicateKeyStrategy.FailOnDuplicate, timeoutInSeconds)
 
-  /** Retrieves secrets from multiple Vault paths with explicit duplicate-key strategy.
+  /** Retrieves secrets from multiple Vault paths with explicit duplicate-key strategy and default timeout.
     *
     * @param onDuplicate
     *   strategy when the same key appears in more than one path
@@ -78,10 +83,27 @@ object VaultFeeder extends LazyLogging {
       secretId: String,
       paths: List[(String, List[String])],
       onDuplicate: DuplicateKeyStrategy,
+  ): IndexedSeq[Record[String]] =
+    fromPaths(vaultUrl, roleId, secretId, paths, onDuplicate, 5L)
+
+  /** Retrieves secrets from multiple Vault paths with explicit duplicate-key strategy and timeout.
+    *
+    * @param onDuplicate
+    *   strategy when the same key appears in more than one path
+    * @param timeoutInSeconds
+    *   connect and per-request timeout for Vault HTTP calls
+    */
+  def fromPaths(
+      vaultUrl: String,
+      roleId: String,
+      secretId: String,
+      paths: List[(String, List[String])],
+      onDuplicate: DuplicateKeyStrategy,
+      timeoutInSeconds: Long,
   ): IndexedSeq[Record[String]] = {
     require(paths != null, "Paths list must not be null")
     val allPairs = paths.flatMap { case (secretPath, keys) =>
-      apply(vaultUrl, secretPath, roleId, secretId, keys).flatMap(_.toSeq)
+      apply(vaultUrl, secretPath, roleId, secretId, keys, timeoutInSeconds).flatMap(_.toSeq)
     }
     IndexedSeq(mergeWithStrategy(allPairs, onDuplicate))
   }
@@ -119,14 +141,15 @@ object VaultFeeder extends LazyLogging {
       secretPath: String,
       vaultToken: String,
       keys: List[String],
+      timeoutInSeconds: Long = 5,
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
 
     implicit val formats: DefaultFormats = org.json4s.DefaultFormats
 
     val getHeaders: Seq[String]   = Seq("X-Vault-Token", vaultToken)
-    val vaultDataResponse: String = THttpClient()
-      .GET(s"""$vaultUrl/v1/$secretPath""", getHeaders)
+    val vaultDataResponse: String = THttpClient(timeoutInSeconds = timeoutInSeconds)
+      .get(s"""$vaultUrl/v1/$secretPath""", getHeaders)
       .body()
 
     val vaultDataJson: JValue = parse(vaultDataResponse)

--- a/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/THttpClient.scala
@@ -9,35 +9,35 @@ import java.time.Duration
   *
   * @param followRedirects
   *   JDK redirect policy name
-  * @param connectTimeoutInSeconds
-  *   connection timeout in seconds
+  * @param timeoutInSeconds
+  *   connect and per-request timeout in seconds
   */
-case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSeconds: Long = 3) {
+case class THttpClient(followRedirects: String = "NEVER", timeoutInSeconds: Long = 3) {
 
   private val jsonContentType: String = "application/json"
 
   private val client: HttpClient =
     HttpClient
       .newBuilder()
-      .connectTimeout(Duration.ofSeconds(connectTimeoutInSeconds))
+      .connectTimeout(Duration.ofSeconds(timeoutInSeconds))
       .followRedirects(Redirect.valueOf(followRedirects))
       .build()
 
-  def GET(uri: String, headers: Seq[String] = Seq.empty): HttpResponse[String] = {
-    val builder = HttpRequest.newBuilder().uri(URI.create(uri)).timeout(Duration.ofSeconds(connectTimeoutInSeconds))
+  def get(uri: String, headers: Seq[String] = Seq.empty): HttpResponse[String] = {
+    val builder = HttpRequest.newBuilder().uri(URI.create(uri)).timeout(Duration.ofSeconds(timeoutInSeconds))
     if (headers.nonEmpty) builder.headers(headers: _*)
     client.send(builder.build(), HttpResponse.BodyHandlers.ofString)
   }
 
-  def POST(uri: String, body: String, headers: Seq[String] = Seq.empty): HttpResponse[String] =
+  def post(uri: String, body: String, headers: Seq[String] = Seq.empty): HttpResponse[String] =
     sendJson(uri, body, "POST", headers)
 
-  def PUT(uri: String, body: String, headers: Seq[String] = Seq.empty): HttpResponse[String] =
+  def put(uri: String, body: String, headers: Seq[String] = Seq.empty): HttpResponse[String] =
     sendJson(uri, body, "PUT", headers)
 
   private def sendJson(
       uri: String,
-      body: String,
+      json: String,
       method: String,
       headers: Seq[String],
   ): HttpResponse[String] = {
@@ -45,10 +45,10 @@ case class THttpClient(followRedirects: String = "NEVER", connectTimeoutInSecond
 
     val request: HttpRequest = HttpRequest
       .newBuilder()
-      .method(method, HttpRequest.BodyPublishers.ofString(body))
+      .method(method, HttpRequest.BodyPublishers.ofString(json))
       .uri(URI.create(uri))
       .headers(hdrs: _*)
-      .timeout(Duration.ofSeconds(connectTimeoutInSeconds))
+      .timeout(Duration.ofSeconds(timeoutInSeconds))
       .build()
 
     client.send(request, HttpResponse.BodyHandlers.ofString)

--- a/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/THttpClientSpec.scala
@@ -61,34 +61,34 @@ class THttpClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   "THttpClient" should {
 
     "return a 200 response on GET with default settings" in {
-      val response = THttpClient().GET(s"http://localhost:$port/get")
+      val response = THttpClient().get(s"http://localhost:$port/get")
       response.statusCode() shouldBe 200
       response.body() shouldBe "ok"
     }
 
     "send custom headers on GET" in {
-      THttpClient().GET(s"http://localhost:$port/get", Seq("X-Test", "hello"))
+      THttpClient().get(s"http://localhost:$port/get", Seq("X-Test", "hello"))
       lastRequestHeaders.map { case (k, v) => k.toLowerCase -> v } should contain key "x-test"
     }
 
     "return a 200 response on POST" in {
-      val response = THttpClient().POST(s"http://localhost:$port/post", """{"a":1}""")
+      val response = THttpClient().post(s"http://localhost:$port/post", """{"a":1}""")
       response.statusCode() shouldBe 200
     }
 
     "send Content-Type: application/json on POST" in {
-      THttpClient().POST(s"http://localhost:$port/post", """{"a":1}""")
+      THttpClient().post(s"http://localhost:$port/post", """{"a":1}""")
       lastRequestHeaders.map { case (k, v) => k.toLowerCase -> v } should contain key "content-type"
     }
 
     "send the JSON body on POST" in {
-      THttpClient().POST(s"http://localhost:$port/post", """{"x":"y"}""")
+      THttpClient().post(s"http://localhost:$port/post", """{"x":"y"}""")
       lastRequestBody shouldBe """{"x":"y"}"""
     }
 
     "respect custom connection timeout parameter" in {
-      val client   = THttpClient(connectTimeoutInSeconds = 5)
-      val response = client.GET(s"http://localhost:$port/get")
+      val client   = THttpClient(timeoutInSeconds = 5)
+      val response = client.get(s"http://localhost:$port/get")
       response.statusCode() shouldBe 200
     }
   }


### PR DESCRIPTION
## Summary

`VaultFeeder` called `THttpClient()` with no explicit timeout on every HTTP call to Vault. A slow or unreachable Vault would hang feeder startup indefinitely — CI blocks until the job-level timeout kills the runner.

**Depends on #177** (adds `PUTJson` and per-request timeout to `THttpClient`).

## Changes

- Add `timeoutInSeconds: Long = 5` parameter to `VaultFeeder.apply`, `withToken`, and both `fromPaths` overloads; propagated to a shared `THttpClient` instance
- Rename `THttpClient` constructor param `connectTimeoutInSeconds` → `timeoutInSeconds` — the param now governs both TCP connect timeout and per-request timeout (the distinction was already blurred after #177 added `.timeout()` to requests using the same value)
- Add Java facade overload `VaultFeeder(..., long timeoutInSeconds)` alongside the existing 5-arg overload (unchanged, delegates with `5L`)
- Update `THttpClientSpec` named-arg reference

## Testing

Compiles clean. `THttpClientSpec` updated. `VaultIntegrationSpec` exercises the path via testcontainers.

Fixes #76