### PR TITLE
docs: add project constitution v1.0.0 (spec-kit governance)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -21,18 +21,9 @@ Follow-up TODOs: none
 
 The Scala DSL and runtime are the canonical implementation of every feature.
 Java/Kotlin facades MUST be thin wrappers that delegate entirely to Scala core —
-they MUST NOT reimplement logic that already exists there.
-
-```scala
-// ✅ correct — thin delegation
-object JHttpFeeder { def apply(url: String): FeederBuilder = ScalaHttpFeeder(url) }
-
-// ❌ violation — duplicates Scala core logic
-object JHttpFeeder { def apply(url: String): FeederBuilder = { /* re-implemented logic */ } }
-```
-
-Any facade that adds business logic, conditional branching, or data transformation
-not present in the Scala layer is a constitution violation.
+they MUST NOT reimplement logic that already exists there. Any facade that adds
+business logic, conditional branching, or data transformation not present in the
+Scala layer is a constitution violation.
 
 ### II. Backward Compatibility (NON-NEGOTIABLE)
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,18 +1,3 @@
-<!--
-SYNC IMPACT REPORT
-==================
-Version change: [TEMPLATE] → 1.0.0 (initial fill-in)
-Modified principles: none (first population)
-Added sections: Core Principles (I–V), Stack Constraints, Development Workflow, Governance
-Removed sections: n/a
-Templates requiring updates:
-  ✅ .specify/templates/plan-template.md — Constitution Check gates updated
-  ✅ .specify/memory/constitution.md — this file
-  ⚠ .specify/templates/spec-template.md — generic, no constitution-specific refs; no change needed
-  ⚠ .specify/templates/tasks-template.md — generic; no change needed
-Follow-up TODOs: none
--->
-
 # Gatling Picatinny Constitution
 
 ## Core Principles
@@ -29,16 +14,16 @@ Scala layer is a constitution violation.
 
 Gatling Picatinny is a published Maven Central library consumed by external teams.
 All of the following are compatibility-sensitive and MUST NOT change without explicit
-authorization and a corresponding MAJOR or MINOR version bump:
+authorization and a corresponding version bump:
 
 - Public Scala and Java API signatures
 - DSL builder/syntax behavior
 - Serialized config and profile formats (PureConfig keys, JSON field names)
 - Feeder output shapes and session variable names
 
-Additions that are purely additive require MINOR bump. Any removal or behavioral
-redefinition requires MAJOR bump. Internal `private`/`package-private` refactors
-are exempt.
+Version bump rules: PATCH for trivial additive changes (new overload, deprecates nothing);
+MINOR for any addition that expands the public surface in a meaningful way; MAJOR for any
+removal or behavioral redefinition. Internal `private`/`package-private` refactors are exempt.
 
 ### III. Test Discipline
 
@@ -52,8 +37,8 @@ are MANDATORY for:
 - Any behavior that depends on external process state
 
 The Gatling runtime MUST NOT be mocked where a real integration path exists.
-Feeder determinism and transaction boundary behavior MUST be tested against an
-actual Gatling simulation run or a verified harness, not stubs.
+Feeder determinism and transaction boundary behavior MUST be covered by Testcontainers-backed
+integration tests, not stubs or hand-rolled fakes.
 
 ### IV. Small, Focused Changes
 
@@ -126,4 +111,4 @@ versioning policy below, and propagate changes to affected templates and AGENTS.
 Violations require explicit justification in the plan's Complexity Tracking table
 before merging.
 
-**Version**: 1.0.0 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-06-20
+**Version**: 1.0.1 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-06-20

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -66,15 +66,16 @@ Rules that MUST be followed without exception:
 
 ## Stack Constraints
 
-Technology stack is fixed. Changes require explicit authorization.
+Technology stack is fixed. Exact versions are in `build.sbt` / `project/Dependencies.scala`
+(source of truth). Changes require explicit authorization.
 
 | Concern | Value |
 |---------|-------|
-| Language | Scala 2.13.18 |
+| Language | Scala 2.13.x |
 | Build tool | sbt |
 | Compile target | Java 17 (`--release 17`) |
 | CI runtime | Temurin 21 |
-| Gatling | 3.13.5 (`Provided` scope — MUST remain `Provided`) |
+| Gatling | 3.13.x (`Provided` scope — MUST remain `Provided`) |
 | Core deps | PureConfig, Circe, json4s, Jackson, Scala Logging, Generex, JWT, fast-uuid |
 | Test infra | ScalaTest, JUnit 5 (sbt-jupiter-interface), Testcontainers |
 | Benchmarks | JMH (`sbt Jmh/run`) |
@@ -111,4 +112,4 @@ versioning policy below, and propagate changes to affected templates and AGENTS.
 Violations require explicit justification in the plan's Complexity Tracking table
 before merging.
 
