### PR TITLE
fix(security): harden storage, JDBC, Vault, and profile parsing (v1.20.0)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/004-template-output-fixes"
+  "feature_directory": "specs/004-storage-vault-security"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 @AGENTS.md
 
 <!-- SPECKIT START -->
-Active plan: [specs/004-template-output-fixes/plan.md](specs/004-template-output-fixes/plan.md) — Template Output Fixes (v1.19.0): arr truncation/EL detection, XML name + RawValGen escaping, missing-templates fast-fail.
+Active plan: [specs/004-storage-vault-security/plan.md](specs/004-storage-vault-security/plan.md) — Storage, JDBC & Vault Security (v1.20.0): SQLi tableName allowlist, Vault HTTPS enforcement, profile path traversal, CSV MatchError, InjectionProfileParser arity guard.
 <!-- SPECKIT END -->

--- a/specs/004-storage-vault-security/checklists/requirements.md
+++ b/specs/004-storage-vault-security/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Storage, JDBC & Vault Security Hardening
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass after two minor fixes:
+- FR-001: validation rule expressed as behavior (safe SQL identifier chars) rather than regex literal
+- SC-003: removed `sbt test` tool reference; expressed as container-free test constraint

--- a/specs/004-storage-vault-security/contracts/api-contracts.md
+++ b/specs/004-storage-vault-security/contracts/api-contracts.md
@@ -1,0 +1,86 @@
+# API Contracts: Storage, JDBC & Vault Security Hardening
+
+This file documents the **behavior contracts** added or tightened by this feature.
+All changes are additive (stricter preconditions on existing APIs) — no signatures change.
+
+---
+
+## `JdbcStorageBackend` Constructor Contract
+
+**Precondition** (new):
+```
+tableName must match [A-Za-z_][A-Za-z0-9_]*
+```
+
+| Input | Result |
+|-------|--------|
+| `"gatling_session_storage"` (default) | construction succeeds |
+| `"my_results_2024"` | construction succeeds |
+| `""` (empty) | `IllegalArgumentException`: "Invalid tableName" |
+| `"results; DROP TABLE results; --"` | `IllegalArgumentException`: "Invalid tableName" |
+| `"123bad"` (starts with digit) | `IllegalArgumentException`: "Invalid tableName" |
+| `"tab le"` (space) | `IllegalArgumentException`: "Invalid tableName" |
+
+**Guarantee**: if construction succeeds, all SQL operations on this instance use a
+validated identifier — no SQL injection surface via `tableName`.
+
+---
+
+## `VaultFeeder` URL Contract
+
+**Warning behavior** (new, applies to `apply`, all `fromPaths` overloads, `withToken`):
+```
+If vaultUrl scheme == "http" AND host is not "localhost" or "127.0.0.1":
+  → WARN logged before any network call; call proceeds
+Otherwise:
+  → no warning
+```
+
+| Input | Result |
+|-------|--------|
+| `"https://vault.prod.internal"` | proceeds, no warning |
+| `"http://localhost:8200"` | proceeds, no warning (localhost exemption) |
+| `"http://127.0.0.1:8200"` | proceeds, no warning (loopback exemption) |
+| `"http://[::1]:8200"` | proceeds, no warning (IPv6 loopback exemption) |
+| `"http://vault.prod.internal"` | WARN logged with URL; call proceeds |
+| `"http://[2001:db8::1]:8200"` | WARN logged with URL; call proceeds (non-loopback IPv6) |
+
+**Guarantee**: if a non-HTTPS non-local URL is used, a WARN-level log entry naming the
+URL is always emitted before the first network call.
+
+---
+
+## `ProfileBuilderNew.buildFromYaml` / `buildFromYamlJava` Path Contract
+
+**Precondition** (new):
+```
+Paths.get(user.dir, path).normalize() must start with Paths.get(user.dir).toAbsolutePath
+```
+
+| Input `path` | Result |
+|-------------|--------|
+| `"src/test/resources/profile.yml"` | resolves, proceeds to file I/O |
+| `"../../etc/passwd"` | `ProfileBuilderException`: "Path traversal detected" (escapes base) |
+| `"/etc/passwd"` (absolute) | `ProfileBuilderException`: "Path traversal detected" (absolute paths rejected outright) |
+| `"profiles/../profiles/p.yml"` (same dir after normalize) | proceeds normally |
+
+**Guarantee**: if path validation passes, the resolved file is within the project's
+working directory tree.
+
+---
+
+## `Request.toRequest` Header Contract
+
+**Precondition** (tightened):
+```
+Every element of requestHeaders must match (.+?): (.+)
+```
+
+| Input header string | Result |
+|--------------------|--------|
+| `"Content-Type: application/json"` | key-value pair extracted correctly |
+| `"greetings: Hello world!"` | key-value pair extracted correctly |
+| `"malformed-no-colon"` | `ProfileBuilderException`: "Malformed header: 'malformed-no-colon'" |
+| `""` (empty string) | `ProfileBuilderException`: "Malformed header: ''" |
+
+**Change from before**: `MatchError` (opaque) → `ProfileBuilderException` (typed, actionable).

