### PR TITLE
fix(redis): propagate Validation on non-numeric LRANGE/EXPIRE args

### DIFF
--- a/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
@@ -7,6 +7,8 @@ import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.structure.ScenarioContext
 
+import scala.util.Try
+
 object RedisActionBuilder {
 
   implicit class RedisClientPoolOps(clientPool: RedisClientPool) {
@@ -60,10 +62,11 @@ object RedisActionBuilder {
         clientPool,
         session =>
           for {
-            k <- key(session)
-            e <- expiry(session)
-            v <- value(session)
-          } yield RedisCommand.Strings.SetEx(k, e.toString.toLong, v),
+            k  <- key(session)
+            e  <- expiry(session)
+            el <- parseLong(e, "expiry")
+            v  <- value(session)
+          } yield RedisCommand.Strings.SetEx(k, el, v),
       )
 
     def MGET(key: Expression[Any], keys: Expression[Any]*): GenericRedisActionBuilder =
@@ -91,9 +94,10 @@ object RedisActionBuilder {
         clientPool,
         session =>
           for {
-            k <- key(session)
-            i <- increment(session)
-          } yield RedisCommand.Strings.IncrBy(k, i.toString.toLong),
+            k  <- key(session)
+            i  <- increment(session)
+            il <- parseLong(i, "increment")
+          } yield RedisCommand.Strings.IncrBy(k, il),
       )
 
     def DECR(key: Expression[Any]): GenericRedisActionBuilder =
@@ -104,9 +108,10 @@ object RedisActionBuilder {
         clientPool,
         session =>
           for {
-            k <- key(session)
-            d <- decrement(session)
-          } yield RedisCommand.Strings.DecrBy(k, d.toString.toLong),
+            k  <- key(session)
+            d  <- decrement(session)
+            dl <- parseLong(d, "decrement")
+          } yield RedisCommand.Strings.DecrBy(k, dl),
       )
 
     // Hash operations
@@ -199,10 +204,12 @@ object RedisActionBuilder {
         clientPool,
         session =>
           for {
-            k <- key(session)
-            s <- start(session)
-            e <- end(session)
-          } yield RedisCommand.Lists.LRange(k, s.toString.toInt, e.toString.toInt),
+            k  <- key(session)
+            s  <- start(session)
+            si <- parseInt(s, "start")
+            e  <- end(session)
+            ei <- parseInt(e, "end")
+          } yield RedisCommand.Lists.LRange(k, si, ei),
       )
 
     def LLEN(key: Expression[Any]): GenericRedisActionBuilder =
@@ -217,9 +224,10 @@ object RedisActionBuilder {
         clientPool,
         session =>
           for {
-            k <- key(session)
-            t <- ttl(session)
-          } yield RedisCommand.Keys.Expire(k, t.toString.toInt),
+            k  <- key(session)
+            t  <- ttl(session)
+            ti <- parseInt(t, "ttl")
+          } yield RedisCommand.Keys.Expire(k, ti),
       )
 
     def TTL(key: Expression[Any]): GenericRedisActionBuilder =
@@ -286,6 +294,27 @@ object RedisActionBuilder {
     override def build(ctx: ScenarioContext, next: Action): Action =
       RedisAction(ctx, next, clientPool, commandFactory, saveAsVar, reqName)
   }