-**Version**: 1.0.1 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-06-20
+**Version**: 1.0.2 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-06-20

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,50 +1,138 @@
-# [PROJECT_NAME] Constitution
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+<!--
+SYNC IMPACT REPORT
+==================
+Version change: [TEMPLATE] → 1.0.0 (initial fill-in)
+Modified principles: none (first population)
+Added sections: Core Principles (I–V), Stack Constraints, Development Workflow, Governance
+Removed sections: n/a
+Templates requiring updates:
+  ✅ .specify/templates/plan-template.md — Constitution Check gates updated
+  ✅ .specify/memory/constitution.md — this file
+  ⚠ .specify/templates/spec-template.md — generic, no constitution-specific refs; no change needed
+  ⚠ .specify/templates/tasks-template.md — generic; no change needed
+Follow-up TODOs: none
+-->
+
+# Gatling Picatinny Constitution
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+### I. Scala DSL as Source of Truth
 
-### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+The Scala DSL and runtime are the canonical implementation of every feature.
+Java/Kotlin facades MUST be thin wrappers that delegate entirely to Scala core —
+they MUST NOT reimplement logic that already exists there.
 
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+```scala
+// ✅ correct — thin delegation
+object JHttpFeeder { def apply(url: String): FeederBuilder = ScalaHttpFeeder(url) }
 
-### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+// ❌ violation — duplicates Scala core logic
+object JHttpFeeder { def apply(url: String): FeederBuilder = { /* re-implemented logic */ } }
+```
 
-### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+Any facade that adds business logic, conditional branching, or data transformation
+not present in the Scala layer is a constitution violation.
 
-## [SECTION_2_NAME]
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+### II. Backward Compatibility (NON-NEGOTIABLE)
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+Gatling Picatinny is a published Maven Central library consumed by external teams.
+All of the following are compatibility-sensitive and MUST NOT change without explicit
+authorization and a corresponding MAJOR or MINOR version bump:
 
