### PR TITLE
chore: silence intentional deprecation warnings

### DIFF
--- a/src/main/scala/org/galaxio/gatling/feeders/faker/FakerBenchmark.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/FakerBenchmark.scala
@@ -6,11 +6,15 @@ import org.galaxio.gatling.jmh.JmhBenchmark
 import org.galaxio.gatling.utils.phone.TypePhone
 import org.openjdk.jmh.annotations.Benchmark
 
+import scala.annotation.nowarn
+
 class FakerBenchmark extends JmhBenchmark {
 
-  private val legacyDigitFeeder = RandomDigitFeeder("digit")
-  private val legacyPanFeeder   = RandomPANFeeder("pan", "411111", "555555", "220220")
-  private val legacyPhoneFeeder = RandomPhoneFeeder("phone", TypePhone.E164PhoneNumber)
+  // Legacy feeders are deprecated; kept here only to baseline the new Faker/GeneratedFeeder
+  // path against the old Random*Feeder path. Suppression is scoped to these three references.
+  @nowarn("cat=deprecation") private val legacyDigitFeeder = RandomDigitFeeder("digit")
+  @nowarn("cat=deprecation") private val legacyPanFeeder   = RandomPANFeeder("pan", "411111", "555555", "220220")
+  @nowarn("cat=deprecation") private val legacyPhoneFeeder = RandomPhoneFeeder("phone", TypePhone.E164PhoneNumber)
 
   private val emailGenerator      = Faker.internet.email()
   private val usPhoneGenerator    = Faker.phone.mobile(Country.US)

--- a/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/redis/RedisActionBuilder.scala
@@ -7,6 +7,7 @@ import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.structure.ScenarioContext
 
+import scala.annotation.nowarn
 import scala.util.Try
 
 object RedisActionBuilder {
@@ -307,9 +308,16 @@ object RedisActionBuilder {
 
   }
 
-  // Legacy builders (backward compatible)
+  // Legacy builders (backward compatible). The Action classes they delegate to are themselves
+  // deprecated, but these shims must preserve the original permissive failure semantics of
+  // RedisDelAction / RedisSremAction / RedisSaddAction (per-key failures logged at DEBUG and
+  // the operation proceeds with the successfully resolved subset). Routing through
+  // GenericRedisActionBuilder would flip those semantics to strict markAsFailed, breaking
+  // existing users. Until the deprecated Actions are removed, keep delegating and scope
+  // @nowarn to the call sites that intentionally reference them.
   case class RedisDelActionBuilder(clientPool: RedisClientPool, key: Expression[Any], keys: Seq[Expression[Any]])
       extends ActionBuilder {
+    @nowarn("cat=deprecation")
     override def build(ctx: ScenarioContext, next: Action): Action = RedisDelAction(ctx, next, clientPool, key, keys)
   }
 
@@ -319,6 +327,7 @@ object RedisActionBuilder {
       value: Expression[Any],
       values: Seq[Expression[Any]],
   ) extends ActionBuilder {
+    @nowarn("cat=deprecation")
     override def build(ctx: ScenarioContext, next: Action): Action = RedisSremAction(ctx, next, clientPool, key, value, values)
   }
 
@@ -328,6 +337,7 @@ object RedisActionBuilder {
       value: Expression[Any],
       values: Seq[Expression[Any]],
   ) extends ActionBuilder {
+    @nowarn("cat=deprecation")
     override def build(ctx: ScenarioContext, next: Action): Action = RedisSaddAction(ctx, next, clientPool, key, value, values)
   }
 

--- a/src/test/scala/org/galaxio/gatling/examples/ExampleSmokeSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/examples/ExampleSmokeSpec.scala
@@ -18,7 +18,13 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneId}
+import scala.annotation.nowarn
 
+// "Legacy feeders from examples" deliberately demonstrates the deprecated Random*Feeder
+// surface so the README examples keep compiling/running until the deprecated objects are
+// removed. The companion "Faker-based feeders from examples" suite below covers the
+// successor API.
+@nowarn("cat=deprecation")
 class ExampleSmokeSpec extends AnyWordSpec with Matchers with CoreDsl with TableDrivenPropertyChecks {
 
   override implicit def configuration: GatlingConfiguration = GatlingConfiguration.loadForTest()

--- a/src/test/scala/org/galaxio/gatling/feeders/FeedersBaseSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/FeedersBaseSpec.scala
@@ -6,6 +6,8 @@ import io.gatling.core.feeder._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.galaxio.gatling.feeders.faker.Predef._
+import org.galaxio.gatling.feeders.faker.{Faker, GeneratedFeeder}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class FeedersBaseSpec extends AnyWordSpec with Matchers with CoreDsl with ScalaCheckDrivenPropertyChecks {
@@ -42,7 +44,7 @@ class FeedersBaseSpec extends AnyWordSpec with Matchers with CoreDsl with ScalaC
   "Feeder finite-length syntax" should {
     "materialize the requested number of records" in {
       forAll(feederName, Gen.choose(1, 100)) { (name, size) =>
-        RandomDigitFeeder(name).toFiniteLength(size).readRecords should have size size
+        GeneratedFeeder(name -> Faker.number.int(0, 9)).toFiniteLength(size).readRecords should have size size
       }
     }
   }

--- a/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/RandomFeedersSpec.scala
@@ -9,7 +9,12 @@ import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
 
 import java.time.temporal.{ChronoUnit, TemporalUnit}
 import java.time.{LocalDateTime, ZoneId}
+import scala.annotation.nowarn
 
+// Regression coverage for the deprecated Random*Feeder family. These tests intentionally
+// exercise the deprecated API for as long as it remains in the published surface; remove
+// this suite together with the deprecated objects.
+@nowarn("cat=deprecation")
 class RandomFeedersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   val positiveInt: Gen[Int] = Gen.posNum[Int]


### PR DESCRIPTION
## Summary

Silences the deprecation warnings emitted by the CI Release job by scoping `@nowarn("cat=deprecation")` to the call sites that intentionally exercise deprecated API, plus one real migration where the legacy usage was incidental.

## Changes

- **`RedisActionBuilder.scala`** — `@nowarn` on `build()` of `RedisDelActionBuilder` / `RedisSremActionBuilder` / `RedisSaddActionBuilder`. These shims delegate to the deprecated `RedisDelAction` / `RedisSremAction` / `RedisSaddAction`, which preserve their original permissive failure semantics (per-key Failure logged at DEBUG; operation proceeds with successfully resolved keys). Routing through `GenericRedisActionBuilder` would flip those semantics to strict `markAsFailed`, breaking existing users — so suppression is the correct fix until the deprecated Actions themselves are removed.
- **`FeedersBaseSpec.scala`** — incidental `RandomDigitFeeder` usage migrated to `GeneratedFeeder(name -> Faker.number.int(0, 9))`. The test only asserts record count, so distribution does not matter.
- **`FakerBenchmark.scala`** — `@nowarn` scoped to the three `legacy*` vals that exist as a comparative baseline for the new Faker / GeneratedFeeder path. Comment documents intent.
- **`ExampleSmokeSpec.scala`** — file-level `@nowarn` with a comment noting that the "Legacy feeders from examples" suite intentionally demonstrates the deprecated `Random*Feeder` surface so README examples keep compiling. The sibling "Faker-based feeders from examples" suite covers the successor API.
- **`RandomFeedersSpec.scala`** — file-level `@nowarn` with a comment: the suite is regression coverage for the deprecated `Random*Feeder` family and must be removed alongside the deprecated objects.

## Testing

- `sbt scalafmtCheckAll compile Test/compile IntegrationTest/compile Jmh/compile` — **0 warnings**
- `sbt test` — 510 / 510 pass (588 total including Java)