--- a/specs/004-storage-vault-security/data-model.md
+++ b/specs/004-storage-vault-security/data-model.md
@@ -1,0 +1,101 @@
+# Data Model: Storage, JDBC & Vault Security Hardening
+
+No new persistent entities or schema changes. This feature hardens existing value-object
+constructors and pure functions. The changes below document modified validation rules and
+state invariants for each affected type.
+
+---
+
+## Modified Types
+
+### `JdbcStorageBackend` (`storage/StorageBackend.scala`)
+
+**Type**: `final case class`  
+**Public constructor**: `JdbcStorageBackend(jdbcUrl, tableName, username, password)`
+
+**New invariant** (post-construction):
+- `tableName` matches `[A-Za-z_][A-Za-z0-9_]*`
+- Violated → `IllegalArgumentException` thrown before any JDBC connection is made
+- Default value `"gatling_session_storage"` satisfies the invariant
+
+**Internal change** (no public impact):
+- `private implicit val formats` removed from this class body; imported from shared `StorageFormats` object
+
+---
+
+### `JsonFileBackend` + `RedisBackend` (`storage/StorageBackend.scala`)
+
+**Internal change only**:
+- `private implicit val formats` removed from both class bodies; imported from shared `StorageFormats` object
+- No public API change; no behavioral change
+
+---
+
+### `StorageFormats` (new private object, same file)
+
+**Type**: `private object`  
+**Scope**: `storage` package only
+
+| Member | Type | Value |
+|--------|------|-------|
+| `formats` | `implicit Formats` | `DefaultFormats` |
+
+---
+
+### `VaultFeeder` (`feeders/VaultFeeder.scala`)
+
+**Type**: Scala `object` (all-static methods)  
+**Changed entry points**: `apply`, `fromPaths` (all three overloads), `withToken`
+
+**New behavior** (before `THttpClient` is created):
+- If `vaultUrl` scheme is `http` and host is not a loopback host → WARN logged naming the URL; call proceeds
+- Loopback hosts (`localhost`, `127.0.0.1`, `[::1]`, `[0:0:0:0:0:0:0:1]`) → no warning (local dev exemption)
+- HTTPS → no warning
+
+**New private helper**:
+
+| Member | Signature | Purpose |
+|--------|-----------|---------|
+| `warnIfNotHttps` | `(vaultUrl: String): Unit` | Parses URL via `java.net.URI`; calls `logger.warn` on HTTP non-localhost |
+
+---
+
+### `ProfileBuilderNew` (`profile/ProfileBuilderNew.scala`)
+
+**Changed methods**: `buildFromYaml`, `buildFromYamlJava`
+
+**New invariant** (post path resolution):
+- Caller-supplied absolute paths (`Paths.get(path).isAbsolute`) are rejected outright
+- Otherwise the resolved path must start with `Paths.get(user.dir).toAbsolutePath.normalize()`
+- Violated → `ProfileBuilderException("Path traversal detected: ...", cause)` thrown before any file I/O
+- Both methods apply the same check; `ProfileBuilderException` is the existing typed exception
+
+---
+
+### `Request` (`profile/ProfileBuilderNew.scala`)
+
+**Changed**: `toRequest` method (in the `Request` case class)  
+**Changed expression**: `requestHeaders.map { case regexHeader(a, b) => (a, b) }`
+
+**New behavior**:
+- Header parsing extracted to `private[gatling] def parsedHeaders`; `toRequest` delegates to it
+- Malformed header string (one that doesn't match `(.+?): (.+)`) → `ProfileBuilderException(s"Malformed header: '$bad' ...")` thrown
+- Valid headers → unchanged behavior
+- Exception type: reuses existing `ProfileBuilderException`
+- The Java/Kotlin facade `javaapi.internal.ProfileBuilderNew.toRequest` now delegates to `parsedHeaders` (was duplicating the unguarded match → `MatchError` for Java callers); `private[gatling]` visibility enables the delegation without exposing public API
+
+---
+
+### `InjectionProfileParser` (`diagnostics/InjectionProfileParser.scala`)
+
+**Type**: `private[gatling] object` (internal only — no public API impact)  
+**Changed methods**: `closedSegments`, `openSegments` (the `other` fallback branches)
+
+**New preconditions**:
+
+| Method | Guard | Thrown on violation |
+|--------|-------|---------------------|
+| `closedSegments` `other` branch | `other.productArity >= 2` | `IllegalArgumentException` with arity + step type in message |
+| `openSegments` `other` branch | `other.productArity >= 1` | `IllegalArgumentException` with arity + step type in message |
+
+Both guards use `require(...)` to match the existing validation style in this codebase.

--- a/specs/004-storage-vault-security/plan.md
+++ b/specs/004-storage-vault-security/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Storage, JDBC & Vault Security Hardening
+
+**Branch**: `004-storage-vault-security` | **Date**: 2026-06-22 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/004-storage-vault-security/spec.md`
+
+**Milestone**: [v1.19.0 — Storage, JDBC & Vault security](https://github.com/galax-io/gatling-picatinny/milestone/4) | Issues: [#204](https://github.com/galax-io/gatling-picatinny/issues/204), [#209](https://github.com/galax-io/gatling-picatinny/issues/209), [#94](https://github.com/galax-io/gatling-picatinny/issues/94)
+
+## Summary
+
+Five targeted security/correctness fixes across four files, plus two internal cleanups,
+with no public API signature changes. Each fix adds a pre-condition guard or replaces
+a partial match with exhaustive handling, making failures loud and actionable instead of
+silent or opaque. All new tests run without containers.
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18
+
+**Primary Dependencies**: json4s (DefaultFormats, native), java.net.URI (stdlib), java.nio.file.Paths (stdlib), Scala Logging — no new deps required
+
+**Storage**: JDBC (PostgreSQL / H2 in tests via `JdbcTestSupport.RecordingJdbcDriver`)
+
+**Testing**: ScalaTest (AnyWordSpec + Matchers), ScalaMock for `THttpClient`, `JdbcTestSupport.RecordingJdbcDriver` for JDBC unit layer
+
+**Target Platform**: JVM 17 (compile target); CI Temurin 21
+
+**Project Type**: Published library (Maven Central)
+
+**Performance Goals**: Validation guards run at simulation setup time (not hot path) — negligible overhead; no performance goal applies
+
+**Constraints**: No new dependencies; no public API signature changes; all new tests in `Test` scope (no Docker for new tests)
+
+**Scale/Scope**: 5 source-file edits (4 production + 1 refactor), 4 test-file extensions
+
+## Test Model *(mandatory — real cases + test sketches, NO implementation)*
+
+| Req | Real case to test | Layer | Test sketch (no code) |
+|-----|-------------------|-------|-----------------------|
+| FR-001 | `JdbcStorageBackend` constructed with `tableName = "bad; DROP TABLE x; --"` | Unit/Functional | Assert `IllegalArgumentException` thrown before any JDBC call (verify `RecordingJdbcDriver` connection count stays 0); exact message includes "Invalid tableName" and the offending value. Negative: `tableName = "gatling_session_storage"` constructs successfully. |
+| FR-001 | `JdbcStorageBackend` with `tableName = ""` (empty) | Unit/Functional | Assert `IllegalArgumentException`; negative: `tableName = "a"` (single letter) succeeds. |
+| FR-002 | `VaultFeeder.apply` called with `vaultUrl = "http://vault.prod.internal"` | Unit/Functional | ScalaMock `THttpClient` receives `postOrThrow` call (proceeds); assert logger WARN captured with URL in message before the HTTP call. |
+| FR-002 | `VaultFeeder.apply` called with `vaultUrl = "http://localhost:8200"` | Unit/Functional | No warning logged; ScalaMock `THttpClient` receives `postOrThrow` call (localhost exemption — no log). |
+| FR-002 | `VaultFeeder.withToken` called with `vaultUrl = "http://10.0.0.1"` | Unit/Functional | Assert WARN logged with URL; ScalaMock `getOrThrow` still called (warning only, no block). |
+| FR-003 | `ProfileBuilderNew.buildFromYaml("../../etc/passwd")` | Unit/Functional | Assert `ProfileBuilderException` thrown before `Source.fromFile` is called; message contains "traversal" or "containment" and the supplied path. |
+| FR-003 | `ProfileBuilderNew.buildFromYaml("src/test/resources/profileTemplates/profile1.yml")` | Unit/Functional | No traversal error; existing happy-path test still passes. |
+| FR-004 | `Request.toRequest` with header `"malformed-no-colon"` in `requestHeaders` | Unit/Functional | Assert `ProfileBuilderException` (not `MatchError`) with message naming `"malformed-no-colon"`. Negative: header `"Content-Type: application/json"` extracts key `"Content-Type"` and value `"application/json"` correctly. |
+| FR-004 | `Request.toRequest` with empty string header `""` | Unit/Functional | Assert `ProfileBuilderException` (not `MatchError`). |
+| FR-005 | `InjectionProfileParser` closed `other` step with `productArity = 0` | Unit/Functional | Minimal `Product` stub with `productArity = 0`; assert `IllegalArgumentException` with arity and type in message before any `productElement` call. |
+| FR-005 | `InjectionProfileParser` open `other` step with `productArity = 0` | Unit/Functional | Same stub pattern for `openSegments`; assert `IllegalArgumentException`. |
+| FR-005 | Well-formed `RampRateOpenInjection(1.0, 5.0, 10.seconds)` | Unit/Functional | Parsed via `fromOpen`; assert `WorkloadSettings.intensityRps > 0` and `stagesNumber` correct exact value. |
+| FR-006 | `StorageBackend.scala` compiles with single `formats` definition | Compile Guard | `sbt compile` succeeds; grep for `private implicit val formats` returns exactly one occurrence (in `StorageFormats` object). |
+| FR-007 | `mergeWithStrategy(FailOnDuplicate, pairs with duplicate key "user")` | Unit/Functional | Pure function call (no mock needed); assert `IllegalArgumentException` listing `"user"` as duplicate. |
+| FR-007 | `mergeWithStrategy(LastWins, [("k","v1"),("k","v2")])` | Unit/Functional | Returns `Map("k" -> "v2")`; assert log warning captured (using `LazyLogging` test intercept or checking logger output). |
+| FR-007 | `mergeWithStrategy(FirstWins, [("k","v1"),("k","v2")])` | Unit/Functional | Returns `Map("k" -> "v1")`; assert log warning captured. |
+| FR-007 | `login` called with mock returning malformed JSON body | Unit/Functional | ScalaMock `THttpClient.postOrThrow` returns `HttpResult(200, "not-json")`; assert `RuntimeException` with message "Failed to parse Vault login response as JSON". |
+| FR-007 | `readSecret` called with mock returning JSON missing `"data"` field | Unit/Functional | ScalaMock `THttpClient.getOrThrow` returns `HttpResult(200, "{}")`; assert `RuntimeException` with message referencing the secret path. |
+| FR-008 | All rejection paths fire on invalid input without false positives | Unit/Functional | Cross-cut: one negative test per FR-001–FR-005 (covered by the rows above); one positive case per fix confirming valid input is not rejected. |
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **I. Scala DSL as Source of Truth** — No Java facade changes in this feature. `InjectionProfileParser` is `private[gatling]`; all other changes are in Scala core modules. Java facade (`javaapi/internal/ProfileBuilderNew.scala`) is not touched — it delegates to Scala `ProfileBuilderNew` which is being hardened.
+- [x] **II. Backward Compatibility** — No public API signatures change. All changes tighten pre-conditions on existing public methods for invalid inputs that were already broken (SQL injection, cleartext credentials, path traversal, `MatchError`). The valid-input happy path is unchanged. MINOR version bump appropriate (security hardening with no removal). No serialized config/profile format changes.
+- [x] **III. Test Discipline** — Test Model filled above: one row per FR, real case named, all layers are Unit/Functional (pure functions or ScalaMock boundary) or Compile Guard. No DSL/Action Component layer needed (no Gatling runtime behavior). No Testcontainers for new tests (FR-007 explicitly avoids Docker). `InjectionProfileParser` is `private[gatling]` — tests go in the `diagnostics` package test scope. ScalaMock for `THttpClient` (existing pattern in `VaultFeederSpec`). `JdbcTestSupport.RecordingJdbcDriver` for JDBC unit tests (existing pattern in `JdbcStorageBackendSpec`). ≥1 negative/boundary case per FR confirmed in test sketches.
+- [x] **IV. Small, Focused Changes** — No opportunistic refactors. FR-006 (`DefaultFormats` dedup) is explicitly authorized by issue #204. No new dependencies. `InjectionProfileParser` is internal — no API signature concern. Changes are isolated to exactly the lines cited in the issues.
+- [ ] **V. Release Integrity** *(release PRs only)* — Not applicable to this feature PR. Will apply when cutting the release.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-storage-vault-security/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: decisions per FR
+├── data-model.md        # Phase 1: modified type contracts
+├── quickstart.md        # Phase 1: validation guide
+├── contracts/
+│   └── api-contracts.md # Phase 1: behavior contract tables
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code
+
+```text
+src/main/scala/org/galaxio/gatling/
+├── storage/
+│   └── StorageBackend.scala        # FR-001 (tableName require), FR-006 (DefaultFormats dedup)
+├── feeders/
+│   └── VaultFeeder.scala           # FR-002 (requireHttps helper + call sites)
+├── profile/
+│   └── ProfileBuilderNew.scala     # FR-003 (path containment), FR-004 (exhaustive header match)
+└── diagnostics/
+    └── InjectionProfileParser.scala # FR-005 (arity guards in closedSegments + openSegments)
+
+src/test/scala/org/galaxio/gatling/
+├── storage/
+│   └── JdbcStorageBackendSpec.scala # FR-001: new negative tests for invalid tableName
+├── feeders/
+│   └── VaultFeederSpec.scala        # FR-002: HTTPS enforcement tests; FR-007: merge/parse unit tests
+├── profile/
+│   └── ProfileBuilderTest.scala     # FR-003: traversal rejection; FR-004: malformed header
+└── diagnostics/
+    └── InjectionProfileParserSpec.scala  # FR-005: arity guard (new file or extend existing)
+```
+
+**Structure Decision**: Single-project layout (existing); no new modules or directories in source. Test files extend existing specs where the class already has coverage (`JdbcStorageBackendSpec`, `VaultFeederSpec`, `ProfileBuilderTest`). `InjectionProfileParserSpec` may be a new file if no existing diagnostics spec exists.
+
+## Complexity Tracking
+
+> No Constitution violations. Table not needed.

--- a/specs/004-storage-vault-security/quickstart.md
+++ b/specs/004-storage-vault-security/quickstart.md
@@ -1,0 +1,134 @@
+# Quickstart Validation Guide: Storage, JDBC & Vault Security Hardening
+
+Proves all five security/correctness fixes work end-to-end via the standard unit test suite.
+No containers or network required.
+
+## Prerequisites
+
+- JDK 17+ on PATH
+- `sbt` available
+- Working directory: repository root
+
+## Run All Unit Tests
+
+```bash
+sbt compile test
+```
+
+Expected: all tests pass, including the new ones listed below.
+
+## Fix-by-Fix Validation
+
+### FR-001 — SQLi: `JdbcStorageBackend` tableName validation
+
+**Test class**: `JdbcStorageBackendSpec`  
+New test: `"reject tableName containing SQL injection payload"`
+
+Verify manually:
+```scala
+// Should throw IllegalArgumentException before any DB connection:
+JdbcStorageBackend(jdbcUrl = "jdbc:h2:mem:test", tableName = "bad; DROP TABLE x; --")
+// Should construct successfully:
+JdbcStorageBackend(jdbcUrl = "jdbc:h2:mem:test", tableName = "valid_table_name")
+```
+
+---
+
+### FR-002 — Vault HTTPS: `VaultFeeder` URL enforcement
+
+**Test class**: `VaultFeederSpec`  
+New tests: `"reject http:// vaultUrl for non-localhost"`, `"allow http:// for localhost"`, `"allow http:// for 127.0.0.1"`
+
+Verify manually:
+```scala
+// Should throw IllegalArgumentException before THttpClient creation:
+VaultFeeder("http://vault.prod.internal", "secret/path", "role", "secret", List("key"))
+// Should proceed (localhost exemption):
+VaultFeeder("http://localhost:8200", "secret/path", "role", "secret", List("key"))
+```
+
+---
+
+### FR-003 — Path traversal: `ProfileBuilderNew` containment check
+
+**Test class**: `ProfileBuilderTest`  
+New test: `"reject paths that escape the working directory"`
+
+Verify manually:
+```scala
+// Should throw ProfileBuilderException "Path traversal detected":
+ProfileBuilderNew.buildFromYaml("../../etc/passwd")
+```
+
+---
+
+### FR-004 — Malformed header: `Request.toRequest` typed exception
+
+**Test class**: `ProfileBuilderTest` (or a new `RequestSpec`)  
+New test: `"throw ProfileBuilderException on malformed header string"`
+
+Verify manually:
+```scala
+val r = Request("r", "100 rph", None, Params("GET", "/", Some(List("bad-header")), None))
+// Should throw ProfileBuilderException "Malformed header: 'bad-header'":
+r.toRequest
+```
+
+---
+
+### FR-005 — Arity guard: `InjectionProfileParser` explicit failure
+
+**Test class**: new `InjectionProfileParserSpec` (or extend existing diagnostics spec)  
+New test: `"throw on closed injection step with arity < 2"`
+
+Verify by running the new unit test — the class is `private[gatling]` and only accessible from within the same package scope (`diagnostics`).
+
+---
+
+### FR-006 — DefaultFormats dedup (compile verification)
+
+```bash
+sbt compile
+```
+
+`StorageBackend.scala` must compile with a single `formats` definition shared across all three backends. No behavioral test needed; failure mode is a compile error.
+
+---
+
+### FR-007 — Vault unit tests for merge/parse (no Docker)
+
+```bash
+sbt test
+```
+
+New tests in `VaultFeederSpec`:
+- `"mergeWithStrategy(FailOnDuplicate) throws on duplicate keys"`
+- `"mergeWithStrategy(LastWins) keeps last value and logs warning"`
+- `"mergeWithStrategy(FirstWins) keeps first value and logs warning"`
+- `"login throws RuntimeException on malformed JSON response"`
+- `"readSecret throws RuntimeException when JSON parse fails"`
+
+All run without containers and complete in under 5 seconds total.
+
+---
+
+## Integration Smoke Test (optional, requires Docker)
+
+```bash
+sbt "IntegrationTest / test"
+```
+
+Verifies `JdbcStorageIntegrationSpec` still passes against a real PostgreSQL container
+with the default `tableName = "gatling_session_storage"` (which satisfies the new validation).
+
+## Acceptance Criteria Summary
+
+| Fix | Validation method | Expected outcome |
+|-----|-------------------|-----------------|
+| SQLi tableName | `JdbcStorageBackendSpec` new negative test | `IllegalArgumentException` thrown |
+| Vault HTTPS | `VaultFeederSpec` new tests | `IllegalArgumentException` for http non-localhost |
+| Path traversal | `ProfileBuilderTest` new test | `ProfileBuilderException` thrown |
+| Malformed header | `ProfileBuilderTest` / `RequestSpec` new test | `ProfileBuilderException` thrown |
+| Arity guard | `InjectionProfileParserSpec` new test | `IllegalArgumentException` thrown |
+| DefaultFormats dedup | `sbt compile` | compiles without error |
+| Vault unit tests | `sbt test` (no Docker) | all new tests green |

--- a/specs/004-storage-vault-security/research.md
+++ b/specs/004-storage-vault-security/research.md
@@ -1,0 +1,100 @@
+# Research: Storage, JDBC & Vault Security Hardening
+
+No `NEEDS CLARIFICATION` markers from the spec. All decisions are straightforward given the fixed stack (Scala 2.13, existing code patterns).
+
+---
+
+## FR-001: SQL identifier validation for `tableName`
+
+**Decision**: `require(tableName.matches("[A-Za-z_][A-Za-z0-9_]*"), s"Invalid tableName: '$tableName'. Must match [A-Za-z_][A-Za-z0-9_]*")`  
+added in the `JdbcStorageBackend` constructor body (after field definitions).
+
+**Rationale**: SQL identifiers cannot be parameterized via `PreparedStatement` — only values can. The minimal correct fix is to validate at construction using the standard SQL-identifier character class. Quoting identifiers (e.g., `"tableName"`) is dialect-specific and more complex than a strict allowlist; strict ASCII identifiers work across PostgreSQL, H2, MySQL, and MariaDB (all tested dialects).
+
+**Alternatives considered**:
+- Quoting identifiers with `"` — rejected: dialect-dependent quoting rules; adds complexity without benefit since Picatinny users control the table name at simulation setup time.
+- Validating in each SQL method — rejected: validate-once-at-construction is safer and avoids repeated checks in hot paths.
+
+---
+
+## FR-002: Vault HTTP warning
+
+**Decision**: extract a private `warnIfNotHttps(vaultUrl: String): Unit` helper that parses the URL scheme and host via `java.net.URI` and calls `logger.warn(...)` if `scheme == "http"` and host is not `localhost`/`127.0.0.1`. Call it at the top of each public entry point (`apply`, `fromPaths`, `withToken`) before `THttpClient` is created.
+
+**Rationale**: Warning (not rejection) is the chosen severity — callers remain unblocked, which is important for environments where HTTP is intentional (internal networks, developer choice). The warning is emitted before any network call so the credential risk is surfaced even if the feeder subsequently fails. `java.net.URI` is stdlib, no new dep. Localhost/127.0.0.1 exemptions avoid noise in local dev.
+
+**Alternatives considered**:
+- Hard reject (`IllegalArgumentException`) — rejected by user preference: too strict for the intended use case.
+- Checking inside `login`/`readSecret` private methods — rejected: warning must fire before any network call, and doing it at the public entry point is the correct placement.
+
+---
+
+## FR-003: Profile path traversal prevention
+
+**Decision**: After `Paths.get(userDir, path)`, call `.normalize()` and assert that the result starts with `Paths.get(userDir).toAbsolutePath`. Throw `ProfileBuilderException` if the check fails.
+
+**Rationale**: `java.nio.file.Path.normalize()` resolves `../` sequences without filesystem I/O. The post-normalize prefix check is the standard path-traversal defense. Already using `Paths`/`Source` from stdlib — no new dep.
+
+**Applies to**: both `buildFromYaml` (functional chain) and `buildFromYamlJava` (imperative try/catch). Both paths must be hardened identically.
+
+**Alternatives considered**:
+- Blocking `../` via string replacement — rejected: fragile, URL-encoded bypasses exist.
+- Restricting to relative paths only (reject absolute) — rejected: over-constrains valid usages; normalization + prefix check is the correct pattern.
+
+---
+
+## FR-004: Exhaustive CSV header matching in `Request.toRequest`
+
+**Decision**: Replace the partial `case regexHeader(a, b)` with a `collect` that produces a typed `ProfileBuilderException` on any non-matching header, i.e. wrap the map in a try/catch or use `map` with an exhaustive match that throws a typed exception.
+
+Preferred: keep `map` but add fallback case:
+```
+requestHeaders.map {
+  case regexHeader(a, b) => (a, b)
+  case bad               => throw ProfileBuilderException(s"Malformed header: '$bad' ...")
+}
+```
+
+**Rationale**: `collect` would silently skip malformed headers, making the issue invisible. A typed exception with the offending value gives the user an actionable message. The exception type `ProfileBuilderException` is already defined in `ProfileBuilderNew` — reuse it for consistency.
+
+**Alternatives considered**:
+- `collect` (silent skip) — rejected: the spec requires a clear error.
+- New exception type — rejected: `ProfileBuilderException` already covers "invalid profile content" semantics.
+
+---
+
+## FR-005: `InjectionProfileParser` arity validation
+
+**Decision**: In the `other` fallback branch of `closedSegments`, add an arity guard before accessing `productElement`:
+```
+require(other.productArity >= 2, s"Unsupported closed injection step ...")
+```
+Similarly in `openSegments` `other` branch, guard `longField(other, 0)` with `require(other.productArity >= 1, ...)`.
+
+**Rationale**: The existing `doubleField`/`longField` helpers return `0.0`/`0L` for unknown types but do NOT guard against empty products. A `require` placed before access throws `IllegalArgumentException` with a clear message. `InjectionProfileParser` is `private[gatling]` — no public API impact.
+
+**Alternatives considered**:
+- Returning a default `WorkloadSegment` for unknown steps — rejected: silent wrong behavior is worse than a loud failure.
+- Pattern-matching exhaustively on all known step types — rejected: Gatling adds new step types over time; the `other` branch exists for forward compatibility; the correct fix is a guard, not exhaustive enumeration.
+
+---
+
+## FR-006: `DefaultFormats` deduplication
+
+**Decision**: Define `private[storage] implicit val formats: Formats = DefaultFormats` in a `private object StorageFormats` (same file), and import it in each backend class body.
+
+**Rationale**: All three backends (`JsonFileBackend`, `RedisBackend`, `JdbcStorageBackend`) are in the same file and package. A package-private object avoids repeating the definition without polluting the package namespace. No behavioral change.
+
+**Alternatives considered**:
+- `package object storage` — rejected: package objects are a Scala 2 legacy pattern; a named `private object` is cleaner.
+- Hoisting to the `StorageBackend` trait — rejected: traits with implicit vals can cause implicit ambiguity in subclasses.
+
+---
+
+## FR-007: Vault unit tests (without container)
+
+**Decision**: Add unit tests for `mergeWithStrategy` (all three strategy branches) and JSON parse error paths in `login`/`readSecret` to `VaultFeederSpec`. Both methods are `private[feeders]` — accessible from within the same package test scope.
+
+**Rationale**: `mergeWithStrategy` is a pure function — no mock needed. `login`/`readSecret` use `THttpClient` which is already the ScalaMock boundary for VaultFeeder (pattern established in prior unit tests); mock `THttpClient` to return crafted responses and assert the `RuntimeException` is thrown with the correct message.
+
+**New test file**: No new file needed; extend `VaultFeederSpec`.

--- a/specs/004-storage-vault-security/spec.md
+++ b/specs/004-storage-vault-security/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: Storage, JDBC & Vault Security Hardening
+
+**Feature Branch**: `004-storage-vault-security`
+
+**Created**: 2026-06-22
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-picatinny/milestone/4"
+
+**Milestone**: v1.19.0 — Storage, JDBC & Vault security (#204, #209, #94)
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  These stories are framed from the library consumer's perspective: teams writing
+  load-test simulations that depend on gatling-picatinny. "System" = the library.
+-->
+
+### User Story 1 - SQL Injection Protection for Storage Backend (Priority: P1)
+
+A load-test author configures `StorageBackend` with a `tableName` that comes from
+an environment variable or CI parameter. Today, a malformed or adversarial name
+(e.g. `"results; DROP TABLE results; --"`) is interpolated directly into DDL/DML,
+creating a SQL injection path inside the test infrastructure. The library must reject
+invalid names before any SQL is executed.
+
+**Why this priority**: SQL injection in test infrastructure can destroy shared databases
+used across teams. It is the only finding with direct data-destruction potential and affects
+the public `StorageBackend` constructor, a compatibility-sensitive surface.
+
+**Independent Test**: Can be fully tested by constructing a `StorageBackend` with an
+invalid `tableName` and asserting the constructor fails with a clear message, plus a
+separate test confirming that a valid name succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `StorageBackend` is constructed with `tableName = "results; DROP TABLE results; --"`, **When** construction is attempted, **Then** an `IllegalArgumentException` is thrown before any database connection is made.
+2. **Given** a `StorageBackend` is constructed with `tableName = "load_test_results"`, **When** construction is attempted, **Then** it succeeds without error.
+3. **Given** a `StorageBackend` is constructed with `tableName = "123bad"` (starts with digit), **When** construction is attempted, **Then** construction fails with a descriptive message naming the offending value.
+4. **Given** a valid `StorageBackend`, **When** any SQL operation (create/insert/select/delete) runs, **Then** only the pre-validated name appears in the query; `record_data` values remain parameterized.
+
+---
+
+### User Story 2 - Vault HTTPS Warning (Priority: P2)
+
+A load-test author configures `VaultFeeder` with `vaultUrl = "http://vault.internal"`.
+Today, the library silently sends token and AppRole `secret_id` credentials over plaintext
+HTTP with no indication of the risk. The library must emit a clearly visible warning before
+any network call when a non-HTTPS URL is used with a non-localhost host.
+
+**Why this priority**: Credential exposure over plaintext HTTP is a security defect affecting
+any team using Vault in a networked environment. Localhost (development) must remain allowed
+to avoid breaking local workflows.
+
+**Independent Test**: Can be fully tested by constructing a `VaultFeeder` with an HTTP URL
+pointing to a non-localhost host and verifying a warning is logged before any network call.
+
+**Acceptance Scenarios**:
+
+1. **Given** `vaultUrl = "http://vault.prod.internal"`, **When** the feeder is initialized, **Then** a warning is logged before any network call citing cleartext credential risk; initialization proceeds.
+2. **Given** `vaultUrl = "http://localhost:8200"`, **When** the feeder is initialized, **Then** no warning is logged (localhost exemption).
+3. **Given** `vaultUrl = "http://127.0.0.1:8200"`, **When** the feeder is initialized, **Then** no warning is logged (loopback exemption).
+4. **Given** `vaultUrl = "https://vault.prod.internal"`, **When** the feeder is initialized, **Then** initialization succeeds without warnings.
+
+---
+
+### User Story 3 - Profile Path Traversal Prevention (Priority: P3)
+
+A load-test author passes a profile file path (e.g. from a CLI argument or config file)
+to `ProfileBuilderNew`. Today, a path like `../../secrets/credentials.conf` is joined
+onto the working directory without containment checks, allowing traversal outside the
+project. The library must normalize and validate that the resolved path stays within
+the expected base directory.
+
+**Why this priority**: Path traversal can expose files outside the project on CI agents.
+Medium severity; affects only teams using `ProfileBuilderNew` with externally supplied paths.
+
+**Independent Test**: Can be fully tested by calling `ProfileBuilderNew` with a traversal
+path and asserting rejection, independently of any CSV parsing logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a profile path of `"../../etc/passwd"`, **When** `ProfileBuilderNew` resolves it, **Then** the call fails with a clear path-containment error before any file I/O.
+2. **Given** a profile path of `"profiles/my_profile.csv"` within the project, **When** `ProfileBuilderNew` resolves it, **Then** it resolves to the correct absolute path and proceeds normally.
+3. **Given** a path that after normalization lands exactly at the base directory, **When** resolved, **Then** it is accepted (boundary case).
+
+---
+
+### User Story 4 - Malformed CSV Header Handling (Priority: P4)
+
+A load-test author provides a profile CSV file with a header that doesn't match any
+known injection step format. Today, `ProfileBuilderNew` throws a `MatchError` at
+runtime (during simulation startup), giving no useful context. The library must produce
+a clear, actionable error message naming the offending header value.
+
+**Why this priority**: `MatchError` stack traces are opaque and slow diagnosis. A clear
+error message saves debugging time for every team with a malformed profile file.
+
+**Independent Test**: Can be fully tested by calling `ProfileBuilderNew` with a CSV
+containing an unrecognized header and asserting a typed, message-bearing exception is
+thrown — independently of Vault or JDBC.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CSV header of `"unknownStep,users/sec"`, **When** `ProfileBuilderNew` parses it, **Then** a typed exception is thrown with a message that includes the unrecognized header token.
+2. **Given** an empty CSV header row, **When** `ProfileBuilderNew` parses it, **Then** a typed exception is thrown (not `MatchError`).
+3. **Given** a valid header like `"rampUsersPerSec,from,to,during"`, **When** parsed, **Then** parsing succeeds.
+
+---
+
+### User Story 5 - InjectionProfileParser Arity Validation (Priority: P5)
+
+A load-test author writes a custom injection step class with a non-standard field
+count. Today, `InjectionProfileParser` accesses `productElement(arity - 2)` without
+checking arity, silently reading the wrong field and producing an incorrect ramp shape.
+The library must validate arity (and field types) before extraction and fail loudly on
+unsupported step shapes.
+
+**Why this priority**: Silent mis-parsing produces wrong load shapes that invalidate
+entire performance test results. A loud failure is far preferable to a silent wrong result.
+
+**Independent Test**: Can be fully tested by constructing a minimal injection profile
+object with unexpected arity and asserting the parser throws an explicit exception
+before producing any output.
+
+**Acceptance Scenarios**:
+
+1. **Given** an injection profile step with `productArity < 2`, **When** `InjectionProfileParser` processes it, **Then** an exception is thrown with a message naming the arity and the step type.
+2. **Given** a step with correct arity but a field of unexpected type at position `arity - 2`, **When** processed, **Then** an exception is thrown naming the unexpected type.
+3. **Given** a well-formed standard injection step, **When** processed, **Then** parsing succeeds and produces the correct ramp shape values.
+
+---
+
+### Edge Cases
+
+- What happens when `tableName` is an empty string? → Must be rejected (fails the identifier regex).
+- What happens when `tableName` contains Unicode or emoji? → Rejected (ASCII identifier pattern only).
+- What happens when `vaultUrl` scheme is `HTTP` (uppercase)? → Must be normalized and rejected for non-localhost.
+- What happens when the profile CSV has a header but zero data rows? → Should produce an empty profile, not crash.
+- What happens when `InjectionProfileParser` receives a `null` step? → Must fail explicitly, not NPE silently.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `StorageBackend` MUST validate `tableName` at construction time; valid names consist solely of letters, digits, and underscores and must start with a letter or underscore (i.e., a safe SQL identifier); invalid names MUST cause construction to fail before any database connection is attempted.
+- **FR-002**: `VaultFeeder` MUST log a WARNING when `vaultUrl` uses a non-HTTPS scheme and the host is not `localhost` or a loopback address; the warning MUST be emitted before any network call and MUST name the URL.
+- **FR-003**: `ProfileBuilderNew` MUST normalize caller-supplied file paths and verify they remain within the declared base directory; traversal attempts MUST produce a containment error naming the offending path.
+- **FR-004**: `ProfileBuilderNew` MUST replace the non-exhaustive partial function over CSV headers with exhaustive matching that emits a typed, message-bearing exception on unrecognized headers.
+- **FR-005**: `InjectionProfileParser` MUST validate `productArity` and field types before accessing `productElement`; unsupported step shapes MUST cause a typed exception with the arity and step type in the message.
+- **FR-006**: `StorageBackend` shared `DefaultFormats` instance MUST be defined once and reused across all three backend implementations (no duplicate `private implicit val formats`).
+- **FR-007**: `VaultFeeder` unit tests MUST cover `mergeWithStrategy` branches and login/readSecret JSON-parse error paths without requiring a running Vault container.
+- **FR-008**: All rejection paths defined in FR-001–FR-005 MUST include at least one negative-case unit test verifying the rejection triggers correctly.
+
+### Key Entities
+
+- **StorageBackend**: Wrapper around a JDBC connection + table name; responsible for persisting and retrieving Gatling session records.
+- **VaultFeeder**: Feeder that authenticates to HashiCorp Vault and reads secrets; holds `vaultUrl` + credentials.
+- **ProfileBuilderNew**: Reads a CSV-format injection profile from disk and returns a Gatling `InjectionProfile`; responsible for path resolution and header parsing.
+- **InjectionProfileParser**: Extracts numeric field values from Scala `Product` case-class instances representing injection steps.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All four rejection paths (FR-001, FR-003–FR-005) trigger on their respective invalid inputs in under 10 ms, with no database or network call made; FR-002 warning is emitted before any network call.
+- **SC-002**: All existing `StorageBackend`, `VaultFeeder`, `ProfileBuilderNew`, and `InjectionProfileParser` unit and integration tests continue to pass without modification after the changes.
+- **SC-003**: New unit tests for Vault merge/parse paths run without any container or network dependency, completing in under 5 seconds.
+- **SC-004**: Zero `MatchError` or `ArrayIndexOutOfBoundsException` exceptions are thrown by the patched code paths under any valid or invalid input combination exercised in the test suite.
+- **SC-005**: Security audit of the four changed files finds no new injection, traversal, or credential-exposure vectors introduced by the changes.
+
+## Assumptions
+
+- `tableName` is a developer-controlled value set at simulation author time, not a per-request runtime value; strict ASCII identifier validation is an acceptable constraint for this surface.
+- Localhost exemption for Vault HTTP covers `localhost`, `127.0.0.1`, and IPv6 loopback (`[::1]`, `[0:0:0:0:0:0:0:1]`).
+- `ProfileBuilderNew` base directory is `System.getProperty("user.dir")`; no new configuration knob is introduced to override it.
+- `StorageBackend` constructor is called at simulation setup time, not in the hot path; a `require` check has negligible performance impact.
+- The `DefaultFormats` deduplication (FR-006) is a non-breaking internal refactor with no public API surface change.
+- Vault unit tests (FR-007) will mock the HTTP client, consistent with the existing unit test model for `HttpJsonFeeder`.

--- a/specs/004-storage-vault-security/tasks.md
+++ b/specs/004-storage-vault-security/tasks.md
@@ -1,0 +1,237 @@
+---
+description: "Task list for Storage, JDBC & Vault Security Hardening"
+---
+
+# Tasks: Storage, JDBC & Vault Security Hardening
+
+**Input**: Design documents from `specs/004-storage-vault-security/`
+
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓
+
+**TDD**: Tests written first (red → green) per Constitution §III. Test tasks precede impl tasks within each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no cross-dependency)
+- **[Story]**: Maps to user story from spec.md (US1–US5)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish clean baseline before any changes.
+
+- [X] T001 Run `sbt compile` on `main` branch; confirm zero errors in `StorageBackend.scala`, `VaultFeeder.scala`, `ProfileBuilderNew.scala`, `InjectionProfileParser.scala`
+
+**Checkpoint**: Clean compile baseline confirmed — no build.sbt changes required.
+
+---
+
+## Phase 2: Foundational — DefaultFormats Deduplication (FR-006)
+
+**Purpose**: Internal refactor touching `StorageBackend.scala` — must complete before US1 to avoid merge conflict in the same file.
+
+- [X] T002 In `src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala`: add `private object StorageFormats { implicit val formats: Formats = DefaultFormats }` before the backend class definitions; remove the three `private implicit val formats: Formats = DefaultFormats` lines from `JsonFileBackend` (line ~38), `RedisBackend` (line ~60), and `JdbcStorageBackend` (line ~116) class bodies; add `import StorageFormats.formats` at the top of each class body; run `sbt compile` to confirm zero errors
+
+**Checkpoint**: Single `DefaultFormats` definition — `sbt compile` green.
+
+---
+
+## Phase 3: User Story 1 — SQL Injection Protection (Priority: P1) 🎯 MVP
+
+**Goal**: `JdbcStorageBackend` rejects invalid `tableName` at construction before any DB connection.
+
+**Independent Test**: `sbt testOnly *JdbcStorageBackendSpec` — all tests pass including 4 new ones.
+
+### Tests for User Story 1
+
+> **Write these FIRST. Run `sbt testOnly *JdbcStorageBackendSpec` and confirm 3 new tests FAIL.**
+
+- [X] T003 [US1] In `src/test/scala/org/galaxio/gatling/storage/JdbcStorageBackendSpec.scala`: add 4 new test cases inside the existing `"JdbcStorageBackend" should` block — (a) `"reject tableName with SQL injection payload"` → `intercept[IllegalArgumentException] { JdbcStorageBackend("jdbc:recording:", tableName = "bad; DROP TABLE x; --") }` and assert message contains `"Invalid tableName"`; (b) `"reject empty tableName"` → same intercept for `tableName = ""`; (c) `"reject tableName starting with a digit"` → same for `tableName = "123bad"`; (d) `"accept a valid tableName"` → `noException should be thrownBy JdbcStorageBackend("jdbc:recording:", tableName = "my_results_2024")` using the `RecordingJdbcDriver` pattern already in the file; run `sbt testOnly *JdbcStorageBackendSpec` and confirm (a)(b)(c) fail, (d) passes
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] In `src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala`, `JdbcStorageBackend` class body (after the field declarations): add `require(tableName.matches("[A-Za-z_][A-Za-z0-9_]*"), s"Invalid tableName: '$tableName'. Must be a valid SQL identifier (letters, digits, underscores, starting with a letter or underscore)")` as the first statement; run `sbt testOnly *JdbcStorageBackendSpec` and confirm all 4 new tests plus all existing tests pass
+
+**Checkpoint**: `JdbcStorageBackendSpec` fully green — US1 independently testable.
+
+---
+
+## Phase 4: User Story 2 — Vault HTTP Warning + Unit Tests (Priority: P2)
+
+**Goal**: `VaultFeeder` logs WARN before any network call when URL is non-HTTPS non-localhost; `mergeWithStrategy` and JSON-parse error paths covered by fast unit tests.
+
+**Independent Test**: `sbt testOnly *VaultFeederSpec` — all tests pass including 8 new ones.
+
+> US2 touches different files than US1. Implementation of T005–T007 can overlap with US1 once T002 is done.
+
+### Refactor for Testability (prerequisite within US2)
+
+- [X] T005 [P] [US2] In `src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala`: (a) change `mergeWithStrategy` from `private` to `private[feeders]`; (b) extract the `Try(parse(...)).fold(...)` expression from `login` into a new `private[feeders] def parseLoginResponse(body: String, loginUrl: String): String` method — same logic, just a separate method; (c) extract the `Try(parse(...)).fold(...)` expression from `readSecret` into a new `private[feeders] def parseSecretResponse(body: String, secretPath: String): Record[String]` method; (d) add `private[feeders] def isUnsafeVaultUrl(vaultUrl: String): Boolean` that parses the URL with `java.net.URI`, returns `true` if scheme is `"http"` (case-insensitive) AND host is neither `"localhost"` nor `"127.0.0.1"`, returns `false` otherwise; update `login` and `readSecret` to delegate to the new extracted methods; run `sbt compile` to confirm
+
+### Tests for User Story 2
+
+> **Write these AFTER T005 but BEFORE T007. Run `sbt testOnly *VaultFeederSpec` and confirm new tests FAIL.**
+
+- [X] T006 [US2] In `src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala`: add 8 test cases — `"VaultFeeder.mergeWithStrategy"` block: (a) `"FailOnDuplicate throws IllegalArgumentException naming the duplicate key"` — call `VaultFeeder.mergeWithStrategy(List(("k","v1"),("k","v2")), DuplicateKeyStrategy.FailOnDuplicate)` and assert `IllegalArgumentException` with `"k"` in message; (b) `"LastWins returns map with last value"` — call with same pairs, `LastWins`, assert result `== Map("k" -> "v2")`; (c) `"FirstWins returns map with first value"` — call same, `FirstWins`, assert `Map("k" -> "v1")`; `"VaultFeeder.parseLoginResponse"` block: (d) `"throws RuntimeException on malformed JSON"` — call `VaultFeeder.parseLoginResponse("not-json", "http://vault/v1/auth/approle/login")` and assert `RuntimeException` with `"Failed to parse Vault login response"` in message; `"VaultFeeder.parseSecretResponse"` block: (e) `"throws RuntimeException when data field is absent"` — call `VaultFeeder.parseSecretResponse("{}", "secret/mypath")` and assert `RuntimeException` with `"Failed to extract secret data"` and `"mypath"` in message; `"VaultFeeder.isUnsafeVaultUrl"` block: (f) `"returns true for http non-localhost"` — assert `VaultFeeder.isUnsafeVaultUrl("http://vault.prod.internal") == true`; (g) `"returns false for http localhost"` — `VaultFeeder.isUnsafeVaultUrl("http://localhost:8200") == false`; (h) `"returns false for https"` — `VaultFeeder.isUnsafeVaultUrl("https://vault.prod.internal") == false`; run `sbt testOnly *VaultFeederSpec` and confirm (a)(d)(e)(f) fail
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] In `src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala`: add `private def warnIfNotHttps(vaultUrl: String): Unit = if (isUnsafeVaultUrl(vaultUrl)) logger.warn(s"VaultFeeder: vaultUrl '$vaultUrl' uses plaintext HTTP — credentials will be sent unencrypted. Use HTTPS for non-local hosts.")` ; insert `warnIfNotHttps(vaultUrl)` as the first statement (before `Using.resource(THttpClient(...))`) in `apply`, in all three `fromPaths` overloads (only the one that creates THttpClient — the other two delegate to it), and in `withToken`; run `sbt testOnly *VaultFeederSpec` — all 8 new tests plus all existing tests pass
+
+**Checkpoint**: `VaultFeederSpec` fully green — US2 independently testable.
+
+---
+
+## Phase 5: User Story 3 — Profile Path Traversal Prevention (Priority: P3)
+
+**Goal**: `ProfileBuilderNew.buildFromYaml` and `buildFromYamlJava` reject traversal paths before any file I/O.
+
+**Independent Test**: `sbt testOnly *ProfileBuilderTest` — all tests pass including new traversal tests.
+
+> US3 and US5 touch different files — can be worked in parallel. US3 and US4 touch the same file — must be sequential.
+
+### Tests for User Story 3
+
+> **Write FIRST. Run `sbt testOnly *ProfileBuilderTest` and confirm new tests FAIL.**
+
+- [X] T008 [US3] In `src/test/scala/org/galaxio/gatling/profile/ProfileBuilderTest.scala`: add 3 test cases inside the `"ProfileBuilderNew.buildFromYaml"` block — (a) `"reject path that escapes the working directory via traversal"` → assert the `ProfileBuilderException` is thrown for path `"../../etc/passwd"` and message contains `"traversal"` or `"containment"`; (b) `"reject absolute path outside working directory"` → assert `ProfileBuilderException` for `"/etc/passwd"`; (c) `"accept a path that normalizes within the project"` → assert `ProfileBuilderException` is NOT thrown for path `"src/test/resources/profileTemplates/../profileTemplates/profile1.yml"` (normalizes to a valid path inside project); add same 3 cases for `buildFromYamlJava` block; run `sbt testOnly *ProfileBuilderTest` — new tests fail
+
+### Implementation for User Story 3
+
+- [X] T009 [US3] In `src/main/scala/org/galaxio/gatling/profile/ProfileBuilderNew.scala`: in `buildFromYaml`, after the `fullPath <- ...map(Paths.get(_, path))` step in the for-comprehension, add a validation step `_ <- { val base = Paths.get(sys.props.getOrElse("user.dir","")).toAbsolutePath.normalize(); val resolved = fullPath.toAbsolutePath.normalize(); Either.cond(resolved.startsWith(base), (), new SecurityException(s"Path traversal detected: resolved path '$resolved' escapes project base '$base'")) }` and update `toProfileBuilderException` to handle `SecurityException`; apply the same guard in `buildFromYamlJava` inside the try block using `Paths.get(...).toAbsolutePath.normalize()` + `startsWith` check before `Source.fromFile`; run `sbt testOnly *ProfileBuilderTest` — all tests including new ones pass
+
+**Checkpoint**: `ProfileBuilderTest` fully green for traversal cases — US3 independently testable.
+
+---
+
+## Phase 6: User Story 4 — Malformed CSV Header Handling (Priority: P4)
+
+**Goal**: `Request.toRequest` throws `ProfileBuilderException` (not `MatchError`) on unrecognized header strings.
+
+**Independent Test**: New tests in `ProfileBuilderTest` covering the malformed-header path.
+
+> Must follow US3 (same source file `ProfileBuilderNew.scala`).
+
+### Tests for User Story 4
+
+> **Write FIRST. Run `sbt testOnly *ProfileBuilderTest` and confirm new tests FAIL.**
+
+- [X] T010 [US4] In `src/test/scala/org/galaxio/gatling/profile/ProfileBuilderTest.scala`: add a new `"Request.toRequest"` block — (a) `"throw ProfileBuilderException on malformed header with no colon"` → construct `Request("r", "100 rph", None, Params("GET", "/", Some(List("bad-header-no-colon")), None))` and assert `intercept[ProfileBuilderException] { r.toRequest }` with message containing `"bad-header-no-colon"`; (b) `"throw ProfileBuilderException on empty header string"` → same for `Some(List(""))`; (c) `"correctly parse valid header Content-Type: application/json"` → `r.toRequest` does not throw and the resulting `HttpRequestBuilder` contains the header (assert via inspecting the builder or just assert no exception); run `sbt testOnly *ProfileBuilderTest` — (a)(b) fail with `MatchError`, (c) passes
+
+### Implementation for User Story 4
+
+- [X] T011 [US4] In `src/main/scala/org/galaxio/gatling/profile/ProfileBuilderNew.scala`, `Request.toRequest` method: replace `.headers(requestHeaders.map { case regexHeader(a, b) => (a, b) }.toMap)` with `.headers(requestHeaders.map { case regexHeader(a, b) => (a, b); case bad => throw ProfileBuilderException(s"Malformed header: '$bad'. Expected format is 'Name: Value'", new IllegalArgumentException(bad)) }.toMap)`; run `sbt testOnly *ProfileBuilderTest` — all tests including new ones pass
+
+**Checkpoint**: `ProfileBuilderTest` fully green — US4 independently testable.
+
+---
+
+## Phase 7: User Story 5 — InjectionProfileParser Arity Validation (Priority: P5)
+
+**Goal**: `InjectionProfileParser` throws an explicit `IllegalArgumentException` (not `IndexOutOfBoundsException`) on steps with insufficient arity.
+
+**Independent Test**: New `InjectionProfileParserSpec` — all tests pass.
+
+> US5 touches different files than US3/US4 — can be worked in parallel with Phase 5.
+
+### Tests for User Story 5
+
+> **Write FIRST. Run `sbt testOnly *InjectionProfileParserSpec` and confirm new tests FAIL.**
+
+- [X] T012 [P] [US5] Create new file `src/test/scala/org/galaxio/gatling/diagnostics/InjectionProfileParserSpec.scala` in `package org.galaxio.gatling.diagnostics`; extend `AnyWordSpec with Matchers with OptionValues`; import `io.gatling.core.controller.inject.closed._`, `io.gatling.core.controller.inject.open._`, `scala.concurrent.duration._`; add 5 test cases — (a) `"fromClosed with a standard RampConcurrentUsersInjection produces correct WorkloadSettings"` → `InjectionProfileParser.fromClosed(List(RampConcurrentUsersInjection(10, 50, 60.seconds)))` asserts `isDefined`, `intensityRps > 0`, `unit == "users"`; (b) `"fromOpen with a standard RampRateOpenInjection produces correct WorkloadSettings"` → `InjectionProfileParser.fromOpen(List(RampRateOpenInjection(1.0, 10.0, 60.seconds)))` asserts `isDefined`; (c) `"fromClosed with empty step list returns None"` → `InjectionProfileParser.fromClosed(Nil) shouldBe None`; (d) `"fromClosed with a zero-arity Product other step throws IllegalArgumentException"` → create a minimal `case object ZeroArityStep extends ClosedInjectionStep` inside the test class (note: if `ClosedInjectionStep` is sealed and cannot be extended, use a reflective proxy or test `doubleField`/`longField` directly via `private[gatling]` access); (e) at minimum assert that calling `fromClosed` with a known-bad step shape results in either `IllegalArgumentException` or correct safe fallback per the implemented guard; run `sbt testOnly *InjectionProfileParserSpec` — standard injection tests pass, arity guard tests fail if guard not yet implemented
+
+### Implementation for User Story 5
+
+- [X] T013 [P] [US5] In `src/main/scala/org/galaxio/gatling/diagnostics/InjectionProfileParser.scala`: in `closedSegments`, inside the `case other =>` branch, add `require(other.productArity >= 2, s"Unsupported closed injection step '${other.productPrefix}' with productArity=${other.productArity}; expected ≥2 fields (start, end, [duration...])")` before `val start = doubleField(other, 0)` and before `val end = doubleField(other, math.max(0, other.productArity - 2))`; in `openSegments`, inside the `case other =>` branch, add `require(other.productArity >= 1, s"Unsupported open injection step '${other.productPrefix}' with productArity=${other.productArity}; expected ≥1 field")` before `val rate = rateFromUsers(longField(other, 0), duration)`; run `sbt testOnly *InjectionProfileParserSpec` — all tests pass
+
+**Checkpoint**: `InjectionProfileParserSpec` fully green — US5 independently testable.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Format, full test run, integration smoke test.
+
+- [X] T014 [P] Run `sbt scalafmtAll scalafmtSbt` to format all changed files; commit format-only change if any diffs produced
+- [X] T015 Run `sbt scalafmtCheckAll scalafmtSbtCheck compile test` — full CI gate must pass with zero failures
+- [X] T016 Run `sbt "IntegrationTest / test"` — `JdbcStorageIntegrationSpec` and `VaultIntegrationSpec` pass with default `tableName = "gatling_session_storage"` (satisfies the new validation rule)
+
+**Checkpoint**: All gates green — feature ready for PR.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (T001)**: No dependencies — start immediately
+- **Foundational (T002)**: Depends on T001; BLOCKS US1 (same file)
+- **US1 (T003–T004)**: Depends on T002
+- **US2 (T005–T007)**: Depends on T001 only; can start in parallel with US1 after T001
+- **US3 (T008–T009)**: Depends on T001 only; can start in parallel with US1/US2
+- **US4 (T010–T011)**: Depends on T009 (same file as US3 — must follow)
+- **US5 (T012–T013)**: Depends on T001 only; can run in parallel with US1/US2/US3
+- **Polish (T014–T016)**: Depends on all story phases complete
+
+### Within Each Story
+
+```
+Tests (red) → Implementation (green) → Story checkpoint
+```
+
+### Parallel Opportunities
+
+- **T005 ∥ T008 ∥ T012**: US2 refactor / US3 tests / US5 tests can all start simultaneously after T001
+- **T003 ∥ T005**: US1 tests and US2 refactor are independent files
+- **T013 ∥ T009**: US5 impl and US3 impl touch different files — can overlap
+
+---
+
+## Parallel Example: After Foundational Phase
+
+```
+T003 (US1 tests, JdbcStorageBackendSpec)
+  → T004 (US1 impl, StorageBackend.scala)
+
+T005 (US2 refactor, VaultFeeder.scala)         ← in parallel with T003
+  → T006 (US2 tests, VaultFeederSpec)
+    → T007 (US2 impl, VaultFeeder.scala)
+
+T008 (US3 tests, ProfileBuilderTest)            ← in parallel with T003/T005
+  → T009 (US3 impl, ProfileBuilderNew.scala)
+    → T010 (US4 tests, ProfileBuilderTest)
+      → T011 (US4 impl, ProfileBuilderNew.scala)
+
+T012 (US5 tests+file, InjectionProfileParserSpec)  ← in parallel with all above
+  → T013 (US5 impl, InjectionProfileParser.scala)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. T001 → T002 → T003 → T004
+2. **STOP & VALIDATE**: `sbt testOnly *JdbcStorageBackendSpec` green
+3. Ship US1 as a standalone security patch if needed
+
+### Incremental Delivery
+
+1. T001 → T002 (foundation)
+2. T003–T004 (US1) + T005–T007 (US2) in parallel → both green
+3. T008–T009 (US3) → T010–T011 (US4), in parallel with T012–T013 (US5)
+4. T014–T016 (polish)
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete-task dependency — safe to run concurrently
+- `[Story]` traces each task to its user story for traceability
+- TDD: every story's tests run first (confirmed failing), then implementation makes them green
+- `JdbcTestSupport.RecordingJdbcDriver` already available in `JdbcStorageBackendSpec` scope — reuse for T003
+- `mergeWithStrategy`, `parseLoginResponse`, `parseSecretResponse`, `isUnsafeVaultUrl` all become `private[feeders]` in T005 — accessible from `VaultFeederSpec` in the same package
+- `InjectionProfileParser` is `private[gatling]` — accessible from `package org.galaxio.gatling.diagnostics` (within the `gatling` scope)
+- Commit after each checkpoint; keep build green at every commit

--- a/src/main/java/org/galaxio/gatling/javaapi/internal/ProfileBuilderNew.scala
+++ b/src/main/java/org/galaxio/gatling/javaapi/internal/ProfileBuilderNew.scala
@@ -13,7 +13,7 @@ object ProfileBuilderNew {
     http(r.request)
       .httpRequest(r.params.method, r.params.path)
       .body(StringBody(r.requestBody))
-      .headers(CollectionConverters.asJava(r.requestHeaders.map { case r.regexHeader(a, b) => (a, b) }.toMap))
+      .headers(CollectionConverters.asJava(r.parsedHeaders))
   }
 
   def toExec(r: Request): ChainBuilder = io.gatling.javaapi.core.CoreDsl.exec(toRequest(r))

--- a/src/main/scala/org/galaxio/gatling/diagnostics/InjectionProfileParser.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/InjectionProfileParser.scala
@@ -60,6 +60,7 @@ private[gatling] object InjectionProfileParser {
           case s: HeavisideOpenInjection    =>
             stressPeak(cursor, longField(s, 0), s.duration) -> currentRate
           case other                        =>
+            requireArity(other, 1)
             val duration = durationField(other)
             val rate     = rateFromUsers(longField(other, 0), duration)
             List(WorkloadSegment(cursor, cursor + duration, other.productPrefix, rate, rate)) -> rate
@@ -79,9 +80,14 @@ private[gatling] object InjectionProfileParser {
             val duration = durationField(s)
             List(WorkloadSegment(cursor, cursor + duration, "ramp", s.from.toDouble, s.to.toDouble))
           case other                               =>
-            val duration = durationField(other)
-            val start    = doubleField(other, 0)
-            val end      = doubleField(other, math.max(0, other.productArity - 2))
+            requireArity(other, 2)
+            val duration   = durationField(other)
+            // Field layout assumed: (start, [..], end, duration). end is second-to-last (-2 skips the trailing duration);
+            // when there is no distinct end field the segment is flat (start == end) by design.
+            val startIndex = 0
+            val endIndex   = math.max(startIndex, other.productArity - 2)
+            val start      = doubleField(other, startIndex)
+            val end        = doubleField(other, endIndex)
             List(WorkloadSegment(cursor, cursor + duration, other.productPrefix, start, end))
         }
         (segments ++ next, cursor + durationField(step))
@@ -131,6 +137,16 @@ private[gatling] object InjectionProfileParser {
 
   private def rateFromUsers(users: Long, duration: FiniteDuration): Double =
     users.toDouble / math.max(1.0, duration.toSeconds.toDouble)
+
+  /** Fails loudly when an injection step exposes fewer Product fields than the parser needs, instead of silently reading the
+    * wrong field (or throwing an opaque index error) and producing a wrong ramp shape.
+    */
+  private[diagnostics] def requireArity(product: Product, min: Int): Unit =
+    require(
+      product.productArity >= min,
+      s"Unsupported injection step '${product.productPrefix}' with productArity=${product.productArity}; " +
+        s"expected at least $min field(s) to derive its ramp shape.",
+    )
 
   private def durationField(product: Product): FiniteDuration =
     product.productIterator.collectFirst { case duration: FiniteDuration => duration }.getOrElse(0.seconds)

--- a/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/VaultFeeder.scala
@@ -37,6 +37,7 @@ object VaultFeeder extends LazyLogging {
       timeoutInSeconds: Long = 5,
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
+    warnIfNotHttps(vaultUrl)
 
     Using.resource(THttpClient(timeoutInSeconds = timeoutInSeconds)) { client =>
       val vaultToken = login(client, vaultUrl, roleId, secretId)
@@ -93,6 +94,7 @@ object VaultFeeder extends LazyLogging {
       timeoutInSeconds: Long,
   ): IndexedSeq[Record[String]] = {
     require(paths != null, "Paths list must not be null")
+    warnIfNotHttps(vaultUrl)
 
     Using.resource(THttpClient(timeoutInSeconds = timeoutInSeconds)) { client =>
       val vaultToken = login(client, vaultUrl, roleId, secretId)
@@ -104,7 +106,7 @@ object VaultFeeder extends LazyLogging {
     }
   }
 
-  private def mergeWithStrategy(
+  private[feeders] def mergeWithStrategy(
       pairs: List[(String, String)],
       strategy: DuplicateKeyStrategy,
   ): Record[String] = {
@@ -140,6 +142,7 @@ object VaultFeeder extends LazyLogging {
       timeoutInSeconds: Long = 5,
   ): IndexedSeq[Record[String]] = {
     require(keys != null, "Keys list must not be null")
+    warnIfNotHttps(vaultUrl)
 
     Using.resource(THttpClient(timeoutInSeconds = timeoutInSeconds)) { client =>
       val data = readSecret(client, vaultUrl, secretPath, vaultToken)
@@ -148,10 +151,14 @@ object VaultFeeder extends LazyLogging {
   }
 
   private def login(client: THttpClient, vaultUrl: String, roleId: String, secretId: String): String = {
-    val body      = approleLoginBody(roleId, secretId)
-    val loginUrl  = s"$vaultUrl/v1/auth/approle/login"
-    val response  = client.postOrThrow(loginUrl, body)
-    val loginJson = Try(parse(response.body)).fold(
+    val body     = approleLoginBody(roleId, secretId)
+    val loginUrl = s"$vaultUrl/v1/auth/approle/login"
+    val response = client.postOrThrow(loginUrl, body)
+    parseLoginResponse(response.body, loginUrl)
+  }
+
+  private[feeders] def parseLoginResponse(body: String, loginUrl: String): String = {
+    val loginJson = Try(parse(body)).fold(
       e => throw new RuntimeException(s"Failed to parse Vault login response as JSON from $loginUrl", e),
       identity,
     )
@@ -164,7 +171,11 @@ object VaultFeeder extends LazyLogging {
   private def readSecret(client: THttpClient, vaultUrl: String, secretPath: String, vaultToken: String): Record[String] = {
     val secretUrl = s"$vaultUrl/v1/$secretPath"
     val response  = client.getOrThrow(secretUrl, Seq("X-Vault-Token", vaultToken))
-    val json      = Try(parse(response.body)).fold(
+    parseSecretResponse(response.body, secretPath)
+  }
+
+  private[feeders] def parseSecretResponse(body: String, secretPath: String): Record[String] = {
+    val json = Try(parse(body)).fold(
       e => throw new RuntimeException(s"Failed to parse Vault secret response as JSON from '$secretPath'", e),
       identity,
     )
@@ -173,6 +184,32 @@ object VaultFeeder extends LazyLogging {
       identity,
     )
   }
+
+  private val loopbackHosts =
+    Set("localhost", "127.0.0.1", "[::1]", "[0:0:0:0:0:0:0:1]", "::1", "0:0:0:0:0:0:0:1")
+
+  /** True when the URL would send credentials in cleartext: scheme is http and the host is not loopback.
+    *
+    * For unbracketed IPv6 authorities (e.g. `http://0:0:0:0:0:0:0:1`) `URI.getHost` returns null, so we fall back to the
+    * authority with any `userinfo@` prefix stripped — that keeps loopback longhand from triggering a spurious warning.
+    */
+  private[feeders] def isUnsafeVaultUrl(vaultUrl: String): Boolean =
+    Try {
+      val uri    = new java.net.URI(vaultUrl)
+      val scheme = Option(uri.getScheme).map(_.toLowerCase).getOrElse("")
+      val host   = Option(uri.getHost)
+        .orElse(Option(uri.getAuthority).map(_.split("@").last))
+        .map(_.toLowerCase)
+        .getOrElse("")
+      scheme == "http" && !loopbackHosts.contains(host)
+    }.getOrElse(false)
+
+  private def warnIfNotHttps(vaultUrl: String): Unit =
+    if (isUnsafeVaultUrl(vaultUrl))
+      logger.warn(
+        s"VaultFeeder: vaultUrl '$vaultUrl' uses plaintext HTTP — credentials will be sent unencrypted. " +
+          "Use HTTPS for non-local hosts.",
+      )
 
   private def filterRecord(data: Record[String], keys: List[String]): Record[String] = {
     val selectedKeys = keys.toSet

--- a/src/main/scala/org/galaxio/gatling/profile/ProfileBuilderNew.scala
+++ b/src/main/scala/org/galaxio/gatling/profile/ProfileBuilderNew.scala
@@ -11,7 +11,7 @@ import org.galaxio.gatling.utils.IntensityConverter.getIntensityFromString
 import cats.syntax.either._
 
 import java.io.FileNotFoundException
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.io.Source
 import scala.util.Using
 import scala.util.matching.Regex
@@ -25,11 +25,26 @@ case class Request(request: String, intensity: String, groups: Option[List[Strin
   val requestBody: String          = params.body.getOrElse("")
   val requestHeaders: List[String] = params.headers.getOrElse(List.empty[String])
 
+  /** Parses raw header lines into a name→value map, failing loudly on any line that is not `Name: Value`.
+    *
+    * `private[gatling]` (not `private[profile]`) so the Java/Kotlin facade in `javaapi.internal` delegates here instead of
+    * duplicating the parsing logic.
+    */
+  private[gatling] lazy val parsedHeaders: Map[String, String] =
+    requestHeaders.map {
+      case regexHeader(a, b) => (a, b)
+      case bad               =>
+        throw ProfileBuilderNew.ProfileBuilderException(
+          s"Malformed header: '$bad'. Expected format is 'Name: Value'",
+          new IllegalArgumentException(bad),
+        )
+    }.toMap
+
   def toRequest: HttpRequestBuilder = {
     http(request)
       .httpRequest(params.method, params.path)
       .body(StringBody(requestBody))
-      .headers(requestHeaders.map { case regexHeader(a, b) => (a, b) }.toMap)
+      .headers(parsedHeaders)
   }
 
   def toExec: ChainBuilder            = exec(toRequest)
@@ -67,9 +82,30 @@ object ProfileBuilderNew {
   final case class ProfileBuilderException(msg: String, cause: Throwable) extends Throwable(msg, cause, false, false)
 
   private def toProfileBuilderException(path: String): PartialFunction[Throwable, ProfileBuilderException] = {
+    case e: SecurityException     => ProfileBuilderException(e.getMessage, e)
     case e: FileNotFoundException => ProfileBuilderException(s"File not found $path", e)
     case e: io.circe.Error        => ProfileBuilderException(s"Incorrect file content in $path", e)
     case e: Throwable             => ProfileBuilderException(s"Unknown error", e)
+  }
+
+  /** Verifies the caller path stays inside the working directory; guards against `../` traversal and absolute paths.
+    *
+    * An absolute caller path is rejected outright: `Paths.get(base, "/abs")` re-roots under `base` (the leading slash is
+    * treated as a separator, not an absolute root), which would silently mask the caller's intent — so we reject it rather than
+    * resolve it.
+    */
+  private def validateContainment(rawPath: String, fullPath: Path): Either[Throwable, Path] = {
+    if (Paths.get(rawPath).isAbsolute)
+      Left(new SecurityException(s"Path traversal detected: absolute path '$rawPath' is not allowed"))
+    else {
+      val base     = Paths.get(sys.props.getOrElse("user.dir", "")).toAbsolutePath.normalize()
+      val resolved = fullPath.toAbsolutePath.normalize()
+      Either.cond(
+        resolved.startsWith(base),
+        resolved,
+        new SecurityException(s"Path traversal detected: resolved path '$resolved' escapes project base '$base'"),
+      )
+    }
   }
 
   def buildFromYaml(path: String): Yaml = {
@@ -78,7 +114,8 @@ object ProfileBuilderNew {
                        .get("user.dir")
                        .toRight(new NoSuchElementException("'user.dir' property not defined"))
                        .map(Paths.get(_, path))
-      yamlContent <- Using(Source.fromFile(fullPath.toFile))(_.mkString).toEither
+      safePath    <- validateContainment(path, fullPath)
+      yamlContent <- Using(Source.fromFile(safePath.toFile))(_.mkString).toEither
       parsed      <- parser.parse(yamlContent).flatMap(_.as[Yaml])
     } yield parsed
 
@@ -88,9 +125,11 @@ object ProfileBuilderNew {
   def buildFromYamlJava(path: String): Yaml = {
     try {
       val fullPath    = Paths.get(sys.props.toMap.apply("user.dir"), path)
-      val yamlContent = Using.resource(Source.fromFile(fullPath.toFile))(_.mkString)
+      val safePath    = validateContainment(path, fullPath).toTry.get
+      val yamlContent = Using.resource(Source.fromFile(safePath.toFile))(_.mkString)
       parser.parse(yamlContent).flatMap(_.as[Yaml]).toTry.get
     } catch {
+      case e: SecurityException     => throw ProfileBuilderException(e.getMessage, e)
       case e: FileNotFoundException => throw ProfileBuilderException(s"File not found $path", e)
       case e: io.circe.Error        => throw ProfileBuilderException(s"Incorrect file content in $path", e)
       case e: Exception             => throw ProfileBuilderException(s"Unknown error", e)

--- a/src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala
+++ b/src/main/scala/org/galaxio/gatling/storage/StorageBackend.scala
@@ -32,10 +32,14 @@ trait StorageBackend {
   def clear(): Unit
 }
 
+private[storage] object StorageFormats {
+  implicit val formats: Formats = DefaultFormats
+}
+
 final class StorageWriteException(message: String) extends RuntimeException(message)
 
 final case class JsonFileBackend(filePath: String) extends StorageBackend {
-  private implicit val formats: Formats = DefaultFormats
+  import StorageFormats.formats
 
   override def save(records: Seq[Record[Any]]): Unit =
     Files.writeString(Paths.get(filePath), writePretty(records))
@@ -57,7 +61,7 @@ final case class RedisBackend(
     storageKey: String = "gatling:auth:storage",
 ) extends StorageBackend {
   import com.redis.RedisClient
-  private implicit val formats: Formats = DefaultFormats
+  import StorageFormats.formats
 
   private def withClient[T](f: RedisClientLike => T): T = {
     val client  = new RedisClient(host, port)
@@ -113,9 +117,14 @@ final case class JdbcStorageBackend(
     username: String = "",
     password: String = "",
 ) extends StorageBackend {
-  private implicit val formats: Formats = DefaultFormats
-  private val tableInitialized          = new AtomicBoolean(false)
-  private val tableInitLock             = new AnyRef
+  import StorageFormats.formats
+  require(
+    tableName.matches("[A-Za-z_][A-Za-z0-9_]*"),
+    s"Invalid tableName: '$tableName'. Must be a valid SQL identifier " +
+      "(letters, digits, underscores, starting with a letter or underscore).",
+  )
+  private val tableInitialized = new AtomicBoolean(false)
+  private val tableInitLock    = new AnyRef
 
   private def withConnection[T](f: Connection => T): T = {
     val conn =

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaProfileTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaProfileTest.java
@@ -3,7 +3,12 @@ package org.galaxio.gatling.javaapi;
 import io.gatling.javaapi.core.ScenarioBuilder;
 import org.galaxio.gatling.javaapi.profile.ProfileBuilderNew;
 
-
+// Compile guard for the Java facade. Request header parsing is NOT exercised here because the facade
+// `internal.ProfileBuilderNew.toRequest` (like the Scala core `Request.toRequest`) static-initializes the
+// Gatling HttpDsl, which needs the Gatling runtime and cannot run in a unit test. The facade delegates header
+// parsing to the shared `Request.parsedHeaders`; its malformed-header behavior (ProfileBuilderException, not
+// MatchError) is unit-tested once at the core in ProfileBuilderTest ("Request.parsedHeaders"). The full
+// toRequest path is exercised end-to-end in the examples/ overlay (WireMock e2e).
 public class JavaProfileTest {
     ScenarioBuilder scn = ProfileBuilderNew
             .buildFromYaml("perf/profiles.yml")

--- a/src/test/scala/org/galaxio/gatling/diagnostics/InjectionProfileParserSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/InjectionProfileParserSpec.scala
@@ -1,0 +1,58 @@
+package org.galaxio.gatling.diagnostics
+
+import io.gatling.core.controller.inject.closed._
+import io.gatling.core.controller.inject.open._
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+
+class InjectionProfileParserSpec extends AnyWordSpec with Matchers with OptionValues {
+
+  "InjectionProfileParser.requireArity" should {
+    "throw IllegalArgumentException when a step has fewer fields than required" in {
+      val thrown = intercept[IllegalArgumentException] {
+        InjectionProfileParser.requireArity(Tuple1("only-one-field"), 2)
+      }
+      thrown.getMessage should include("productArity=1")
+      thrown.getMessage should include("at least 2")
+    }
+
+    "accept a step whose arity meets the requirement" in {
+      noException should be thrownBy InjectionProfileParser.requireArity(("a", "b"), 2)
+    }
+
+    "accept a step whose arity exceeds the requirement" in {
+      noException should be thrownBy InjectionProfileParser.requireArity(("a", "b", "c"), 2)
+    }
+  }
+
+  "InjectionProfileParser.fromClosed" should {
+    "produce WorkloadSettings from a ramp concurrent-users step" in {
+      val settings = InjectionProfileParser.fromClosed(List(RampConcurrentUsersInjection(10, 50, 60.seconds))).value
+
+      settings.unit shouldBe "users"
+      settings.intensityRps shouldBe 50.0
+      settings.testDuration shouldBe 60.seconds
+    }
+
+    "return None for an empty step list" in {
+      InjectionProfileParser.fromClosed(Nil) shouldBe None
+    }
+  }
+
+  "InjectionProfileParser.fromOpen" should {
+    "produce WorkloadSettings from a ramp-rate open step" in {
+      val settings = InjectionProfileParser.fromOpen(List(RampRateOpenInjection(1.0, 10.0, 60.seconds))).value
+
+      settings.unit shouldBe "rps"
+      settings.intensityRps shouldBe 10.0
+      settings.testDuration shouldBe 60.seconds
+    }
+
+    "return None for an empty step list" in {
+      InjectionProfileParser.fromOpen(Nil) shouldBe None
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/VaultFeederSpec.scala
@@ -25,4 +25,82 @@ class VaultFeederSpec extends AnyWordSpec with Matchers {
       VaultFeeder.extractClientToken(payload) shouldBe "vault-token-123"
     }
   }
+
+  "VaultFeeder.mergeWithStrategy" should {
+    "throw IllegalArgumentException naming the duplicate key under FailOnDuplicate" in {
+      val thrown = intercept[IllegalArgumentException] {
+        VaultFeeder.mergeWithStrategy(List("k" -> "v1", "k" -> "v2"), DuplicateKeyStrategy.FailOnDuplicate)
+      }
+      thrown.getMessage should include("k")
+    }
+
+    "keep the last value under LastWins" in {
+      VaultFeeder.mergeWithStrategy(List("k" -> "v1", "k" -> "v2"), DuplicateKeyStrategy.LastWins) shouldBe Map(
+        "k" -> "v2",
+      )
+    }
+
+    "keep the first value under FirstWins" in {
+      VaultFeeder.mergeWithStrategy(List("k" -> "v1", "k" -> "v2"), DuplicateKeyStrategy.FirstWins) shouldBe Map(
+        "k" -> "v1",
+      )
+    }
+  }
+
+  "VaultFeeder.parseLoginResponse" should {
+    "throw RuntimeException on malformed JSON" in {
+      val thrown = intercept[RuntimeException] {
+        VaultFeeder.parseLoginResponse("not-json", "http://vault/v1/auth/approle/login")
+      }
+      thrown.getMessage should include("Failed to parse Vault login response")
+    }
+  }
+
+  "VaultFeeder.parseSecretResponse" should {
+    "throw RuntimeException on malformed JSON" in {
+      val thrown = intercept[RuntimeException] {
+        VaultFeeder.parseSecretResponse("not-json", "secret/mypath")
+      }
+      thrown.getMessage should include("Failed to parse Vault secret response")
+      thrown.getMessage should include("mypath")
+    }
+
+    "throw RuntimeException when the data field is not a key-value object" in {
+      val thrown = intercept[RuntimeException] {
+        VaultFeeder.parseSecretResponse("""{"data":"not-an-object"}""", "secret/mypath")
+      }
+      thrown.getMessage should include("Failed to extract secret data")
+      thrown.getMessage should include("mypath")
+    }
+  }
+
+  "VaultFeeder.isUnsafeVaultUrl" should {
+    "return true for http non-localhost" in {
+      VaultFeeder.isUnsafeVaultUrl("http://vault.prod.internal") shouldBe true
+    }
+
+    "return false for http localhost" in {
+      VaultFeeder.isUnsafeVaultUrl("http://localhost:8200") shouldBe false
+    }
+
+    "return false for http 127.0.0.1" in {
+      VaultFeeder.isUnsafeVaultUrl("http://127.0.0.1:8200") shouldBe false
+    }
+
+    "return false for http IPv6 loopback [::1]" in {
+      VaultFeeder.isUnsafeVaultUrl("http://[::1]:8200") shouldBe false
+    }
+
+    "return false for http unbracketed IPv6 loopback longhand" in {
+      VaultFeeder.isUnsafeVaultUrl("http://0:0:0:0:0:0:0:1") shouldBe false
+    }
+
+    "return true for http on a non-loopback IPv6 host" in {
+      VaultFeeder.isUnsafeVaultUrl("http://[2001:db8::1]:8200") shouldBe true
+    }
+
+    "return false for https" in {
+      VaultFeeder.isUnsafeVaultUrl("https://vault.prod.internal") shouldBe false
+    }
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/profile/ProfileBuilderTest.scala
+++ b/src/test/scala/org/galaxio/gatling/profile/ProfileBuilderTest.scala
@@ -63,9 +63,48 @@ class ProfileBuilderTest extends AnyWordSpec with Matchers {
 
       thrown.getMessage should include(s"Incorrect file content in $path")
     }
+
+    "reject a path that escapes the working directory via traversal" in {
+      val thrown = the[ProfileBuilderException] thrownBy {
+        ProfileBuilderNew.buildFromYaml("../../etc/passwd")
+      }
+
+      thrown.getMessage.toLowerCase should include("traversal")
+    }
+
+    "accept a path that normalizes back within the project" in {
+      val path = "src/test/resources/profileTemplates/../profileTemplates/profile1.yml"
+
+      ProfileBuilderNew.buildFromYaml(path) shouldBe expectedYaml
+    }
+
+    "reject an absolute path outside the working directory" in {
+      val thrown = the[ProfileBuilderException] thrownBy {
+        ProfileBuilderNew.buildFromYaml("/etc/passwd")
+      }
+
+      thrown.getMessage.toLowerCase should include("traversal")
+    }
   }
 
   "ProfileBuilderNew.buildFromYamlJava" should {
+
+    "reject a path that escapes the working directory via traversal" in {
+      val thrown = the[ProfileBuilderException] thrownBy {
+        ProfileBuilderNew.buildFromYamlJava("../../etc/passwd")
+      }
+
+      thrown.getMessage.toLowerCase should include("traversal")
+    }
+
+    "reject an absolute path outside the working directory" in {
+      val thrown = the[ProfileBuilderException] thrownBy {
+        ProfileBuilderNew.buildFromYamlJava("/etc/passwd")
+      }
+
+      thrown.getMessage.toLowerCase should include("traversal")
+    }
+
     "use the same error model as the Scala facade" in {
       Seq(
         "notExistsFile"                                            -> "File not found notExistsFile",
@@ -81,6 +120,30 @@ class ProfileBuilderTest extends AnyWordSpec with Matchers {
           thrown.getMessage should include(expectedMessage)
         }
       }
+    }
+  }
+
+  "Request.parsedHeaders" should {
+    "throw ProfileBuilderException on a header with no colon separator" in {
+      val request =
+        Request("r", "100 rph", None, Params("GET", "/", Some(List("bad-header-no-colon")), None))
+
+      val thrown = the[ProfileBuilderException] thrownBy request.parsedHeaders
+
+      thrown.getMessage should include("bad-header-no-colon")
+    }
+
+    "throw ProfileBuilderException on an empty header string" in {
+      val request = Request("r", "100 rph", None, Params("GET", "/", Some(List("")), None))
+
+      the[ProfileBuilderException] thrownBy request.parsedHeaders
+    }
+
+    "parse a well-formed header into a name to value pair" in {
+      val request =
+        Request("r", "100 rph", None, Params("GET", "/", Some(List("Content-Type: application/json")), None))
+
+      request.parsedHeaders shouldBe Map("Content-Type" -> "application/json")
     }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/storage/JdbcStorageBackendSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/JdbcStorageBackendSpec.scala
@@ -7,6 +7,31 @@ class JdbcStorageBackendSpec extends AnyWordSpec with Matchers {
 
   "JdbcStorageBackend" should {
 
+    "reject tableName with SQL injection payload" in {
+      val thrown = intercept[IllegalArgumentException] {
+        JdbcStorageBackend("jdbc:recording:", tableName = "results; DROP TABLE results; --")
+      }
+      thrown.getMessage should include("Invalid tableName")
+    }
+
+    "reject empty tableName" in {
+      val thrown = intercept[IllegalArgumentException] {
+        JdbcStorageBackend("jdbc:recording:", tableName = "")
+      }
+      thrown.getMessage should include("Invalid tableName")
+    }
+
+    "reject tableName starting with a digit" in {
+      val thrown = intercept[IllegalArgumentException] {
+        JdbcStorageBackend("jdbc:recording:", tableName = "123bad")
+      }
+      thrown.getMessage should include("Invalid tableName")
+    }
+
+    "accept a valid tableName" in {
+      noException should be thrownBy JdbcStorageBackend("jdbc:recording:", tableName = "my_results_2024")
+    }
+
     "close the result set when load fails" in {
       val driver = new JdbcTestSupport.RecordingJdbcDriver("jdbc:recording:", Seq("not-json"))
 


### PR DESCRIPTION
## What

Security & correctness hardening for milestone [v1.20.0 — Storage, JDBC & Vault security](https://github.com/galax-io/gatling-picatinny/milestone/4). Closes the SQLi / cleartext-credential / path-traversal / crash-on-malformed-input findings from the production-readiness audit.

Resolves [#204](https://github.com/galax-io/gatling-picatinny/issues/204), [#209](https://github.com/galax-io/gatling-picatinny/issues/209), [#94](https://github.com/galax-io/gatling-picatinny/issues/94).

## Changes

| Area | Fix | File |
|------|-----|------|
| SQLi | `JdbcStorageBackend` validates `tableName` as a SQL identifier at construction, before any DB connection | `storage/StorageBackend.scala` |
| Vault | `VaultFeeder` logs a WARN (before any network call) when `vaultUrl` is plaintext `http://` on a non-loopback host | `feeders/VaultFeeder.scala` |
| Path traversal | `ProfileBuilderNew` rejects `../` escapes and absolute paths (normalize + containment) before any file I/O | `profile/ProfileBuilderNew.scala` |
| Crash → typed error | Malformed profile headers now throw `ProfileBuilderException` instead of an opaque `MatchError` | `profile/ProfileBuilderNew.scala` |
| Wrong ramp / crash | `InjectionProfileParser` arity guard fails loudly on unsupported injection steps | `diagnostics/InjectionProfileParser.scala` |
| Cleanup | Dedupe `DefaultFormats` into a shared `StorageFormats` object | `storage/StorageBackend.scala` |
| Thin facade | Java/Kotlin facade delegates header parsing to core `parsedHeaders` (was duplicating logic → `MatchError` for Java callers) | `javaapi/internal/ProfileBuilderNew.scala` |

## Why

All findings are in published-library code consumed by external teams. `tableName` is interpolated into DDL/DML (SQL identifiers can't be parameterized); Vault credentials were sent over cleartext HTTP with no signal; caller-supplied profile paths were joined onto the working dir with no containment; malformed input surfaced as `MatchError`/index errors instead of actionable messages.

## Compatibility

- No public API signature changes. All changes tighten preconditions on inputs that were already broken, or add internal helpers (`private[feeders]`/`private[gatling]`/`private[storage]`).
- Vault HTTP is a **warning, not a rejection** — by design, callers stay unblocked.
- Loopback exemption covers `localhost`, `127.0.0.1`, and IPv6 `[::1]` / longhand.
- MINOR version bump (security hardening, no removal).

## Tests

- Unit + CI gate (`scalafmtCheckAll scalafmtSbtCheck compile test`): **729 passing**, 0 failed.
- Integration (Testcontainers Redis / JDBC PostgreSQL / Vault): **38 passing**, 0 failed.
- TDD: every fix has a failing test first, ≥1 negative/boundary case per FR. New Vault merge/parse unit tests run without Docker.

## Reviewer notes — accepted residual gaps (out of scope)

- `ProfileBuilderNew` containment uses lexical `normalize()` — does not resolve symlinks planted under `user.dir` (pre-existing threat model).
- `tableName` permits reserved SQL words (e.g. `order`); they pass the identifier check but fail at runtime on first query (self-misconfig, not injection).
- Facade `toRequest` is not unit-tested for the malformed-header path: it static-initializes the Gatling `HttpDsl` (needs the runtime). The duplicated facade logic was the real defect (now fixed — it delegates to the unit-tested `parsedHeaders`); the full path is exercised in the `examples/` WireMock e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)