### PR TITLE
perf(redis): typed numeric overloads for RedisActionBuilder

### DIFF
--- a/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
@@ -69,6 +69,17 @@ object RedisActionBuilder {
           } yield RedisCommand.Strings.SetEx(k, el, v),
       )
 
+    def setExL(key: Expression[Any], expiry: Expression[Long], value: Expression[Any]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            e <- expiry(session)
+            v <- value(session)
+          } yield RedisCommand.Strings.SetEx(k, e, v),
+      )
+
     def MGET(key: Expression[Any], keys: Expression[Any]*): GenericRedisActionBuilder =
       GenericRedisActionBuilder(
         clientPool,
@@ -100,6 +111,16 @@ object RedisActionBuilder {
           } yield RedisCommand.Strings.IncrBy(k, il),
       )
 
+    def incrByL(key: Expression[Any], increment: Expression[Long]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            i <- increment(session)
+          } yield RedisCommand.Strings.IncrBy(k, i),
+      )
+
     def DECR(key: Expression[Any]): GenericRedisActionBuilder =
       GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Strings.Decr(k)))
 
@@ -112,6 +133,16 @@ object RedisActionBuilder {
             d  <- decrement(session)
             dl <- parseLong(d, "decrement")
           } yield RedisCommand.Strings.DecrBy(k, dl),
+      )
+
+    def decrByL(key: Expression[Any], decrement: Expression[Long]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            d <- decrement(session)
+          } yield RedisCommand.Strings.DecrBy(k, d),
       )
 
     // Hash operations
@@ -212,6 +243,17 @@ object RedisActionBuilder {
           } yield RedisCommand.Lists.LRange(k, si, ei),
       )
 
+    def lRangeI(key: Expression[Any], start: Expression[Int], end: Expression[Int]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            s <- start(session)
+            e <- end(session)
+          } yield RedisCommand.Lists.LRange(k, s, e),
+      )
+
     def LLEN(key: Expression[Any]): GenericRedisActionBuilder =
       GenericRedisActionBuilder(clientPool, session => key(session).map(k => RedisCommand.Lists.LLen(k)))
 
@@ -228,6 +270,16 @@ object RedisActionBuilder {
             t  <- ttl(session)
             ti <- parseInt(t, "ttl")
           } yield RedisCommand.Keys.Expire(k, ti),
+      )
+
+    def expireI(key: Expression[Any], ttl: Expression[Int]): GenericRedisActionBuilder =
+      GenericRedisActionBuilder(
+        clientPool,
+        session =>
+          for {
+            k <- key(session)
+            t <- ttl(session)
+          } yield RedisCommand.Keys.Expire(k, t),
       )
 
     def TTL(key: Expression[Any]): GenericRedisActionBuilder =

--- a/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/redis/RedisActionBuilderSpec.scala
@@ -292,4 +292,37 @@ class RedisActionBuilderSpec extends AnyWordSpec with Matchers {
       runFactory(builder, session) shouldBe a[Success[_]]
     }
   }
+
+  "Typed numeric variants" should {
+    "add setExL builder to Gatling chains" in {
+      val ttl: Expression[Long] = 60L
+      val chain                 = exec(redisPool.setExL(redisKey, ttl, redisValue))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add incrByL builder to Gatling chains" in {
+      val inc: Expression[Long] = 5L
+      val chain                 = exec(redisPool.incrByL(redisKey, inc))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add decrByL builder to Gatling chains" in {
+      val dec: Expression[Long] = 3L
+      val chain                 = exec(redisPool.decrByL(redisKey, dec))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add lRangeI builder to Gatling chains" in {
+      val start: Expression[Int] = 0
+      val end: Expression[Int]   = 10
+      val chain                  = exec(redisPool.lRangeI(redisKey, start, end))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+
+    "add expireI builder to Gatling chains" in {
+      val ttl: Expression[Int] = 300
+      val chain                = exec(redisPool.expireI(redisKey, ttl))
+      chain.actionBuilders.head shouldBe a[GenericRedisActionBuilder]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Depends on #187. Adds typed `Expression[Long]` / `Expression[Int]` overloads (`setExL`, `incrByL`, `decrByL`, `lRangeI`, `expireI`) for Redis commands that previously round-tripped through `.toString.toLong/toInt`. Legacy string-expression methods are kept and route through #187 Validation-safe `parseInt` / `parseLong` helpers — no separate throwing path.

## Changes

- New typed overloads (additive, backward compatible)
- Legacy methods unchanged from #187
- Tests verifying typed builders attach to Gatling chains

## Testing

- `sbt scalafmtCheckAll compile test` — 52/52 redis tests pass

Fixes #132