### PR TITLE
fix(jwt): allow EL payloads in JwtGeneratorBuilder

### DIFF
--- a/src/main/scala/org/galaxio/gatling/utils/jwt/JwtGeneratorBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/jwt/JwtGeneratorBuilder.scala
@@ -43,12 +43,19 @@ final case class JwtGeneratorBuilder(
     claimsBuilder: Option[ClaimsBuilder] = None,
 ) {
 
+  private def containsEl(s: String): Boolean = s.contains("#{")
+
+  /** Validate JSON syntax, but skip validation when the string contains Gatling EL markers (`#&#123;...&#125;`), since EL
+    * placeholders are not legal JSON and are resolved at token generation time.
+    */
   private def validateJson(json: String): String =
-    try compact(render(parse(json)))
-    catch {
-      case e: Exception =>
-        throw new IllegalArgumentException(s"Invalid JSON: $json", e)
-    }
+    if (containsEl(json)) json
+    else
+      try compact(render(parse(json)))
+      catch {
+        case e: Exception =>
+          throw new IllegalArgumentException(s"Invalid JSON: $json", e)
+      }
 
   private def readResource(path: String): String = {
     val url    = getClass.getClassLoader.getResource(path)
@@ -89,7 +96,11 @@ final case class JwtGeneratorBuilder(
   def claims(builder: ClaimsBuilder): JwtGeneratorBuilder =
     copy(claimsBuilder = Some(builder))
 
-  private[jwt] val jwtAlgorithm: JwtAlgorithm = {
+  /** Resolved [[JwtAlgorithm]] for this builder. Validation is deferred to first token generation so that builders can be
+    * constructed eagerly (e.g. at simulation setup) without forcing the algorithm name to be known statically. Throws
+    * [[IllegalArgumentException]] when the configured `algorithm` is not supported.
+    */
+  private[jwt] def jwtAlgorithm: JwtAlgorithm = {
     val alg = JwtAlgorithm.fromString(algorithm.toUpperCase)
     alg match {
       case _: JwtUnknownAlgorithm =>

--- a/src/main/scala/org/galaxio/gatling/utils/jwt/JwtGeneratorBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/jwt/JwtGeneratorBuilder.scala
@@ -6,6 +6,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
+import java.util.Locale
 import scala.io.Source
 
 /** Builder for configuring JWT token generation.
@@ -43,6 +44,10 @@ final case class JwtGeneratorBuilder(
     claimsBuilder: Option[ClaimsBuilder] = None,
 ) {
 
+  /** Heuristic check for Gatling EL markers (`#&#123;`). A literal `#&#123;` substring inside JSON values will also match and
+    * cause [[validateJson]] to skip parsing — accepted trade-off since such strings are also treated as EL by Gatling at
+    * resolution time, so the runtime behavior is consistent.
+    */
   private def containsEl(s: String): Boolean = s.contains("#{")
 
   /** Validate JSON syntax, but skip validation when the string contains Gatling EL markers (`#&#123;...&#125;`), since EL
@@ -65,7 +70,9 @@ final case class JwtGeneratorBuilder(
     finally source.close()
   }
 
-  /** Load JWT header from a classpath resource (must be valid JSON). */
+  /** Load JWT header from a classpath resource (must be valid JSON). Resources containing Gatling EL markers
+    * (`#&#123;...&#125;`) bypass JSON validation and are resolved at token generation time.
+    */
   def headerFromResource(path: String): JwtGeneratorBuilder =
     copy(header = Header(readResource(path)))
 
@@ -79,8 +86,8 @@ final case class JwtGeneratorBuilder(
     copy(header = Header(compact(render(body))))
   }
 
-  /** Load JWT payload from a classpath resource (must be valid JSON). Supports Gatling EL expressions (`#&#123;varName&#125;`)
-    * resolved at generation time.
+  /** Load JWT payload from a classpath resource. Supports Gatling EL expressions (`#&#123;varName&#125;`) resolved at
+    * generation time; payloads containing EL markers bypass JSON validation.
     */
   def payloadFromResource(path: String): JwtGeneratorBuilder =
     copy(payload = Payload(readResource(path)))
@@ -101,7 +108,7 @@ final case class JwtGeneratorBuilder(
     * [[IllegalArgumentException]] when the configured `algorithm` is not supported.
     */
   private[jwt] lazy val jwtAlgorithm: JwtAlgorithm = {
-    val alg = JwtAlgorithm.fromString(algorithm.toUpperCase)
+    val alg = JwtAlgorithm.fromString(algorithm.toUpperCase(Locale.ROOT))
     alg match {
       case _: JwtUnknownAlgorithm =>
         throw new IllegalArgumentException(s"Unsupported JWT algorithm: $algorithm")

--- a/src/main/scala/org/galaxio/gatling/utils/jwt/JwtGeneratorBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/jwt/JwtGeneratorBuilder.scala
@@ -100,7 +100,7 @@ final case class JwtGeneratorBuilder(
     * constructed eagerly (e.g. at simulation setup) without forcing the algorithm name to be known statically. Throws
     * [[IllegalArgumentException]] when the configured `algorithm` is not supported.
     */
-  private[jwt] def jwtAlgorithm: JwtAlgorithm = {
+  private[jwt] lazy val jwtAlgorithm: JwtAlgorithm = {
     val alg = JwtAlgorithm.fromString(algorithm.toUpperCase)
     alg match {
       case _: JwtUnknownAlgorithm =>

--- a/src/test/scala/org/galaxio/gatling/utils/jwt/JwtSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/jwt/JwtSpec.scala
@@ -62,10 +62,31 @@ class JwtSpec extends AnyWordSpec with Matchers {
       }
     }
 
-    "throw on unsupported algorithm" in {
+    "defer unsupported algorithm validation to first token generation" in {
+      // Builder construction must NOT throw — validation happens at generation time
+      val gen = jwtPkg.jwt("INVALID", "secret").defaultHeader.payload("""{"sub":"user1"}""")
+      gen.algorithm shouldBe "INVALID"
+
+      // Resolving jwtAlgorithm (used during token generation) throws
       an[IllegalArgumentException] shouldBe thrownBy {
-        jwtPkg.jwt("INVALID", "secret")
+        gen.jwtAlgorithm
       }
+    }
+
+    "accept payload containing Gatling EL without parsing as JSON" in {
+      // Payloads with EL placeholders (`#{var}`) are not legal JSON and must be accepted by the builder;
+      // they are resolved at token generation time.
+      val gen = jwtPkg
+        .jwt("HS256", "secret")
+        .defaultHeader
+        .payload("""{"sub":"#{userId}","scope":"#{scope}"}""")
+      gen.payload.json should include("#{userId}")
+      gen.payload.json should include("#{scope}")
+    }
+
+    "accept header containing Gatling EL without parsing as JSON" in {
+      val gen = jwtPkg.jwt("HS256", "secret").header("""{"alg":"HS256","kid":"#{keyId}"}""")
+      gen.header.json should include("#{keyId}")
     }
 
     "load header from resource" in {


### PR DESCRIPTION
## Summary

`JwtGeneratorBuilder` parsed the payload/header as JSON and validated the algorithm at builder construction time. Payloads containing Gatling EL placeholders (e.g. `#{userId}`) are not legal JSON, so the validator threw before the simulation even started — forcing users to bypass the safe builder API for any dynamic claim. This change defers algorithm validation to first token generation and skips JSON parsing when an EL marker (`#{`) is present.

## Changes

- `JwtGeneratorBuilder.validateJson`: short-circuit when the string contains `#{`, returning it as-is (EL is resolved at generation time).
- `JwtGeneratorBuilder.jwtAlgorithm`: converted from `val` to `def` so the algorithm string is only validated when a token is actually generated.
- Tests: replaced the eager "throw on unsupported algorithm" expectation with a deferred-validation test, and added regression tests for EL in both `payload(...)` and `header(...)`.

Public API signatures are unchanged; the package-private `jwtAlgorithm` member is the only call site (used in `jwt.scala` during encoding).

## Testing

- `sbt scalafmtCheckAll scalafmtSbtCheck compile`
- `sbt "testOnly org.galaxio.gatling.utils.jwt.JwtSpec"` — 25/25 pass, including new EL payload/header cases.

Fixes #68