### PR TITLE
fix(ci): add Refactoring group to cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -34,10 +34,11 @@ commit_parsers = [
   { body = ".*BREAKING CHANGE", group = "<!-- 00 -->Breaking changes" },
   { message = "^feat", group = "<!-- 01 -->Features" },
   { message = "^fix", group = "<!-- 02 -->Fixes" },
-  { message = "^perf", group = "<!-- 03 -->Performance" },
-  { message = "^docs", group = "<!-- 04 -->Documentation" },
-  { message = "^chore\\(deps\\)", group = "<!-- 05 -->Dependencies" },
-  { message = "^(refactor|test|ci|build|chore|style|revert)", group = "<!-- 06 -->Maintenance" },
+  { message = "^refactor", group = "<!-- 03 -->Refactoring" },
+  { message = "^perf", group = "<!-- 04 -->Performance" },
+  { message = "^docs", group = "<!-- 05 -->Documentation" },
+  { message = "^chore\\(deps\\)", group = "<!-- 06 -->Dependencies" },
+  { message = "^(test|ci|build|chore|style|revert)", group = "<!-- 07 -->Maintenance" },
 ]
 filter_commits = true
 tag_pattern = "v[0-9].*"


### PR DESCRIPTION
## Summary

- `refactor` commits were lumped with `ci`/`chore`/`style`/`revert` in **Maintenance**, making structural library changes invisible as a category
- Add dedicated **Refactoring** group (`<!-- 03 -->`) between Fixes and Performance
- Shift remaining groups down one slot (`<!-- 04 -->` – `<!-- 07 -->`)

## Test plan
- [ ] Verify `git-cliff v1.15.7..v1.16.0` shows a **Refactoring** section with the 3 `refactor(transactions):` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)