+
+  private[redis] def parseInt(value: Any, name: String): Validation[Int] =
+    value match {
+      case i: Int  => Success(i)
+      case l: Long =>
+        Try(Math.toIntExact(l)).toOption.fold[Validation[Int]](
+          Failure(s"Redis $name '$l' is out of Int range"),
+        )(Success(_))
+      case other   =>
+        Try(other.toString.toInt).toOption
+          .fold[Validation[Int]](Failure(s"Redis $name '$other' is not a valid Int"))(Success(_))
+    }
+
+  private[redis] def parseLong(value: Any, name: String): Validation[Long] =
+    value match {
+      case i: Int  => Success(i.toLong)
+      case l: Long => Success(l)
+      case other   =>
+        Try(other.toString.toLong).toOption
+          .fold[Validation[Long]](Failure(s"Redis $name '$other' is not a valid Long"))(Success(_))
+    }
 
   private def resolveSeq(exprs: Seq[Expression[Any]], session: Session): Validation[Seq[Any]] = {
     val results  = exprs.map(_(session))

--- a/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
@@ -272,5 +272,24 @@ class RedisActionBuilderSpec extends AnyWordSpec with Matchers {
       val builder              = redisPool.DECRBY(redisKey, dec)
       runFactory(builder, session) shouldBe a[Failure]
     }
+
+    "succeed Validation when SETEX expiry is a typed Long" in {
+      val expiry: Expression[Any] = (_: Session) => Success(60L)
+      val builder                 = redisPool.SETEX(redisKey, expiry, redisValue)
+      runFactory(builder, session) shouldBe a[Success[_]]
+    }
+
+    "succeed Validation when EXPIRE ttl is a typed Int" in {
+      val ttl: Expression[Any] = (_: Session) => Success(300)
+      val builder              = redisPool.EXPIRE(redisKey, ttl)
+      runFactory(builder, session) shouldBe a[Success[_]]
+    }
+
+    "succeed Validation when LRANGE bounds are typed Ints" in {
+      val start: Expression[Any] = (_: Session) => Success(0)
+      val end: Expression[Any]   = (_: Session) => Success(10)
+      val builder                = redisPool.LRANGE(redisKey, start, end)
+      runFactory(builder, session) shouldBe a[Success[_]]
+    }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
@@ -1,9 +1,11 @@
 package org.galaxio.gatling.redis
 
 import com.redis.RedisClientPool
+import io.gatling.commons.validation.{Failure, Success}
 import io.gatling.core.Predef._
-import io.gatling.core.session.Expression
+import io.gatling.core.session.{Expression, Session}
 import org.galaxio.gatling.redis.RedisActionBuilder._
+import org.galaxio.gatling.transactions.fixtures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -217,6 +219,58 @@ class RedisActionBuilderSpec extends AnyWordSpec with Matchers {
       val builder = redisPool.GET(redisKey).saveAs("result").requestName("redis-get")
       builder.saveAsVar shouldBe Some("result")
       builder.reqName shouldBe Some("redis-get")
+    }
+  }
+
+  "Numeric argument validation" should {
+    def runFactory(builder: GenericRedisActionBuilder, session: Session) =
+      builder.commandFactory(session)
+
+    val session = fixtures.emptySession("redis-validation")
+
+    "fail Validation when LRANGE end is non-numeric instead of throwing" in {
+      val start: Expression[Any] = "0"
+      val end: Expression[Any]   = "not-a-number"
+      val builder                = redisPool.LRANGE(redisKey, start, end)
+      runFactory(builder, session) shouldBe a[Failure]
+    }
+
+    "fail Validation when LRANGE start is non-numeric instead of throwing" in {
+      val start: Expression[Any] = "oops"
+      val end: Expression[Any]   = "10"
+      val builder                = redisPool.LRANGE(redisKey, start, end)
+      runFactory(builder, session) shouldBe a[Failure]
+    }
+
+    "succeed Validation when LRANGE bounds are numeric strings" in {
+      val start: Expression[Any] = "0"
+      val end: Expression[Any]   = "10"
+      val builder                = redisPool.LRANGE(redisKey, start, end)
+      runFactory(builder, session) shouldBe a[Success[_]]
+    }
+
+    "fail Validation when EXPIRE ttl is non-numeric instead of throwing" in {
+      val ttl: Expression[Any] = "abc"
+      val builder              = redisPool.EXPIRE(redisKey, ttl)
+      runFactory(builder, session) shouldBe a[Failure]
+    }
+
+    "fail Validation when SETEX expiry is non-numeric instead of throwing" in {
+      val expiry: Expression[Any] = "not-long"
+      val builder                 = redisPool.SETEX(redisKey, expiry, redisValue)
+      runFactory(builder, session) shouldBe a[Failure]
+    }
+
+    "fail Validation when INCRBY increment is non-numeric instead of throwing" in {
+      val inc: Expression[Any] = "x"
+      val builder              = redisPool.INCRBY(redisKey, inc)
+      runFactory(builder, session) shouldBe a[Failure]
+    }
+
+    "fail Validation when DECRBY decrement is non-numeric instead of throwing" in {
+      val dec: Expression[Any] = "x"
+      val builder              = redisPool.DECRBY(redisKey, dec)
+      runFactory(builder, session) shouldBe a[Failure]
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces `.toString.toInt` / `.toString.toLong` in `RedisActionBuilder` with `Validation`-returning conversions so a non-numeric session value yields a clean KO instead of crashing the scenario with `NumberFormatException`.

## Changes

- `RedisActionBuilder.scala`: typed parse using `Validation` via new private `parseInt`/`parseLong` helpers (handles `Int`/`Long`/string inputs). Applied to `SETEX`, `INCRBY`, `DECRBY`, `LRANGE`, `EXPIRE`.
- `RedisActionBuilderSpec.scala`: tests for non-numeric input -> failed `Validation` (and a numeric success case).

Public API signatures unchanged.

## Testing

- `sbt scalafmtAll scalafmtSbt` clean
- `sbt "testOnly org.galaxio.gatling.redis.*"` -> 44 passed

Fixes #66