-## [SECTION_3_NAME]
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+- Public Scala and Java API signatures
+- DSL builder/syntax behavior
+- Serialized config and profile formats (PureConfig keys, JSON field names)
+- Feeder output shapes and session variable names
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+Additions that are purely additive require MINOR bump. Any removal or behavioral
+redefinition requires MAJOR bump. Internal `private`/`package-private` refactors
+are exempt.
+
+### III. Test Discipline
+
+Unit tests MUST accompany every new or modified code path (ScalaTest, JUnit via
+sbt-jupiter-interface). Integration tests using real infrastructure (Testcontainers)
+are MANDATORY for:
+
+- Redis side effects and session state
+- JWT generation and verification
+- Startup diagnostics
+- Any behavior that depends on external process state
+
+The Gatling runtime MUST NOT be mocked where a real integration path exists.
+Feeder determinism and transaction boundary behavior MUST be tested against an
+actual Gatling simulation run or a verified harness, not stubs.
+
+### IV. Small, Focused Changes
+
+Default to the minimal change that satisfies the task.
+
+- Opportunistic refactors outside task scope are PROHIBITED.
+- New dependencies MUST be explicitly authorized before adding to `build.sbt`.
+- Public API signature changes MUST be explicitly authorized.
+- Changing serialized config/profile formats MUST be explicitly authorized.
+- Complexity MUST be justified in the plan's Complexity Tracking table when a
+  constitution principle is bent.
+
+### V. Release Integrity
+
+Release process is trunk-based with release branches.
+
+Rules that MUST be followed without exception:
+
+- Every minor version gets its own `release/X.Y.0` branch cut from `main`.
+- Version tags (`vX.Y.Z`) are placed ONLY on `release/*` branches or `main`.
+- Branch name MUST match the tag version family (`release/1.2.0` hosts `v1.2.0`, `v1.2.1`).
+- Once a tag is pushed and Sonatype deployment starts, the tag MUST NOT be deleted.
+- Version numbers MUST NOT be reused — Sonatype Central permanently rejects duplicates.
+- Patch fixes land on `main` first, then are cherry-picked onto the release branch.
+
+## Stack Constraints
+
+Technology stack is fixed. Changes require explicit authorization.
+
+| Concern | Value |
+|---------|-------|
+| Language | Scala 2.13.18 |
+| Build tool | sbt |
+| Compile target | Java 17 (`--release 17`) |
+| CI runtime | Temurin 21 |
+| Gatling | 3.13.5 (`Provided` scope — MUST remain `Provided`) |
+| Core deps | PureConfig, Circe, json4s, Jackson, Scala Logging, Generex, JWT, fast-uuid |
+| Test infra | ScalaTest, JUnit 5 (sbt-jupiter-interface), Testcontainers |
+| Benchmarks | JMH (`sbt Jmh/run`) |
+| Code style | scalafmt (enforced; run `sbt scalafmtAll scalafmtSbt` before every commit) |
+
+Gatling MUST stay `Provided` — it is the host runtime, not a bundled dependency.
+
+## Development Workflow
+
+1. Branch from `main` for every change. No direct commits to `main` or `release/*`.
+2. Run `sbt scalafmtAll scalafmtSbt` before committing.
+3. CI gate: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` MUST pass.
+4. Integration gate (when touching Redis, diagnostics, JWT): `sbt "IntegrationTest / test"`.
+5. PRs only — force-push and merge commits in PR branches are prohibited (rebase only).
+6. Commits MUST be semantic (conventional commits) and leave the build green.
+7. New or changed examples in `examples/` MUST compile against the published artifact
+   version, not a local snapshot, before release.
 
 ## Governance
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+This constitution supersedes all other agent and developer practices for this project.
+Operational guidance (commands, stack details, structure) lives in `AGENTS.md`; this
+document governs the non-negotiable rules and their rationale.
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+**Amendment procedure**: Update this file, bump `CONSTITUTION_VERSION` per semantic
+versioning policy below, and propagate changes to affected templates and AGENTS.md.
+
+**Versioning policy**:
+- MAJOR: principle removed, redefined, or made incompatible with prior behavior.
+- MINOR: new principle or section added; materially expanded guidance.
+- PATCH: clarifications, wording, typo fixes, non-semantic refinements.
+
+**Compliance review**: Every PR MUST be evaluated against all five Core Principles.
+Violations require explicit justification in the plan's Complexity Tracking table
+before merging.
+
+**Version**: 1.0.0 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-06-20

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -40,7 +40,11 @@
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-[Gates determined based on constitution file]
+- [ ] **I. Scala DSL as Source of Truth** — Java/Kotlin facade changes delegate to Scala core; no logic duplication in facade layer.
+- [ ] **II. Backward Compatibility** — No public API, DSL behavior, or serialized config/profile format broken without MAJOR bump and explicit authorization.
+- [ ] **III. Test Discipline** — Unit tests accompany all code paths; integration tests (Testcontainers) required for Redis, JWT, diagnostics; Gatling runtime not mocked where real path exists.
+- [ ] **IV. Small, Focused Changes** — No opportunistic refactors; new deps / API signature / config format changes explicitly authorized; complexity justified in table below if principle bent.
+- [ ] **V. Release Integrity** — Correct branch strategy; tag placement; no version reuse.
 
 ## Project Structure
 

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -44,7 +44,7 @@
 - [ ] **II. Backward Compatibility** — No public API, DSL behavior, or serialized config/profile format broken without MAJOR bump and explicit authorization.
 - [ ] **III. Test Discipline** — Unit tests accompany all code paths; integration tests (Testcontainers) required for Redis, JWT, diagnostics; Gatling runtime not mocked where real path exists.
 - [ ] **IV. Small, Focused Changes** — No opportunistic refactors; new deps / API signature / config format changes explicitly authorized; complexity justified in table below if principle bent.
-- [ ] **V. Release Integrity** — Correct branch strategy; tag placement; no version reuse.
+- [ ] **V. Release Integrity** *(release PRs only)* — Correct branch strategy; tag placement; no version reuse.
 
 ## Project Structure
 


### PR DESCRIPTION
## What

Populates the spec-kit constitution template (`.specify/memory/constitution.md`) with
project-specific governance for gatling-picatinny. Also updates the plan template's
Constitution Check section to reference the actual principles.

## Why

The spec-kit workflow requires a filled-in constitution before `/speckit-plan` and
`/speckit-specify` can generate gated output. Without it, Constitution Check in every
plan is a no-op placeholder.

## Changes

### `.specify/memory/constitution.md`
Five core principles (non-negotiable rules + rationale):
1. **Scala DSL as Source of Truth** — facades MUST delegate to Scala core, never reimplement
2. **Backward Compatibility** — published Maven Central library; API/DSL/config format changes are compatibility-sensitive
3. **Test Discipline** — unit tests mandatory; integration tests (Testcontainers) required for Redis/JWT/diagnostics; no Gatling runtime mocks
4. **Small, Focused Changes** — no scope creep; new deps/API/config changes need explicit authorization
5. **Release Integrity** — trunk-based, strict `release/X.Y.0` branches, no tag deletion/reuse

Also includes: Stack Constraints table, Development Workflow checklist, Governance/amendment procedure.

### `.specify/templates/plan-template.md`
Constitution Check gate replaced from generic `[Gates determined based on constitution file]`
to a concrete checklist referencing all five principles by name.

## Reviewer notes

- No production code changed — governance docs only
- Constitution version: `1.0.0` (initial population; MINOR by policy since all sections are new)
- Ratified and last amended: `2026-06-20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)