### PR TITLE
fix(feeders): VaultFeeder error handling and token reuse in fromPaths

### DIFF
--- a/src/it/scala/org/galaxio/gatling/feeders/VaultIntegrationSpec.scala
+++ b/src/it/scala/org/galaxio/gatling/feeders/VaultIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package org.galaxio.gatling.feeders
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
-import org.galaxio.gatling.utils.{HttpClientException, THttpClient}
+import org.galaxio.gatling.utils.{HttpClientException, HttpMethod, THttpClient}
 import org.json4s.DefaultFormats
 import org.json4s.native.JsonMethods
 import org.scalatest.matchers.should.Matchers
@@ -200,7 +200,7 @@ class VaultIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
         VaultFeeder(vaultUrl, s"$kvMount/test/creds", "bad-role", "bad-secret", List("x"))
       }
       ex.statusCode shouldBe 400
-      ex.method shouldBe "POST"
+      ex.method shouldBe HttpMethod.Post
       ex.getMessage should include("auth/approle/login")
     }
 

--- a/src/it/scala/org/galaxio/gatling/feeders/VaultIntegrationSpec.scala
+++ b/src/it/scala/org/galaxio/gatling/feeders/VaultIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package org.galaxio.gatling.feeders
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
-import org.galaxio.gatling.utils.THttpClient
+import org.galaxio.gatling.utils.{HttpClientException, THttpClient}
 import org.json4s.DefaultFormats
 import org.json4s.native.JsonMethods
 import org.scalatest.matchers.should.Matchers
@@ -174,6 +174,42 @@ class VaultIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestCont
       result.head("key") shouldBe "first"
       result.head("a") shouldBe "1"
       result.head("b") shouldBe "2"
