### PR TITLE
fix(faker): exclude löpnummer 000 from Swedish personnummer (patch v1.21.2)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -578,7 +578,7 @@ object Faker {
         yy     <- number.int(0, 99)
         mm     <- number.int(1, 12)
         dd     <- number.int(1, 28)
-        serial <- number.int(0, 999)
+        serial <- number.int(1, 999) // löpnummer 001–999; 000 is reserved and fails validation
       } yield {
         val first9 = f"$yy%02d$mm%02d$dd%02d$serial%03d"
         first9 + LuhnCheckDigit.LUHN_CHECK_DIGIT.calculate(first9)


### PR DESCRIPTION
## Summary

- Swedish personnummer löpnummer 000 is reserved and rejected by `dev.personnummer` validator even when the Luhn digit is correct
- `number.int(0, 999)` → `number.int(1, 999)` ensures 001–999 range
- Fixes flaky CI: *should generate a personnummer that passes dev.personnummer validation* (reproduced as `9909180003` with serial 000)

Closes #229

## Test plan
- [x] `sbt test` — 791 tests pass locally
- [x] Personnummer test passes with 10 × forced seed covering serial=001 and serial=999 boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)