### PR TITLE
chore: clear speckit active plan (v1.21.1 shipped)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 @AGENTS.md
 
 <!-- SPECKIT START -->
-Active plan: [specs/005-feeders-generators-jwt/plan.md](specs/005-feeders-generators-jwt/plan.md) — Feeders, Generators & JWT Correctness (v1.21.0): long() Long-range bounds, generators test suite, **/separateBy n≤0 guard, codiceFiscale gender day-code, JWT claimFromSession type-preservation bug fix (#223) + typed overrides, alg/key mismatch IllegalArgumentException, key-load contextual errors. All changes bug-fix/additive → MINOR (v1.21.0).
+Active plan: [specs/005-feeders-generators-jwt/plan.md](specs/005-feeders-generators-jwt/plan.md) — Feeders, Generators & JWT Correctness (v1.21.1): long() Long-range bounds, generators test suite, **/separateBy n≤0 guard, codiceFiscale Belfiore filter, JWT claimFromSession type-preservation (#223), typed overrides, alg/key mismatch IllegalArgumentException, key-load contextual errors. Released v1.21.1.
 <!-- SPECKIT END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,4 @@
 @AGENTS.md
 
 <!-- SPECKIT START -->
-Active plan: [specs/005-feeders-generators-jwt/plan.md](specs/005-feeders-generators-jwt/plan.md) — Feeders, Generators & JWT Correctness (v1.21.1): long() Long-range bounds, generators test suite, **/separateBy n≤0 guard, codiceFiscale Belfiore filter, JWT claimFromSession type-preservation (#223), typed overrides, alg/key mismatch IllegalArgumentException, key-load contextual errors. Released v1.21.1.
 <!-- SPECKIT END -->

--- a/specs/005-feeders-generators-jwt/plan.md
+++ b/specs/005-feeders-generators-jwt/plan.md
@@ -4,7 +4,7 @@
 
 **Input**: Feature specification from `specs/005-feeders-generators-jwt/spec.md`
 
-**Milestone**: [v1.21.0 — Feeders, Generators & JWT](https://github.com/galax-io/gatling-picatinny/milestone/5) | Issues: [#205](https://github.com/galax-io/gatling-picatinny/issues/205), [#206](https://github.com/galax-io/gatling-picatinny/issues/206), [#223](https://github.com/galax-io/gatling-picatinny/issues/223)
+**Milestone**: [v1.21.0 — Feeders, Generators & JWT](https://github.com/galax-io/gatling-picatinny/milestone/5) | Issues: [#205](https://github.com/galax-io/gatling-picatinny/issues/205), [#206](https://github.com/galax-io/gatling-picatinny/issues/206), [#223](https://github.com/galax-io/gatling-picatinny/issues/223) | **Released**: [v1.21.1](https://github.com/galax-io/gatling-picatinny/releases/tag/v1.21.1) (patch: Belfiore regex broadened to `[A-Z][0-9]{3}`)
 
 ## Summary
 


### PR DESCRIPTION
Clears the SPECKIT active plan reference after v1.21.1 release. Housekeeping only.