### PR TITLE
chore(ci): pin templates-gatling to v0.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
   JVM_OPTS: -Xms2G -Xmx2G -Xss4M -XX:+UseG1GC
   FORCE_COLOR: "1"
   TERM: xterm-256color
+  TEMPLATES_GATLING_VERSION: v0.15.0
 
 jobs:
   format:
@@ -158,7 +159,7 @@ jobs:
           registry_dir="$work_dir/registry"
           project_dir="$work_dir/java-maven-example"
 
-          git clone --depth 1 --branch v0.15.0 https://github.com/galax-io/templates-gatling.git "$templates_dir"
+          git clone --depth 1 --branch "${TEMPLATES_GATLING_VERSION}" https://github.com/galax-io/templates-gatling.git "$templates_dir"
 
           mkdir -p "$registry_dir"
           cat > "$registry_dir/galaxio-registry.yaml" <<YAML

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           registry_dir="$work_dir/registry"
           project_dir="$work_dir/java-maven-example"
 
-          git clone --depth 1 https://github.com/galax-io/templates-gatling.git "$templates_dir"
+          git clone --depth 1 --branch v0.15.0 https://github.com/galax-io/templates-gatling.git "$templates_dir"
 
           mkdir -p "$registry_dir"
           cat > "$registry_dir/galaxio-registry.yaml" <<YAML

--- a/scripts/test-kotlin-gradle-template.sh
+++ b/scripts/test-kotlin-gradle-template.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK_DIR="${PICATINNY_KOTLIN_GRADLE_TEMPLATE_WORKDIR:-$(mktemp -d)}"
+TEMPLATES_GATLING_VERSION="${TEMPLATES_GATLING_VERSION:-v0.15.0}"
 TEMPLATES_DIR="$WORK_DIR/templates-gatling"
 REGISTRY_DIR="$WORK_DIR/registry"
 PROJECT_DIR="$WORK_DIR/kotlin-gradle-example"
@@ -19,7 +20,7 @@ if ! command -v galaxio >/dev/null 2>&1; then
   exit 1
 fi
 
-git clone --depth 1 --branch v0.15.0 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
+git clone --depth 1 --branch "${TEMPLATES_GATLING_VERSION}" https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
 
 mkdir -p "$REGISTRY_DIR"
 cat > "$REGISTRY_DIR/galaxio-registry.yaml" <<YAML

--- a/scripts/test-kotlin-gradle-template.sh
+++ b/scripts/test-kotlin-gradle-template.sh
@@ -19,7 +19,7 @@ if ! command -v galaxio >/dev/null 2>&1; then
   exit 1
 fi
 
-git clone --depth 1 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
+git clone --depth 1 --branch v0.15.0 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
 
 mkdir -p "$REGISTRY_DIR"
 cat > "$REGISTRY_DIR/galaxio-registry.yaml" <<YAML

--- a/scripts/test-scala-sbt-template.sh
+++ b/scripts/test-scala-sbt-template.sh
@@ -19,7 +19,7 @@ if ! command -v galaxio >/dev/null 2>&1; then
   exit 1
 fi
 
-git clone --depth 1 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
+git clone --depth 1 --branch v0.15.0 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
 
 mkdir -p "$REGISTRY_DIR"
 cat > "$REGISTRY_DIR/galaxio-registry.yaml" <<YAML

--- a/scripts/test-scala-sbt-template.sh
+++ b/scripts/test-scala-sbt-template.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK_DIR="${PICATINNY_SCALA_SBT_TEMPLATE_WORKDIR:-$(mktemp -d)}"
+TEMPLATES_GATLING_VERSION="${TEMPLATES_GATLING_VERSION:-v0.15.0}"
 TEMPLATES_DIR="$WORK_DIR/templates-gatling"
 REGISTRY_DIR="$WORK_DIR/registry"
 PROJECT_DIR="$WORK_DIR/scala-sbt-example"
@@ -19,7 +20,7 @@ if ! command -v galaxio >/dev/null 2>&1; then
   exit 1
 fi
 
-git clone --depth 1 --branch v0.15.0 https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
+git clone --depth 1 --branch "${TEMPLATES_GATLING_VERSION}" https://github.com/galax-io/templates-gatling.git "$TEMPLATES_DIR"
 
 mkdir -p "$REGISTRY_DIR"
 cat > "$REGISTRY_DIR/galaxio-registry.yaml" <<YAML


### PR DESCRIPTION
## Summary
- Replace `--depth 1` (HEAD main) with `--branch v0.15.0` in all three template test scripts (`ci.yml`, `test-kotlin-gradle-template.sh`, `test-scala-sbt-template.sh`)
- Pins CI to the templates-gatling release that ships `GatlingPicatinnyVersion` default `1.17.1`

## Test plan
- [ ] Template / java-maven passes with v0.15.0 templates
- [ ] Template / kotlin-gradle passes
- [ ] Template / scala-sbt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)