### PR TITLE
perf(redis): defer RedisAction error log interpolation

### DIFF
--- a/src/main/scala/org/galaxio/gatling/redis/RedisAction.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisAction.scala
@@ -49,7 +49,7 @@ case class RedisAction(
           next ! updatedSession
 
         case Failure(message) =>
-          logger.error(s"Redis ${name} expression resolution failed: $message")
+          logger.error("Redis {} expression resolution failed: {}", name, message)
           if (statsEnabled) {
             statsEngine.logResponse(
               session.scenario,
@@ -66,7 +66,7 @@ case class RedisAction(
       }
     } catch {
       case e: Exception =>
-        logger.error(s"Redis ${name} failed", e)
+        logger.error("Redis {} failed", name, e)
         if (statsEnabled) {
           statsEngine.logResponse(
             session.scenario,


### PR DESCRIPTION
## Summary

Guards eager `s"..."` interpolation in `RedisAction` error logs so allocations only happen when error logging is enabled.

## Changes

- `RedisAction.scala`: parameterized scala-logging calls (or `isErrorEnabled` guards) at the affected sites

## Testing

- `sbt scalafmtCheckAll compile test`

Fixes #141