+    }
+
+    "merge secrets from three paths with single login" in {
+      writeSecret(s"$kvMount/test/tri-a", Map("a" -> "1"))
+      writeSecret(s"$kvMount/test/tri-b", Map("b" -> "2"))
+      writeSecret(s"$kvMount/test/tri-c", Map("c" -> "3"))
+
+      val paths = List(
+        (s"$kvMount/test/tri-a", List("a")),
+        (s"$kvMount/test/tri-b", List("b")),
+        (s"$kvMount/test/tri-c", List("c")),
+      )
+
+      val result = VaultFeeder.fromPaths(vaultUrl, appRoleId, appSecretId, paths)
+
+      result should have size 1
+      result.head shouldBe Map("a" -> "1", "b" -> "2", "c" -> "3")
+    }
+  }
+
+  "VaultFeeder error handling" should {
+    "throw HttpClientException on bad AppRole credentials" in {
+      val ex = the[HttpClientException] thrownBy {
+        VaultFeeder(vaultUrl, s"$kvMount/test/creds", "bad-role", "bad-secret", List("x"))
+      }
+      ex.statusCode shouldBe 400
+      ex.method shouldBe "POST"
+      ex.getMessage should include("auth/approle/login")
+    }
+
+    "throw HttpClientException on non-existent secret path" in {
+      val ex = the[HttpClientException] thrownBy {
+        VaultFeeder.withToken(vaultUrl, s"$kvMount/nonexistent/path", rootToken, List("x"))
+      }
+      ex.statusCode shouldBe 404
+      ex.getMessage should include(s"$kvMount/nonexistent/path")
     }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -6,6 +6,8 @@ import org.galaxio.gatling.utils.THttpClient
 import org.json4s.native.JsonMethods.{compact, parse, render}
 import org.json4s.{DefaultFormats, Extraction, JValue}
 
+import scala.util.Using
+
 /** Strategy for handling duplicate keys when merging secrets from multiple Vault paths. */
 sealed trait DuplicateKeyStrategy
 
@@ -36,11 +38,11 @@ object VaultFeeder extends LazyLogging {
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
 
-    val client     = THttpClient(timeoutInSeconds = timeoutInSeconds)
-    val vaultToken = login(client, vaultUrl, roleId, secretId)
-    val data       = readSecret(client, vaultUrl, secretPath, vaultToken)
-
-    IndexedSeq(filterRecord(data, keys))
+    Using.resource(THttpClient(timeoutInSeconds = timeoutInSeconds)) { client =>
+      val vaultToken = login(client, vaultUrl, roleId, secretId)
+      val data       = readSecret(client, vaultUrl, secretPath, vaultToken)
+      IndexedSeq(filterRecord(data, keys))
+    }
   }
 
   /** Retrieves secrets from multiple Vault paths and merges them into a single record.
@@ -92,14 +94,14 @@ object VaultFeeder extends LazyLogging {
   ): IndexedSeq[Record[String]] = {
     require(paths != null, "Paths list must not be null")
 
-    val client     = THttpClient(timeoutInSeconds = timeoutInSeconds)
-    val vaultToken = login(client, vaultUrl, roleId, secretId)
-
-    val allPairs = paths.flatMap { case (secretPath, keys) =>
-      val data = readSecret(client, vaultUrl, secretPath, vaultToken)
-      filterRecord(data, keys).toSeq
+    Using.resource(THttpClient(timeoutInSeconds = timeoutInSeconds)) { client =>
+      val vaultToken = login(client, vaultUrl, roleId, secretId)
+      val allPairs   = paths.flatMap { case (secretPath, keys) =>
+        val data = readSecret(client, vaultUrl, secretPath, vaultToken)
+        filterRecord(data, keys).toSeq
+      }
+      IndexedSeq(mergeWithStrategy(allPairs, onDuplicate))
     }
-    IndexedSeq(mergeWithStrategy(allPairs, onDuplicate))
   }
 
   private def mergeWithStrategy(
@@ -139,10 +141,10 @@ object VaultFeeder extends LazyLogging {
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
 
-    val client = THttpClient(timeoutInSeconds = timeoutInSeconds)
-    val data   = readSecret(client, vaultUrl, secretPath, vaultToken)
-
-    IndexedSeq(filterRecord(data, keys))
+    Using.resource(THttpClient(timeoutInSeconds = timeoutInSeconds)) { client =>
+      val data = readSecret(client, vaultUrl, secretPath, vaultToken)
+      IndexedSeq(filterRecord(data, keys))
+    }
   }
 
   private def login(client: THttpClient, vaultUrl: String, roleId: String, secretId: String): String = {
@@ -153,10 +155,7 @@ object VaultFeeder extends LazyLogging {
       try parse(response.body)
       catch {
         case e: Exception =>
-          throw new RuntimeException(
-            s"Failed to parse Vault login response as JSON from $loginUrl: ${response.body.take(200)}",
-            e,
-          )
+          throw new RuntimeException(s"Failed to parse Vault login response as JSON from $loginUrl", e)
       }
     try extractClientToken(loginJson)
     catch {
@@ -173,10 +172,7 @@ object VaultFeeder extends LazyLogging {
       try parse(response.body)
       catch {
         case e: Exception =>
-          throw new RuntimeException(
-            s"Failed to parse Vault secret response as JSON from '$secretPath': ${response.body.take(200)}",
-            e,
-          )
+          throw new RuntimeException(s"Failed to parse Vault secret response as JSON from '$secretPath'", e)
       }
     try (json \ "data").extract[Map[String, String]]
     catch {

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -23,6 +23,8 @@ object DuplicateKeyStrategy {
 
 object VaultFeeder extends LazyLogging {
 
+  private implicit val formats: DefaultFormats = org.json4s.DefaultFormats
+
   /** Retrieves secrets from a single Vault path as a one-record feeder. */
   def apply(
       vaultUrl: String,
@@ -34,31 +36,16 @@ object VaultFeeder extends LazyLogging {
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
 
-    implicit val formats: DefaultFormats = org.json4s.DefaultFormats
-
-    val body   = approleLoginBody(roleId, secretId)
-    val client = THttpClient(timeoutInSeconds = timeoutInSeconds)
-
-    val vaultTokenResponse: String = client
-      .post(s"""$vaultUrl/v1/auth/approle/login""", body)
-      .body
-
-    val vaultToken = extractClientToken(parse(vaultTokenResponse))
-
-    val getHeaders: Seq[String]   = Seq("X-Vault-Token", s"""$vaultToken""")
-    val vaultDataResponse: String = client
-      .get(s"""$vaultUrl/v1/$secretPath""", getHeaders)
-      .body
-
-    val vaultDataJson: JValue = parse(vaultDataResponse)
-    val data: Record[String]  = (vaultDataJson \ "data").extract[Map[String, String]]
+    val client     = THttpClient(timeoutInSeconds = timeoutInSeconds)
+    val vaultToken = login(client, vaultUrl, roleId, secretId)
+    val data       = readSecret(client, vaultUrl, secretPath, vaultToken)
 
     IndexedSeq(filterRecord(data, keys))
   }
 
   /** Retrieves secrets from multiple Vault paths and merges them into a single record.
     *
-    * Uses [[DuplicateKeyStrategy.FailOnDuplicate]] by default.
+    * Uses [[DuplicateKeyStrategy.FailOnDuplicate]] by default. Authenticates once and reuses the token across all path reads.
     *
     * @param timeoutInSeconds
     *   connect and per-request timeout for Vault HTTP calls (default 5s)
@@ -88,6 +75,8 @@ object VaultFeeder extends LazyLogging {
 
   /** Retrieves secrets from multiple Vault paths with explicit duplicate-key strategy and timeout.
     *
+    * Authenticates once and reuses the token for all path reads.
+    *
     * @param onDuplicate
     *   strategy when the same key appears in more than one path
     * @param timeoutInSeconds
@@ -102,8 +91,13 @@ object VaultFeeder extends LazyLogging {
       timeoutInSeconds: Long,
   ): IndexedSeq[Record[String]] = {
     require(paths != null, "Paths list must not be null")
+
+    val client     = THttpClient(timeoutInSeconds = timeoutInSeconds)
+    val vaultToken = login(client, vaultUrl, roleId, secretId)
+
     val allPairs = paths.flatMap { case (secretPath, keys) =>
-      apply(vaultUrl, secretPath, roleId, secretId, keys, timeoutInSeconds).flatMap(_.toSeq)
+      val data = readSecret(client, vaultUrl, secretPath, vaultToken)
+      filterRecord(data, keys).toSeq
     }
     IndexedSeq(mergeWithStrategy(allPairs, onDuplicate))
   }
@@ -145,27 +139,66 @@ object VaultFeeder extends LazyLogging {
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
 
-    implicit val formats: DefaultFormats = org.json4s.DefaultFormats
-
-    val getHeaders: Seq[String]   = Seq("X-Vault-Token", vaultToken)
-    val vaultDataResponse: String = THttpClient(timeoutInSeconds = timeoutInSeconds)
-      .get(s"""$vaultUrl/v1/$secretPath""", getHeaders)
-      .body
-
-    val vaultDataJson: JValue = parse(vaultDataResponse)
-    val data: Record[String]  = (vaultDataJson \ "data").extract[Map[String, String]]
+    val client = THttpClient(timeoutInSeconds = timeoutInSeconds)
+    val data   = readSecret(client, vaultUrl, secretPath, vaultToken)
 
     IndexedSeq(filterRecord(data, keys))
   }
 
-  private def filterRecord(data: Record[String], keys: List[String]): Record[String] = {
-    val selectedKeys = keys.toSet
-    data.view.filterKeys(selectedKeys.contains).toMap
+  private def login(client: THttpClient, vaultUrl: String, roleId: String, secretId: String): String = {
+    val body      = approleLoginBody(roleId, secretId)
+    val loginUrl  = s"$vaultUrl/v1/auth/approle/login"
+    val response  = client.postOrThrow(loginUrl, body)
+    val loginJson =
+      try parse(response.body)
+      catch {
+        case e: Exception =>
+          throw new RuntimeException(
+            s"Failed to parse Vault login response as JSON from $loginUrl: ${response.body.take(200)}",
+            e,
+          )
+      }
+    try extractClientToken(loginJson)
+    catch {
+      case e: Exception =>
+        throw new RuntimeException("Failed to extract client_token from Vault login response", e)
+    }
   }
 
-  private[feeders] def approleLoginBody(roleId: String, secretId: String)(implicit formats: DefaultFormats): String =
+  private def readSecret(client: THttpClient, vaultUrl: String, secretPath: String, vaultToken: String): Record[String] = {
+    val secretUrl = s"$vaultUrl/v1/$secretPath"
+    val headers   = Seq("X-Vault-Token", vaultToken)
+    val response  = client.getOrThrow(secretUrl, headers)
+    val json      =
+      try parse(response.body)
+      catch {
+        case e: Exception =>
+          throw new RuntimeException(
+            s"Failed to parse Vault secret response as JSON from '$secretPath': ${response.body.take(200)}",
+            e,
+          )
+      }
+    try (json \ "data").extract[Map[String, String]]
+    catch {
+      case e: Exception =>
+        throw new RuntimeException(s"Failed to extract secret data from Vault response at '$secretPath'", e)
+    }
+  }
+
+  private def filterRecord(data: Record[String], keys: List[String]): Record[String] = {
+    val selectedKeys = keys.toSet
+    val result       = data.view.filterKeys(selectedKeys.contains).toMap
+    if (result.isEmpty && keys.nonEmpty)
+      logger.warn(
+        s"None of the requested keys [${keys.mkString(", ")}] were found in the Vault secret. " +
+          s"Available keys: [${data.keys.mkString(", ")}]",
+      )
+    result
+  }
+
+  private[feeders] def approleLoginBody(roleId: String, secretId: String): String =
     compact(render(Extraction.decompose(Map("role_id" -> roleId, "secret_id" -> secretId))))
 
-  private[feeders] def extractClientToken(vaultTokenJson: JValue)(implicit formats: DefaultFormats): String =
+  private[feeders] def extractClientToken(vaultTokenJson: JValue): String =
     (vaultTokenJson \ "auth" \ "client_token").extract[String]
 }

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -6,7 +6,7 @@ import org.galaxio.gatling.utils.THttpClient
 import org.json4s.native.JsonMethods.{compact, parse, render}
 import org.json4s.{DefaultFormats, Extraction, JValue}
 
-import scala.util.Using
+import scala.util.{Try, Using}
 
 /** Strategy for handling duplicate keys when merging secrets from multiple Vault paths. */
 sealed trait DuplicateKeyStrategy
@@ -151,34 +151,27 @@ object VaultFeeder extends LazyLogging {
     val body      = approleLoginBody(roleId, secretId)
     val loginUrl  = s"$vaultUrl/v1/auth/approle/login"
     val response  = client.postOrThrow(loginUrl, body)
-    val loginJson =
-      try parse(response.body)
-      catch {
-        case e: Exception =>
-          throw new RuntimeException(s"Failed to parse Vault login response as JSON from $loginUrl", e)
-      }
-    try extractClientToken(loginJson)
-    catch {
-      case e: Exception =>
-        throw new RuntimeException("Failed to extract client_token from Vault login response", e)
-    }
+    val loginJson = Try(parse(response.body)).fold(
+      e => throw new RuntimeException(s"Failed to parse Vault login response as JSON from $loginUrl", e),
+      identity,
+    )
+    Try(extractClientToken(loginJson)).fold(
+      e => throw new RuntimeException("Failed to extract client_token from Vault login response", e),
+      identity,
+    )
   }
 
   private def readSecret(client: THttpClient, vaultUrl: String, secretPath: String, vaultToken: String): Record[String] = {
     val secretUrl = s"$vaultUrl/v1/$secretPath"
-    val headers   = Seq("X-Vault-Token", vaultToken)
-    val response  = client.getOrThrow(secretUrl, headers)
-    val json      =
-      try parse(response.body)
-      catch {
-        case e: Exception =>
-          throw new RuntimeException(s"Failed to parse Vault secret response as JSON from '$secretPath'", e)
-      }
-    try (json \ "data").extract[Map[String, String]]
-    catch {
-      case e: Exception =>
-        throw new RuntimeException(s"Failed to extract secret data from Vault response at '$secretPath'", e)
-    }
+    val response  = client.getOrThrow(secretUrl, Seq("X-Vault-Token", vaultToken))
+    val json      = Try(parse(response.body)).fold(
+      e => throw new RuntimeException(s"Failed to parse Vault secret response as JSON from '$secretPath'", e),
+      identity,
+    )
+    Try((json \ "data").extract[Map[String, String]]).fold(
+      e => throw new RuntimeException(s"Failed to extract secret data from Vault response at '$secretPath'", e),
+      identity,
+    )
   }
 
   private def filterRecord(data: Record[String], keys: List[String]): Record[String] = {


### PR DESCRIPTION
## Summary
- **Contextual error messages**: HTTP errors surface via `HttpClientException` with status/URI/body. JSON parse failures include path. Missing `client_token` reports specific failure. Empty key match logs warning with available vs requested keys.
- **Token reuse in `fromPaths`**: Previously each path triggered a separate AppRole login (N logins for N paths). Now authenticates once, reuses token for all reads.
- **Internal refactoring**: Extract `login()` and `readSecret()` private methods, eliminating duplication between `apply()`, `withToken()`, and `fromPaths()`.
- **Resource cleanup**: All entry points wrap `THttpClient` in `Using.resource` for deterministic executor shutdown.

Closes #136

## Test plan
- [x] All 578 existing unit tests pass
- [x] Bad AppRole credentials → `HttpClientException` with status 400 (integration test added)
- [x] Non-existent secret path → `HttpClientException` with status 404 (integration test added)
- [x] `fromPaths` with 3 paths merges correctly with single login (integration test added)
- [x] Existing VaultFeeder integration tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)