### PR TITLE
v1.22.0 — Config & cookie correctness fixes (#93, #111, #207)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-feeders-generators-jwt"
+  "feature_directory": "specs/006-config-cookie-fixes"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 @AGENTS.md
 
 <!-- SPECKIT START -->
+Active plan: [specs/006-config-cookie-fixes/plan.md](specs/006-config-cookie-fixes/plan.md)
 <!-- SPECKIT END -->

--- a/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Debug.scala
+++ b/examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Debug.scala
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.{WireMock => WM}
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
+import org.galaxio.gatling.storage.SessionStorage
 import org.galaxio.gatling.transactions.Predef._
 import org.galaxio.performance.picatinny.cases.{FeederValidationCases, HttpIntegrationCases}
 import org.galaxio.performance.picatinny.feeders.{FeederValidationFeeders, HttpIntegrationFeeders}
@@ -16,6 +17,7 @@ import org.galaxio.performance.picatinny.scenarios.PicatinnyScenario
   *   - all picatinny feeders + JWT + transactions (via PicatinnyScenario)
   *   - every faker feeder echoed + validated over HTTP (WireMock GET /echo)
   *   - CurrentDateFeeder + JWT round-trip over HTTP (WireMock GET /echo/{ts})
+  *   - picatinny `SessionStorage.restoreCookies` two-role cookie switching (user/admin)
   */
 class Debug extends SimulationWithTransactions {
 
@@ -45,6 +47,61 @@ class Debug extends SimulationWithTransactions {
       ),
   )
 
+  // --- Cookie role-switch e2e (picatinny SessionStorage.restoreCookies) ---
+  // Login stubs return the raw Set-Cookie in the response BODY (not a Set-Cookie header) so Gatling does NOT
+  // auto-capture it — the cookie reaches the protected endpoints ONLY via restoreCookies.
+  mock.stubFor(
+    WM.get(WM.urlPathEqualTo("/login/user"))
+      .willReturn(
+        WM.aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+          .withBody("""{"cookie":"sid=user-secret; Path=/"}"""),
+      ),
+  )
+  mock.stubFor(
+    WM.get(WM.urlPathEqualTo("/login/admin"))
+      .willReturn(
+        WM.aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+          .withBody("""{"cookie":"sid=admin-secret; Path=/"}"""),
+      ),
+  )
+  // Protected endpoints: 200 only when the auto-sent cookie value matches the role; otherwise the catch-all 403.
+  mock.stubFor(
+    WM.get(WM.urlPathEqualTo("/admin/data")).atPriority(1)
+      .withCookie("sid", WM.equalTo("admin-secret"))
+      .willReturn(WM.aResponse().withStatus(200)),
+  )
+  mock.stubFor(
+    WM.get(WM.urlPathEqualTo("/admin/data")).atPriority(10)
+      .willReturn(WM.aResponse().withStatus(403)),
+  )
+  mock.stubFor(
+    WM.get(WM.urlPathEqualTo("/user/data")).atPriority(1)
+      .withCookie("sid", WM.equalTo("user-secret"))
+      .willReturn(WM.aResponse().withStatus(200)),
+  )
+  mock.stubFor(
+    WM.get(WM.urlPathEqualTo("/user/data")).atPriority(10)
+      .willReturn(WM.aResponse().withStatus(403)),
+  )
+
+  private val cookieStorage = SessionStorage()
+
+  // 8 steps, 5 role-gated status checks. Each protected call carries NO explicit Cookie header — it relies on
+  // the jar populated by restoreCookies. Re-restoring `sid` overwrites the prior value (role switch).
+  private val cookieSwitch =
+    scenario("Cookie role switch")
+      .exec(http("login user").get("/login/user").check(status.is(200)).check(jsonPath("$.cookie").saveAs("setCookie")))
+      .exec(cookieStorage.restoreCookies("setCookie", "localhost"))
+      .exec(http("admin denied as user").get("/admin/data").check(status.is(403)))
+      .exec(http("user ok as user").get("/user/data").check(status.is(200)))
+      .exec(http("login admin").get("/login/admin").check(status.is(200)).check(jsonPath("$.cookie").saveAs("setCookie")))
+      .exec(cookieStorage.restoreCookies("setCookie", "localhost"))
+      .exec(http("admin ok as admin").get("/admin/data").check(status.is(200)))
+      .exec(http("user denied as admin").get("/user/data").check(status.is(403)))
+      .exec(http("login user again").get("/login/user").check(status.is(200)).check(jsonPath("$.cookie").saveAs("setCookie")))
+      .exec(cookieStorage.restoreCookies("setCookie", "localhost"))
+      .exec(http("user ok again").get("/user/data").check(status.is(200)))
+
   setUp(
     PicatinnyScenario("Picatinny Debug", "scala-debug")
       .feed(FeederValidationFeeders.all)
@@ -52,6 +109,7 @@ class Debug extends SimulationWithTransactions {
       .exec(FeederValidationCases.validateAll)
       .exec(HttpIntegrationCases.echo)
       .inject(atOnceUsers(1)),
+    cookieSwitch.inject(atOnceUsers(1)),
   ).protocols(http.baseUrl(s"http://localhost:${mock.port()}"))
     .assertions(global.failedRequests.count.is(0))
 

--- a/specs/006-config-cookie-fixes/checklists/requirements.md
+++ b/specs/006-config-cookie-fixes/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Config & Cookie Correctness Fixes (v1.22.0)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec covers all 4 milestone items: #93 (decimal intensity), #207 cookie discard-attrs (US2), #111 (Max-Age warn), #207 randomValue doc (US4).
+- One backward-compat decision (US2 cookie-jar injection) resolved via `/speckit-clarify` 2026-06-23: **additive** — register in cookie jar AND retain the session attribute. See Clarifications section.
+- Minor wording references to types (`Double`) and logging facility appear only in the Assumptions/Key Entities to bound scope; core requirements and success criteria stay technology-agnostic.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/006-config-cookie-fixes/contracts/public-api.md
+++ b/specs/006-config-cookie-fixes/contracts/public-api.md
@@ -1,0 +1,50 @@
+# Public API Contract: Config & Cookie Correctness Fixes (v1.22.0)
+
+This feature changes **behavior**, not **signatures**. Every public surface below keeps its exact signature; the contract records what callers can rely on before and after.
+
+## `org.galaxio.gatling.utils.IntensityConverter`
+
+```scala
+def getIntensityFromString(intensity: String): Double   // signature UNCHANGED
+```
+
+- **Before**: decimals beyond the first fractional digit silently truncated (`"0.25 rps"` → `0.2`); some malformed inputs silently mis-parsed.
+- **After**: exact decimal parsing (`"0.25 rps"` → `0.25`); clearly-malformed input throws `IllegalArgumentException`. The message keeps the `"Simulation param for intensity incorrect"` prefix and now appends a specific cause (e.g. `: unsupported unit 'jpeg' (use rps, rpm or rph)`) — type unchanged, prefix unchanged, suffix added for diagnostics.
+- **Compat**: bug fix. Previously-correct inputs (whole numbers, single-decimal, valid units) return identical values. Java facade `javaapi/utils/IntensityConverter.getIntensityFromString` delegates unchanged.
+- **Behavior delta (release note)**: negative input such as `"-5"` / `"-5 rps"` now **throws** instead of silently extracting `5` (the old `findAllIn` matched a substring). `requirePositive` already rejected such values downstream, so no valid config is affected — but note it in the v1.22.0 release notes.
+
+## `org.galaxio.gatling.storage.CookieParser`
+
+```scala
+def parse(rawSetCookie: String, defaultDomain: String): Seq[ParsedCookie]   // signature UNCHANGED
+case class ParsedCookie(...)                                                 // shape UNCHANGED
+```
+
+- **Before**: a non-numeric `Max-Age` was dropped silently (`maxAge = None`, no log).
+- **After**: identical return value (`maxAge = None`), plus a single WARN naming the offending value. Valid/absent `Max-Age` unchanged and silent.
+- **Compat**: additive observability only; return shape identical.
+
+## `org.galaxio.gatling.storage.SessionStorage`
+
+```scala
+def restoreCookies(setCookieField: String, domain: String): ChainBuilder   // signature UNCHANGED
+```
+
+- **Before**: copied each cookie's `name`→`value` into a session attribute only; cookies were **not** registered with the jar and therefore not auto-sent.
+- **After**: still sets the session attribute (additive/compat) AND registers each cookie in the Gatling cookie jar via the public `addCookie` DSL, scoped to `domain` with default path `/`, so cookies auto-attach to subsequent requests to that domain. Per-cookie `path`/`max-age`/`secure`/`httpOnly` are not propagated.
+- **Compat**: additive DSL behavior addition → MINOR bump (v1.22.0). No signature change. No-op when the source attribute is missing.
+
+## `org.galaxio.gatling.utils.RandomDataGenerators`
+
+```scala
+def randomValue[T](max: T)(implicit rng: RandomProvider[T]): T              // UNCHANGED
+def randomValue[T](min: T, max: T)(implicit rng, ord): T                    // UNCHANGED
+```
+
+- **Before**: Scaladoc stated the maximum is inclusive.
+- **After**: Scaladoc states the maximum is **exclusive** (matches the implementation). No behavior change.
+- **Compat**: documentation only.
+
+## Java/Kotlin facade
+
+No facade file changes. `javaapi` delegations (`IntensityConverter`, `SimulationConfig.intensity`) already forward to Scala core (Constitution I).

--- a/specs/006-config-cookie-fixes/data-model.md
+++ b/specs/006-config-cookie-fixes/data-model.md
@@ -1,0 +1,46 @@
+# Phase 1 Data Model: Config & Cookie Correctness Fixes (v1.22.0)
+
+No new persisted entities. This feature touches two existing in-memory value types and one transient session-stored collection. All shapes are backward-compatible (no field added/removed/renamed).
+
+## ParsedCookie (existing — unchanged)
+
+`org.galaxio.gatling.storage.ParsedCookie` (`CookieParser.scala:3-11`).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | `String` | required |
+| `value` | `String` | required |
+| `domain` | `Option[String]` | defaults to `restoreCookies` domain arg when absent |
+| `path` | `Option[String]` | parsed but **not** propagated to the jar (build-time-fixed in public DSL) |
+| `maxAge` | `Option[Long]` | seconds; `None` when absent **or** present-but-unparseable (FR-006 adds a WARN for the present-but-unparseable case); not propagated to the jar |
+| `secure` | `Boolean` | parsed; not propagated to the jar |
+| `httpOnly` | `Boolean` | parsed; not propagated (irrelevant to an outbound cookie) |
+
+**Validation rule change (FR-006/007)**: when the `max-age` attribute is present but `toLongOption` returns `None` (non-numeric `abc`, empty `Max-Age=`, or overflow beyond `Long`), `maxAge` stays `None` AND a single WARN is logged naming the offending value. Absent `max-age` → `None`, no log. Parseable value, **including negative** (e.g. `-1` → `Some(-1L)`) → no log. Never throws.
+
+**Note**: the shape is intentionally unchanged — `path`/`maxAge`/`secure`/`httpOnly` remain on `ParsedCookie` (other callers and the parser tests use them) even though `restoreCookies` does not push them into the jar.
+
+## Intensity value (conceptual — `IntensityConverter`)
+
+Input grammar (anchored): `^<number>(\s*<unit>)?$` where `<number>` = `\d+(?:\.\d+)?` (arbitrary-precision decimal, no leading dot, no trailing dot, single dot) and `<unit>` ∈ {`rps`, `rpm`, `rph`} case-insensitive, default `rps`.
+
+| Aspect | Rule |
+|--------|------|
+| Output type | `Double` (requests per second) — **unchanged** |
+| Conversion | `rps` → value; `rpm` → value/60; `rph` → value/3600 |
+| Default unit | `rps` when unit absent |
+| Malformed | no match → `IllegalArgumentException("Simulation param for intensity incorrect")` |
+| Unsupported unit | explicit `case _` throw (not a swallowed `MatchError`) |
+
+Positivity/zero validation is the caller's concern (`SimulationConfig.requirePositive`), not this converter — unchanged.
+
+## Transient restore collection (new, internal)
+
+`restoreCookies` stores the runtime-parsed cookies in a **temporary session attribute** so Gatling's `foreach` can iterate them and emit one `addCookie` action per cookie. This is an internal, private session key used only within the returned `ChainBuilder`; it is not a public/serialized format. Each element exposes at least `name` and `value` for EL access (`#{cookie.name}`, `#{cookie.value}`). Choose a collision-free attribute name (e.g. a picatinny-namespaced key) and clean intent is local to the chain.
+
+State flow within the returned `ChainBuilder`:
+
+1. `exec { session => parse raw Set-Cookie → list; set each name→value session attr (compat); store list under the temp key }`
+2. `foreach(<temp key>, "cookie") { exec(addCookie(Cookie("#{cookie.name}", "#{cookie.value}").withDomain(domain))) }`
+
+No-op: if the source attribute is absent or not a `String`, step 1 leaves the session unchanged and the list is empty → `foreach` iterates nothing → flow continues without error.

--- a/specs/006-config-cookie-fixes/plan.md
+++ b/specs/006-config-cookie-fixes/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Config & Cookie Correctness Fixes (v1.22.0)
+
+**Branch**: `006-config-cookie-fixes` | **Date**: 2026-06-23 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/006-config-cookie-fixes/spec.md`
+
+## Summary
+
+Four independent correctness fixes for milestone [v1.22.0](https://github.com/galax-io/gatling-picatinny/milestone/7). Note: issue [#207](https://github.com/galax-io/gatling-picatinny/issues/207) bundles TWO sub-fixes — the cookie-discard fix (item 2) and the randomValue doc fix (item 4):
+
+1. **#93 — decimal intensity truncation**: `IntensityConverter` regex `(\d+\.?\d?)` captures only one fractional digit; replace with an anchored full-match `^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$` so `0.25 rps` → `0.25` and malformed input throws cleanly instead of silently truncating.
+2. **#207 cookie discard — restore into the jar**: `SessionStorage.restoreCookies` parses cookies then only `session.set(name, value)`, so cookies never auto-send. Add jar registration via the **supported public** `addCookie`/`Cookie` DSL (name/value at runtime, scoped to the `domain` arg, default path `/`), iterating the runtime-parsed list with `foreach`. Keep the existing `session.set` (additive). Per-cookie `path`/`max-age`/`secure`/`httpOnly` are not propagated — the public DSL fixes them at build time, and reflection into Gatling internals is rejected (see Constitution IV note).
+3. **#111 — silent Max-Age**: `CookieParser` drops a non-numeric `Max-Age` with no log; add a WARN naming the offending value (`StrictLogging`, matching `TransactionTracker`).
+4. **#207 (same issue as item 2) randomValue doc**: Scaladoc for `randomValue(min, max)` / `randomValue(max)` says the max is inclusive; the implementation is exclusive (`ThreadLocalRandom.next*(min, max)`). Fix the docs only; no behavior change.
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18
+
+**Primary Dependencies**: Gatling 3.13.5 (`Provided`), Scala Logging (`StrictLogging`), netty cookie types (transitive via gatling-http, 4.1.119.Final). No new dependencies.
+
+**Storage**: N/A (cookie jar lives in the Gatling `Session`, managed by Gatling).
+
+**Testing**: ScalaTest (`AnyWordSpec` + `Matchers` + `ScalaCheckDrivenPropertyChecks`); Logback `ListAppender` for WARN capture (already on the test classpath, idiom from `AssertionsBuilderSpec`); full Gatling e2e in `examples/scala-sbt-example` against WireMock (`sbt Gatling/test`).
+
+**Target Platform**: JVM (compile target Java 17; CI Temurin 21).
+
+**Project Type**: Published Scala library with thin Java/Kotlin facade.
+
+**Performance Goals**: N/A (correctness fixes; no hot-path change. `foreach` over a per-VU cookie list is O(cookies), negligible).
+
+**Constraints**: Backward compatibility (Constitution II) — no public Scala/Java signature change; `restoreCookies(setCookieField: String, domain: String): ChainBuilder` unchanged; `ParsedCookie` shape unchanged; intensity stays `Double`. Coverage floor 65%/60%.
+
+**Scale/Scope**: 4 source files + 2–3 test files + 1 examples overlay e2e. ~Small.
+
+## Test Model *(mandatory — real cases + test sketches, NO implementation)*
+
+| Req | Real case to test | Layer | Test sketch (no code) |
+|-----|-------------------|-------|-----------------------|
+| FR-001 | `"0.25 rps"` and `"123.55 rph"` configured intensities | Unit / Functional | In `IntensityConverterTest`, assert `getIntensityFromString("0.25 rps")` equals exactly `0.25` and `"123.55 rph"` equals `123.55/3600` (exact-value). Negative/boundary: `"1.2.3 rps"` and `".5"` MUST throw `IllegalArgumentException` (no silent truncation). These are the regression guards #93 lacked. |
+| FR-002 | Whole numbers, case-insensitive unit, default unit, extra whitespace | Unit / Functional | Assert `"50 rpm"` = `50/60`, `"10"` (no unit) = `10` rps, `"100 RPS"` = `100`, `"1.5   rps"` = `1.5` (extra spaces tolerated). Boundary: `"12rps"` (no separator) still parses to `12` rps. |
+| FR-003 | Garbage and partial inputs | Unit / Functional | Assert `"abc"`, `""`, `"1."`, `"-5"` each throw `IllegalArgumentException` with the existing message; assert a valid value still parses (positive case) so the throw is specific to malformed input, not blanket. |
+| FR-004 | Two-role cookie switching: restore user cookie → admin endpoint fails / user succeeds; restore admin (same `sid`, overwrites) → admin succeeds / user fails; restore user again → user succeeds | Full Gatling e2e (examples) | Added to the existing single-VU `Debug.scala` in `examples/scala-sbt-example`. Two login stubs return the raw Set-Cookie in the response **body** (so Gatling does NOT auto-capture — only `restoreCookies` injects). One cookie name `sid`, two values (`user-secret`/`admin-secret`); same domain/path so re-restore overwrites and revokes the prior role. Protected stubs match on `withCookie("sid", equalTo(...))` → 200 else 403. Each protected request carries NO explicit `Cookie` header; assert the 8-step status sequence (5 role-gated checks) via `check(status.is(200|403))` (403 = NOT success, 200 = success), gated by `global.failedRequests.count.is(0)`. Boundary: step 6 (`/user/data` → 403 after admin overwrite) proves the switch revokes. No `WireMock.verify` / request re-decode. Full flow in research.md Decision 5. |
+| FR-004 | `restoreCookies` also still sets the session attribute (backward compat) | DSL / Action Component | Drive `restoreCookies` via the `transactions/Mocks` ActorSystem harness against a real `Session` seeded with a raw `Set-Cookie`; assert the resulting session has the cookie name→value attribute set (exact value) — the additive behavior is preserved. |
+| FR-005 | Multi-line `Set-Cookie` (2 cookies) and a missing source attribute | DSL / Action Component + Unit | Component: seed a two-cookie multi-line value; assert both name→value pairs are set and the chain completes. No-op boundary: when the source attribute is absent, assert the session passes through unchanged with no error. (Pure parse of the multi-line string is already covered in `CookieParserSpec`.) |
+| FR-006 | `Set-Cookie: sid=x; Max-Age=abc` | Unit / Functional | In `CookieParserSpec`, assert the returned `ParsedCookie.maxAge` is `None` AND (via the repo's `captureWarns` Logback `ListAppender` idiom, logger `org.galaxio.gatling.storage`) exactly one WARN is emitted whose message contains `abc`. Negative pairing with FR-007 below. |
+| FR-007 | Valid `Max-Age=3600` and entirely absent `Max-Age` | Unit / Functional | Assert `maxAge == Some(3600L)` with zero WARNs for the valid case, and `maxAge == None` with zero WARNs for the absent case (absence is not an error — the key boundary that prevents log noise). |
+| FR-008 | `randomValue(min, max)` documented bound vs runtime bound | Unit / Functional (existing) + doc | Doc-only change; no new behavior test required. The existing `RandomDataGeneratorsTest` property check already asserts generated values fall in `[min, max)` — it stands as the guard that the doc now matches (value `>= min` and `< max`). |
+| FR-009 | Public Scala/Java signatures unchanged | Compile Guard + Facade Delegation | Existing compile-guard / facade tests must stay green: `restoreCookies` signature, `IntensityConverter.getIntensityFromString: Double`, `SimulationConfig.intensity: Double`, and the Java facade delegations compile and delegate unchanged. |
+| FR-010 | Re-restoring `sid` with a new value revokes the prior value (role switch) | Full Gatling e2e (examples) | The two-role flow in `Debug.scala` is the verifier: after restoring `sid=user-secret` then `sid=admin-secret` (same domain/path), the boundary assertion is step 6 `GET /user/data` → **403** (old user value gone) while step 5 `GET /admin/data` → 200, then step 7-8 restores user and `/user/data` → 200 again. Exact-status checks; gated by `global.failedRequests.count.is(0)`. |
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **I. Scala DSL as Source of Truth** — All four fixes are in Scala core. The Java facade (`IntensityConverter.java`, `SimulationConfig.java`) already delegates; no facade logic added. ✓
+- [x] **II. Backward Compatibility** — No public signature change: `restoreCookies(String, String): ChainBuilder`, `getIntensityFromString: Double`, `ParsedCookie` shape all unchanged. The cookie-jar registration is an **additive** DSL behavior addition (authorized in `/speckit-clarify`), warranting the v1.22.0 MINOR bump. randomValue is doc-only. Intensity regex fix changes only previously-wrong output (truncated → correct), which is a bug fix, not a compat break. ✓
+- [x] **III. Test Discipline** — Test Model above is filled per FR with real case + layer + code-free sketch and ≥1 negative/boundary each; work is test-first; layers follow TESTING.md (HTTP-free unit for parser/converter; DSL-component via `transactions/Mocks` for `restoreCookies` session behavior; full e2e via WireMock overlay for auto-send; no Gatling-runtime mocking; ScalaMock only if a leaf needs mocking — none required here). Coverage stays ≥ floor. ✓
+- [x] **IV. Small, Focused Changes** — No new deps (`scalalogging` already main; `logback`/`scalacheck` already test). No API signature change. **Note (principle bent, justified in Complexity Tracking):** `restoreCookies` is restructured from a single `exec{}` to `exec{} + foreach{ addCookie }` — minimal restructure required to populate the jar; the rejected fuller alternative (reflection) is documented. No opportunistic refactors. ✓
+- [x] **V. Release Integrity** *(release PRs only)* — Fixes land on `main` via PR first; v1.22.0 is a MINOR release cut as `release/1.22.0` from `main` per the release process. Not exercised at plan stage. ✓
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-config-cookie-fixes/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (Gatling cookie API + repo patterns)
+├── data-model.md        # Phase 1 output (ParsedCookie, Intensity)
+├── quickstart.md        # Phase 1 output (how to validate each fix)
+├── contracts/
+│   └── public-api.md    # Phase 1 output (unchanged public surfaces this touches)
+└── tasks.md             # /speckit-tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/
+├── utils/
+│   ├── IntensityConverter.scala        # FR-001/002/003 — regex fix
+│   └── RandomDataGenerators.scala      # FR-008 — scaladoc fix (randomValue overloads)
+└── storage/
+    ├── CookieParser.scala              # FR-006/007 — WARN on bad Max-Age (StrictLogging)
+    └── SessionStorage.scala            # FR-004/005 — restoreCookies: addCookie + foreach, keep session.set
+
+src/test/scala/org/galaxio/gatling/
+├── utils/
+│   └── IntensityConverterTest.scala    # FR-001/002/003 — decimal + malformed cases
+└── storage/
+    ├── CookieParserSpec.scala          # FR-006/007 — maxAge None + WARN capture
+    └── SessionStorageSpec.scala        # FR-004/005 — restoreCookies session.set + multi/no-op (component, transactions/Mocks)
+
+examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/
+└── Debug.scala                         # FR-004/010 — add login/admin/user WireMock stubs + 8-step switch scenario + wire into setUp (no separate simulation file)
+```
+
+**Structure Decision**: Single published-library project (Option 1). Changes are confined to `utils/` and `storage/` in Scala core plus their existing test specs, with the cookie e2e added to the existing `Debug.scala` in the `scala-sbt-example` overlay (the authoritative copy CI overlays onto the template) — no separate simulation file. No facade files change (delegation already covers it).
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| `restoreCookies` restructured to `exec{} + foreach{ addCookie }` (Principle IV — minimal-change bent) | The jar can only be populated via the public `addCookie` action, which is build-time; a runtime-variable cookie list therefore requires `foreach` over a session-stored collection. | A single `exec{ session => ... }` cannot call `addCookie` (it is an action, not a `Session` transform). |
+| Per-cookie `path`/`max-age`/`secure`/`httpOnly` NOT propagated to the jar (FR-004 scoped down from "take all") | The public `addCookie` DSL accepts only `name`/`value` as runtime values; the rest are build-time-fixed. | Reflection into `private[http] CookieSupport.storeCookie` would carry all attributes but couples a published library to Gatling internals across `Provided`-scope versions (silent breakage at the user's runtime). Rejected by user decision 2026-06-23; the dropped attributes do not affect what an outbound cookie transmits. |

--- a/specs/006-config-cookie-fixes/quickstart.md
+++ b/specs/006-config-cookie-fixes/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Validate the v1.22.0 Config & Cookie Fixes
+
+Prerequisites: repo root, sbt, Java 17+. Docker NOT required (no Testcontainers in scope).
+
+Run formatting + the standard CI gate before committing any change:
+
+```bash
+sbt scalafmtAll scalafmtSbt
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+## FR-001/002/003 — Decimal intensity (#93)
+
+Unit layer. The regression guard the bug lacked:
+
+```bash
+sbt "testOnly org.galaxio.gatling.utils.IntensityConverterTest"
+```
+
+Expected after the fix: `"0.25 rps"` → `0.25`, `"123.55 rph"` → `123.55/3600`, whole numbers and units unchanged; `".5"`, `"1.2.3"`, `"abc"`, `""` throw `IllegalArgumentException`. (Before the fix, the new decimal cases fail — write them first, watch them go red.)
+
+## FR-006/007 — Max-Age WARN (#111)
+
+Unit layer (value + WARN capture via the repo's Logback `ListAppender` idiom):
+
+```bash
+sbt "testOnly org.galaxio.gatling.storage.CookieParserSpec"
+```
+
+Expected: `Max-Age=abc` → `maxAge = None` AND exactly one WARN containing `abc`; `Max-Age=3600` → `Some(3600L)`, zero WARNs; absent `Max-Age` → `None`, zero WARNs.
+
+## FR-004/005 — Cookie restored into the jar (#207)
+
+Component layer (session.set + multi-cookie + no-op via `transactions/Mocks`):
+
+```bash
+sbt "testOnly org.galaxio.gatling.storage.SessionStorageSpec"
+```
+
+End-to-end two-role switching (proves the cookie auto-sends AND that re-restoring swaps the active role):
+
+```bash
+sbt publishLocal            # from repo root first, OR set PICATINNY_VERSION to a published build
+cd examples/scala-sbt-example
+sbt "Gatling/testOnly org.galaxio.performance.picatinny.Debug"   # switching scenario added to Debug; or: sbt Gatling/test
+```
+
+Scenario (single VU, no explicit `Cookie` header on any protected call — relies purely on the jar):
+
+| Step | Action | Expected status |
+|------|--------|-----------------|
+| 1 | login user → save body cookie; `restoreCookies(..,"localhost")` | 200 |
+| 2 | `GET /admin/data` | **403** (user ≠ admin) |
+| 3 | `GET /user/data` | **200** |
+| 4 | login admin → `restoreCookies` (overwrites `sid`) | 200 |
+| 5 | `GET /admin/data` | **200** |
+| 6 | `GET /user/data` | **403** (user revoked by overwrite) |
+| 7 | login user again → `restoreCookies` | 200 |
+| 8 | `GET /user/data` | **200** (back to user) |
+
+All assertions are `check(status.is(...))` on the response; `global.failedRequests.count.is(0)` gates the build. Login stubs return the cookie in the response **body** (not a `Set-Cookie` header) so only `restoreCookies` injects it. No `WireMock.verify`, no request re-decode.
+
+## FR-008 — randomValue scaladoc (#207)
+
+Doc-only; no behavior change. The existing property tests stand as the guard:
+
+```bash
+sbt "testOnly org.galaxio.gatling.utils.RandomDataGeneratorsTest"
+```
+
+Confirm the Scaladoc on `randomValue(min, max)` and `randomValue(max)` now reads "exclusive" for the maximum.
+
+## FR-009 — Backward compatibility
+
+```bash
+sbt compile test    # compile guard + facade delegation specs stay green
+```
+
+Confirm no public signature changed: `getIntensityFromString: Double`, `restoreCookies(String, String): ChainBuilder`, `ParsedCookie` shape, `SimulationConfig.intensity: Double`.
+
+## Coverage gate
+
+```bash
+sbt clean coverage test coverageReport
+```
+
+Statement ≥ 65%, branch ≥ 60% (must not regress).

--- a/specs/006-config-cookie-fixes/research.md
+++ b/specs/006-config-cookie-fixes/research.md
@@ -1,0 +1,114 @@
+# Phase 0 Research: Config & Cookie Correctness Fixes (v1.22.0)
+
+Sources: Gatling 3.13.5 sources jar (`gatling-http-3.13.5-sources.jar`), netty 4.1.119.Final cookie sources, repo grep. All findings independently adversarially verified (cookie-API accessibility verdict re-confirmed against the jar).
+
+---
+
+## Decision 1 — Gatling cookie-jar registration route (FR-004)
+
+**Decision**: Use the **public** Gatling DSL `addCookie(Cookie(name, value).withDomain(domain))`, iterating the runtime-parsed cookie list with `foreach` over a session-stored collection. Carry `name`/`value` (runtime) + `domain` (the `restoreCookies` arg) + default path `/`. Keep the existing `session.set(name, value)` (additive).
+
+**Rationale**:
+- The full-fidelity jar-store API `io.gatling.http.cookie.CookieSupport.storeCookie/storeCookies` is `private[http] object CookieSupport` (`CookieSupport.scala:27`) — **not referenceable from `org.galaxio.gatling.storage` at Scala compile time** (verified; the bytecode is public but only reachable via reflection). Reflection couples a published library to Gatling internals across `Provided`-scope versions → rejected by user decision (2026-06-23).
+- The public `addCookie` route is supported and compile-safe. `AddCookieDsl` (`AddCookieDsl.scala:20-32`) types `name`/`value` as `Expression[String]` (runtime EL OK) but `domain: Option[String]`, `path: Option[String]`, `maxAge: Option[Long]`, `secure: Boolean` are **plain build-time values** — they cannot vary per parsed cookie at runtime. There is **no `withHttpOnly`**.
+- `addCookie` returns an `AddCookieBuilder` → a `SessionHook` **action** wired at scenario-build time; it is NOT a `Session => Session` and cannot run inside `exec { session => ... }`. A runtime-variable cookie count is therefore handled with `foreach("#{cookies}", "cookie") { exec(addCookie(...)) }`.
+
+**Alternatives considered**:
+- *Reflection into `CookieSupport$.MODULE$.storeCookie`* — full per-cookie fidelity incl. httpOnly, works inside `exec`, but fragile/version-coupled. Rejected.
+- *Construct `AddCookieDsl(...)` directly with per-cookie attrs* — the attribute fields are build-time; cannot carry runtime per-cookie domain/path/maxAge/secure. Does not solve the runtime problem.
+
+**Key facts to honor in implementation**:
+- `withMaxAge` takes `Int` (`AddCookieDsl.scala:31`) — N/A since we don't propagate maxAge, but note for any future change.
+- netty maxAge is **seconds**; a jar cookie is persistent iff `maxAge != UNDEFINED_MAX_AGE` and expired iff `maxAge <= 0` (`CookieJar.scala:53-56`). Restored cookies become session cookies (no maxAge) — correct for a test run.
+- `CookieJar.get` filters secure cookies unless the request is a secure context (https/wss/localhost) (`CookieJar.scala:128-159`). Since we don't propagate `secure`, restored cookies attach on plain http too — acceptable.
+- The default cookie path constant is `/` (`CookieActionBuilder.scala:25`).
+- **httpOnly is irrelevant to an outbound (client-sent) cookie** — it is a server→browser directive governing JS access; a load client transmits only `name=value`. Dropping it has zero functional effect.
+
+**Citations**: `CookieSupport.scala:27,45-51,53-56,80-90`; `AddCookieDsl.scala:20-32`; `AddCookieBuilder.scala:24,63-68,71`; `CookieActionBuilder.scala:25`; `CookieJar.scala:53-56,128-159`; netty `Cookie.java:110,145`, `DefaultCookie.java:37,120-122`.
+
+---
+
+## Decision 2 — IntensityConverter regex (FR-001/002/003)
+
+**Decision**: Replace `"""(\d+\.?\d?)\s?(\w+)?"""` with an **anchored full-match** `"""^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$"""`, matched against `intensity.trim` (explicit `.trim` so leading/trailing whitespace like `" 0.25 rps "` is stripped before the anchored `^…$` match; via a `case pattern(value, unit) =>` extractor / `findFirstMatchIn`), defaulting the unit to `rps`, and making the unit `match` exhaustive with an explicit `case _ => throw IllegalArgumentException(...)`.
+
+**Rationale**:
+- Current `\d+\.?\d?` captures at most ONE fractional digit, so `"0.25 rps"` → group(1)=`0.2`, group(2)=`5` → `0.2`; `"123.55"` → `123.5`. Verified on the JVM regex engine. This is #93.
+- `findAllIn` + `group()` without a match-success check matches a prefix substring and never rejects trailing garbage, so `"1.2.3"`→`1.2`, `".5"`→`5` are silently accepted. Anchoring with `^...$` + `[a-zA-Z]+` unit makes malformed input produce **no match** → clean `IllegalArgumentException` (preserve the existing message `"Simulation param for intensity incorrect"` and type).
+- Default unit (`rps`) and case-insensitivity (`toLowerCase`) are preserved.
+
+**Edge-case table** (expected behavior after fix):
+
+| Input | Result |
+|-------|--------|
+| `"0.25 rps"` | `0.25` (was `0.2`) |
+| `"123.55 rph"` | `123.55/3600` (was `123.5/3600`) |
+| `"50 rpm"` | `50/60` |
+| `"10"` (no unit) | `10` rps |
+| `"100 RPS"` / `"Rps"` | `100` rps |
+| `"1.5   rps"` (extra ws) | `1.5` rps (was: unit lost → defaulted) |
+| `"12rps"` (no sep) | `12` rps |
+| `".5"`, `"1."`, `"1.2.3"`, `"abc"`, `""`, `"-5"` | throw `IllegalArgumentException` |
+| `"3600.0 jpeg"` (bad unit) | throw (now explicit `case _`, not swallowed `MatchError`) |
+
+**Alternatives considered**: keep `\w+` for the unit (minimal diff) — acceptable once the value group is fixed and the match anchored; `[a-zA-Z]+` chosen as defense-in-depth so a digit can never leak into the unit group.
+
+**Citations**: `IntensityConverter.scala:17,20-22,23-27,28-30`; `IntensityConverterTest.scala:34-48` (no multi-digit-decimal case existed — why #93 slipped through).
+
+---
+
+## Decision 3 — Max-Age WARN logging (FR-006/007)
+
+**Decision**: Make `CookieParser` `extends StrictLogging` (`import com.typesafe.scalalogging.StrictLogging`) and emit `logger.warn(...)` naming the offending value only when `Max-Age` is **present but not parseable as a `Long`** (`toLongOption` returns `None` — covers non-numeric `abc`, empty `Max-Age=`, and overflow). Absent → no warn; a value that parses (including negative, e.g. `-1`) → no warn. Never throw.
+
+**Rationale**: Matches the repo's `object ... extends StrictLogging` precedent (`TransactionTracker.scala:5,11,29` — `logger.warn(s"...")`). `CookieParser` is a plain `object` today with no logger. The current `attrs.get("max-age").flatMap(_.toLongOption)` (`CookieParser.scala:37`) silently drops bad values — split it so a present-but-unparseable value triggers the warn while still returning `maxAge = None` (behavior preserved, observability added).
+
+**Test idiom**: assert the returned `ParsedCookie.maxAge` value (`CookieParserSpec` style, `c.maxAge shouldBe ...`), AND capture the WARN with the repo's existing Logback `ListAppender` helper pattern from `AssertionsBuilderSpec.scala:46-59` (`captureWarns`), targeting logger name `org.galaxio.gatling.storage`. No new dependency (logback-classic already on the test classpath); no Mockito.
+
+**Citations**: `CookieParser.scala:13,37`; `TransactionTracker.scala:5,11,29`; `AssertionsBuilderSpec.scala:46-59,82-88`; `CookieParserSpec.scala:6,27`.
+
+---
+
+## Decision 4 — randomValue scaladoc (FR-008)
+
+**Decision**: Fix the Scaladoc on `randomValue(min, max)` (and the single-bound `randomValue(max)`) to state the maximum is **exclusive**. No implementation or test change.
+
+**Rationale**: All `RandomProvider` impls use `ThreadLocalRandom.nextInt/nextLong(min, max)` and `min + nextDouble()*(max-min)` — all **exclusive** of `max`. The Scaladoc at `RandomDataGenerators.scala:143-144` says "inclusive" (wrong); `randomValue(max)` at `:135` says "less than or equal to max" (also wrong). Doc-only — the existing property tests in `RandomDataGeneratorsTest` already assert `[min, max)` and stand as the behavior guard (TESTING.md layer 5 compile/behavior guard). No new test needed.
+
+**Citations**: `RandomDataGenerators.scala:128-137,139-160`; `package.scala:14-44` (provider impls, all exclusive).
+
+---
+
+## Decision 5 — Test layering & e2e (FR-004/005)
+
+**Decision**: pure cookie-string parsing → `CookieParserSpec` (layer 1, exists); `restoreCookies` session-attribute behavior + multi-cookie + no-op → `SessionStorageSpec` extended as a DSL/action component test using the `transactions/Mocks` ActorSystem harness (layer 2); full cookie auto-send round-trip → net-new e2e in `examples/scala-sbt-example` (layer 4).
+
+**e2e sketch (no code) — two-role cookie switching**: Prove that `restoreCookies` injects a cookie into the jar so it auto-sends, AND that re-restoring a different value for the **same** cookie name *swaps the active role* (overwrite revokes the prior one). This is a stronger test than a single echo: the response **status** is gated by the cookie value, asserted via Gatling `check`.
+
+Design rationale: use ONE cookie name `sid` with two distinct values (`user-secret`, `admin-secret`). Same name + same domain (`localhost`) + same path (`/`) ⇒ the jar overwrites on re-restore, so switching roles genuinely *revokes* the previous one. (Two different cookie names would accumulate in the jar — both would stay valid and "the opposite endpoint must fail" could not hold.)
+
+Cookie isolation: the two "login" stubs return the raw Set-Cookie string in the **response body** (NOT in a `Set-Cookie` response header), so Gatling's native cookie auto-capture does NOT fire — the cookie reaches the protected endpoints ONLY via `restoreCookies`. This is what makes the test exercise picatinny, not Gatling's built-in handling.
+
+WireMock stubs (dynamic port, `globalTemplating` already on, `Debug.scala:22`):
+- `GET /login/user` → 200, body `{"cookie":"sid=user-secret; Path=/"}` (no Set-Cookie header).
+- `GET /login/admin` → 200, body `{"cookie":"sid=admin-secret; Path=/"}`.
+- `GET /admin/data`: high-priority stub matching `withCookie("sid", equalTo("admin-secret"))` → 200; low-priority catch-all for the same path → 403.
+- `GET /user/data`: high-priority stub matching `withCookie("sid", equalTo("user-secret"))` → 200; catch-all → 403.
+
+Scenario flow — **8 steps, 5 role-gated status checks** (single VU, one chain; each protected call carries NO explicit `Cookie` header — relies purely on auto-send from the jar). Steps 1/4/7 are login+`restoreCookies`; steps 2/3/5/6/8 are the role-gated protected calls:
+1. `GET /login/user` (`check(status.is(200))`, save body cookie) → `restoreCookies(<attr>, "localhost")` ⇒ jar `sid=user-secret`.
+2. `GET /admin/data` ⇒ **403** `check(status.is(403))` (user cookie, not admin — NOT success).
+3. `GET /user/data` ⇒ **200** `check(status.is(200))` (user — success).
+4. `GET /login/admin` (200, save body cookie) → `restoreCookies(...)` ⇒ jar `sid=admin-secret` (overwrites user).
+5. `GET /admin/data` ⇒ **200** (admin — success).
+6. `GET /user/data` ⇒ **403** (user revoked by overwrite — the "наоборот").
+7. `GET /login/user` again (200, save) → `restoreCookies(...)` ⇒ jar `sid=user-secret` (back to user).
+8. `GET /user/data` ⇒ **200** (returned to user — success).
+
+Each step's expectation is a Gatling `check(status.is(...))` on the RESPONSE; a failed check fails the request and the simulation's `.assertions(global.failedRequests.count.is(0))` gate fails the build. No `WireMock.verify`, no request re-decoding (the stub *matching* on cookie value only drives the response status, which Gatling then asserts — allowed; it is not mock-testing-mock).
+
+Placement (decided 2026-06-23): add this directly to the existing `Debug.scala` simulation — the cookie stubs into its `WireMockServer` setup, the 8-step flow as a scenario wired into its `setUp` (`atOnceUsers(1)`), reusing Debug's existing `after { mock.stop() }` and `.assertions(global.failedRequests.count.is(0))`. No separate `CookieSwitchSimulation` file. Cookie values can be inline constants in the stubs (no separate feeder needed). The `SessionStorageSpec` component unit test is kept for the `session.set`/no-op behavior.
+
+**Run**: from `examples/scala-sbt-example`, `sbt Gatling/test` (or `sbt "Gatling/testOnly ...<Sim>"`); requires the library on the classpath (`sbt publishLocal` or `PICATINNY_VERSION`). No Docker.
+
+**Citations**: `Debug.scala:22,25-46,55-60`; `HttpIntegrationCases.scala:16-28`; `FeederValidationCases.scala:20-25`; `build.sbt:8-19`; `scripts/test-scala-sbt-template.sh:63-69`; TESTING.md layers 1/2/4.

--- a/specs/006-config-cookie-fixes/spec.md
+++ b/specs/006-config-cookie-fixes/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: Config & Cookie Correctness Fixes (v1.22.0)
+
+**Feature Branch**: `006-config-cookie-fixes`
+
+**Created**: 2026-06-23
+
+**Status**: Draft
+
+**Input**: Milestone [v1.22.0 — Config & cookies](https://github.com/galax-io/gatling-picatinny/milestone/7): `#93` intensity regex, `randomValue` doc-fix, `#111` Max-Age, cookie discard-attrs (`#207`).
+
+## Overview
+
+A bundle of four correctness defects in the **config**, **utils**, and **cookies/storage** areas of the published Gatling Picatinny library. Each defect causes a load test to either run with the *wrong* configured value, silently lose information, or be described inaccurately to the user. None add new capability — they make existing behavior match what users already expect from the DSL and its documentation.
+
+The four defects are independent and each is shippable on its own; they are grouped only because they target the same v1.22.0 milestone and the same correctness theme.
+
+## Clarifications
+
+### Session 2026-06-23
+
+- Q: US2 cookie restore — what happens to the existing `session.set(name, value)` behavior when wiring cookies into the engine cookie jar? → A: Additive — register the cookie in the Gatling cookie jar **and** keep setting the session attribute (backward-compatible, Constitution II).
+- Q: US2 cookie restore — which parsed cookie attributes must be propagated into the cookie jar? → A: (initial intent) all of them. **Superseded below** by the API-feasibility clarification.
+- Q: US2 cookie restore — given that Gatling's jar-store API (`CookieSupport`) is `private[http]` (uncallable from picatinny) and the public `addCookie` DSL only accepts runtime values for name/value (domain/path/max-age/secure are build-time-fixed), how should cookies be wired into the jar? → A: **Public DSL (safe, partial)** — use the supported `addCookie(Cookie(name, value).withDomain(<restoreCookies domain arg>))` route. Name and value flow at runtime; the cookie is scoped to the `domain` argument with default path `/`. Per-cookie parsed `path`/`max-age`/`secure`/`httpOnly` are **not** propagated. No reflection into Gatling internals; no public API signature change. Rationale: for an outbound (client-sent) cookie only `name=value` is transmitted; `max-age` affects only in-test jar expiry, `secure`/`path` affect attach-matching, and `httpOnly` is meaningless to a sending client — so the practical loss is negligible for load tests.
+- Q: Should the cookie switch/overwrite behavior (re-restoring a cookie of the same name/domain replaces the prior value, revoking the previous role) be a stated requirement or only e2e coverage? → A: **Formalize as requirement** — overwrite-revocation is a guaranteed, published behavioral contract (FR-010), verified by the two-role switching e2e.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Decimal request intensities are honored exactly (Priority: P1)
+
+A performance engineer configures a fractional request intensity (e.g. `0.25 rps`, `12.75 rpm`, `123.55 rph`) via the `intensity` simulation parameter. They expect the load generator to drive exactly the rate they typed.
+
+**Why this priority**: This silently corrupts the *primary purpose* of a load test — the offered load. The number reported and applied differs from what the user configured, with no error. Wrong load → wrong results → invalid conclusions. Highest real-world blast radius of the four.
+
+**Independent Test**: Feed a range of decimal intensity strings through the intensity parser and assert the returned requests-per-second value equals the exact configured value (within floating-point tolerance), including ≥2-digit decimals and a no-unit default case.
+
+**Acceptance Scenarios**:
+
+1. **Given** intensity `"0.25 rps"`, **When** the value is parsed, **Then** the resulting rate is `0.25` rps (not `0.2`).
+2. **Given** intensity `"123.55 rph"`, **When** the value is parsed, **Then** the resulting rate equals `123.55 / 3600` rps (not `123.5 / 3600`).
+3. **Given** intensity `"50 rpm"`, **When** the value is parsed, **Then** the resulting rate equals `50 / 60` rps (whole numbers still work).
+4. **Given** intensity `"10"` with no unit, **When** the value is parsed, **Then** it defaults to `10` rps (default unit preserved).
+5. **Given** a malformed intensity such as `"abc"` or `"1.2.3 rps"`, **When** the value is parsed, **Then** parsing fails with a clear error rather than silently truncating.
+
+---
+
+### User Story 2 - Restored cookies are actually sent on later requests (Priority: P2)
+
+A user captures a `Set-Cookie` response header into a session attribute, then later restores it (via the cookie-restore DSL helper) so that subsequent requests in the same virtual-user flow carry the cookie — for example to resume an authenticated session loaded from storage.
+
+**Why this priority**: Today the restore step parses the full cookie (name, value, domain, path, Max-Age, Secure, HttpOnly) but only copies name/value into a plain session attribute and never registers the cookie with the HTTP engine's cookie jar. As a result the cookie is **not** automatically attached to later requests — the feature does not deliver its core promise. High functional value; ranked below P1 only because intensity corrupts every test while this affects cookie-dependent flows.
+
+**Independent Test**: Restore a cookie for a domain, then make a follow-up request to that domain carrying NO explicit `Cookie` header, and assert via Gatling `check` on the RESPONSE status that the cookie was auto-attached (a WireMock stub matches on the cookie value and returns 200, else 403). The two-role switching e2e (TESTING.md layer 4) further restores a different value for the same cookie name and asserts the prior role is revoked.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session holding a `Set-Cookie` value with a name, value, and `Path`, **When** cookies are restored for the target domain, **Then** a subsequent request to that domain/path automatically includes the cookie.
+2. **Given** a `Set-Cookie` carrying attributes, **When** cookies are restored for the target `domain`, **Then** the cookie is registered in the jar scoped to that domain with default path `/` (via the supported public `addCookie` DSL); per-cookie `path`/`max-age`/`secure`/`httpOnly` are not propagated, and this is acceptable because they do not affect what an outbound load-test cookie transmits.
+3. **Given** a session that does not contain the named `Set-Cookie` attribute, **When** restore runs, **Then** the flow continues unchanged with no error.
+4. **Given** a multi-line `Set-Cookie` value containing several cookies, **When** restore runs, **Then** every well-formed cookie is registered.
+5. **Given** any restored cookie, **When** restore runs, **Then** the cookie's name→value is **also** set as a session attribute (existing behavior retained for backward compatibility), in addition to being registered with the cookie jar.
+6. **Given** a cookie of name `sid` already restored with value A for a domain, **When** a cookie of the same name `sid` is later restored with value B for the same domain, **Then** the jar entry is replaced with value B (the prior value A is revoked), so subsequent requests carry only value B — enabling role switching (e.g. user → admin → user).
+
+---
+
+### User Story 3 - Malformed `Max-Age` is visible, not silent (Priority: P3)
+
+An engineer debugging why a restored cookie has no expiry inspects the logs. A `Set-Cookie` header arrived with a non-numeric `Max-Age` (e.g. `Max-Age=abc`).
+
+**Why this priority**: Observability fix. The cookie still parses (Max-Age simply omitted), so behavior is already safe; the gap is that the user has no signal explaining the missing TTL. Lower urgency than a wrong value, but cheap and prevents silent confusion.
+
+**Independent Test**: Parse a `Set-Cookie` line whose `Max-Age` is non-numeric and assert (a) the cookie is still returned with no max-age set, and (b) a warning is emitted naming the offending value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `Set-Cookie` with `Max-Age=abc`, **When** it is parsed, **Then** the cookie is returned with no max-age **and** a warning is logged that includes the offending value `abc`.
+2. **Given** a `Set-Cookie` with a valid numeric `Max-Age=3600`, **When** it is parsed, **Then** the max-age is set and **no** warning is logged.
+3. **Given** a `Set-Cookie` with no `Max-Age` attribute at all, **When** it is parsed, **Then** the cookie is returned with no max-age and **no** warning is logged (absence is not an error).
+
+---
+
+### User Story 4 - `randomValue` range bounds are documented correctly (Priority: P3)
+
+A developer reading the API documentation for the random-value range generator relies on the stated bounds to decide whether the maximum is a reachable value.
+
+**Why this priority**: Documentation-only correctness. The implementation is correct and must not change (callers depend on current behavior); the published Scaladoc misstates the upper bound as inclusive when it is exclusive. Low risk, but for a published library inaccurate docs are a real defect.
+
+**Independent Test**: Inspect the documentation of the `randomValue` overloads and confirm the upper-bound wording reads "exclusive"; behavior is unchanged and remains covered by existing tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** the range overload `randomValue(min, max)`, **When** a user reads its documentation, **Then** the maximum is described as **exclusive** (returned value is `>= min` and `< max`), matching the implementation.
+2. **Given** the single-bound overload `randomValue(max)`, **When** a user reads its documentation, **Then** the maximum is likewise described as **exclusive**.
+3. **Given** the runtime behavior of `randomValue`, **When** the doc fix is applied, **Then** generated values are unchanged (no behavior change, only wording).
+
+---
+
+### Edge Cases
+
+- **Intensity**: leading/trailing whitespace (`" 0.25 rps "`), unit case-insensitivity (`RPS`/`Rps`), missing unit (default rps), zero or negative values (existing positivity validation still rejects non-positive intensities), and `.5 rps` (leading-dot decimal) — define behavior explicitly rather than truncating.
+- **Cookies**: cookie value containing `=`; empty/blank lines among multiple cookies; attribute keys in mixed case; cookie with no attributes at all; restore invoked when the source attribute is absent or not a string.
+- **Max-Age**: must never throw. Present-but-unparseable values — non-numeric (`abc`), empty (`Max-Age=`), and overflow (beyond `Long`) — yield `maxAge=None` + exactly one WARN. A negative value (`-1`) parses to a valid `Long` (`Some(-1)`) and is silent. Absent is silent.
+- **randomValue**: `min == max` behavior is unchanged (returns `max`); no documentation should imply otherwise.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The intensity parser MUST accept decimal request intensities with an arbitrary number of fractional digits and apply the exact value (no truncation of digits beyond the first decimal place).
+- **FR-002**: The intensity parser MUST continue to support whole-number intensities, the `rps`/`rpm`/`rph` units (case-insensitive), optional surrounding whitespace, and the no-unit default of `rps`.
+- **FR-003**: The intensity parser MUST reject clearly malformed intensity strings with a clear error rather than silently parsing a partial/incorrect value; existing positive-value validation MUST remain in force.
+- **FR-004**: Cookie restoration MUST register restored cookies with the HTTP engine's cookie jar (via the supported public Gatling cookie DSL — `addCookie`/`Cookie`) so they are automatically attached to subsequent requests to the target `domain`. The cookie's `name` and `value` carry at runtime; the cookie is scoped to the `domain` argument with default path `/`. Per-cookie parsed `path`/`max-age`/`secure`/`httpOnly` are NOT propagated (the public DSL fixes these at build time and cannot accept per-cookie runtime values; reflection into Gatling internals is explicitly rejected). Restoration MUST **also** continue to set each cookie's name→value as a session attribute (additive, backward-compatible per Constitution II).
+- **FR-005**: Cookie restoration MUST handle multiple cookies from a multi-line value and MUST be a no-op (no error, flow continues) when the source attribute is missing or not a string.
+- **FR-006**: Cookie parsing MUST emit one warning, including the offending value, when a `Set-Cookie` carries a `Max-Age` that is present but not parseable as a `Long` (non-numeric, empty, or out-of-range/overflow), while still returning the cookie with no max-age set and never throwing.
+- **FR-007**: Cookie parsing MUST NOT warn when `Max-Age` is a valid `Long` (including negative values, which parse successfully) or entirely absent.
+- **FR-008**: The published documentation for the `randomValue` range and single-bound overloads MUST describe the maximum bound as exclusive, consistent with the implementation; the implementation MUST NOT change.
+- **FR-009**: All four fixes MUST preserve backward compatibility of public Scala/Java API signatures and serialized config formats (Constitution II).
+- **FR-010**: Restoring a cookie of the same name and domain as a previously-restored cookie MUST replace the prior jar entry (overwrite-revocation), so only the most recently restored value is sent on subsequent requests to that domain. This makes role switching (restore user → restore admin → restore user) a supported, guaranteed behavior.
+
+### Key Entities *(include if feature involves data)*
+
+- **Intensity value**: a user-supplied rate string (`<number>[ ]<unit?>`) converted to a requests-per-second number; the number may be fractional, the unit is one of rps/rpm/rph (default rps).
+- **Parsed cookie**: name, value, and optional attributes (domain, path, max-age, secure, httpOnly) derived from a `Set-Cookie` line.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of valid decimal intensity inputs parse to their exact configured rate (verified across a parameterized set including ≥2-digit decimals); 0 cases of digit truncation.
+- **SC-002**: A cookie restored via the DSL is present on 100% of subsequent in-flow requests to its target domain in an end-to-end run (auto-attached by the cookie jar, with no explicit `Cookie` header in the request code).
+- **SC-006**: In the two-role switching e2e (8 steps; login+restore = steps 1/4/7, protected calls = steps 2/3/5/6/8), every step returns its expected status — the 5 role-gated protected calls (user phase: admin→403, user→200; admin phase: admin→200, user→403; back-to-user: user→200) plus the 3 login 200s — proving overwrite-revocation; the run passes `global.failedRequests.count.is(0)`.
+- **SC-003**: Every present-but-unparseable `Max-Age` (non-numeric, empty, or overflow) produces exactly one warning naming the value; valid (incl. negative) and absent `Max-Age` produce zero warnings.
+- **SC-004**: The `randomValue` overload documentation states "exclusive" for the maximum and matches observed runtime bounds, with no change to generated values.
+- **SC-005**: All existing unit and example e2e suites remain green, and module coverage stays at or above the project floor (65% statement / 60% branch). No `it`/IntegrationTest sources (Redis/Vault/JDBC) are modified, so the integration suite is out of risk-scope (may be run as an optional full pass).
+
+## Assumptions
+
+- **Cookie restoration is an additive behavior change** (US2, confirmed 2026-06-23): cookies are newly registered with the engine cookie jar via the supported public `addCookie` DSL (name/value at runtime, scoped to the `domain` argument, default path `/`) **and** the existing session-attribute copy of name→value is retained for backward compatibility. This is a DSL behavior addition and warrants the v1.22.0 (minor) version bump.
+- **Per-cookie `path`/`max-age`/`secure`/`httpOnly` are intentionally not propagated** (decided 2026-06-23): the public `addCookie` DSL accepts only `name`/`value` as runtime values; `domain`/`path`/`max-age`/`secure` are build-time-fixed and cannot vary per parsed cookie, and there is no `httpOnly` setter. Reflection into Gatling's `private[http]` `CookieSupport` (the only route to full per-cookie fidelity) is rejected to avoid coupling a published library to Gatling internals across `Provided`-scope versions. The dropped attributes do not affect what an outbound load-test cookie transmits (`max-age` = in-test jar expiry only; `httpOnly` = irrelevant to a sending client).
+- `restoreCookies` keeps its current signature `restoreCookies(setCookieField: String, domain: String): ChainBuilder`; the variable-length runtime cookie list is iterated with Gatling's `foreach` over a session-stored collection so the per-VU cookie count is honored.
+- The intensity fix targets the parser regex only; the public type (`Double`) and method signatures are already correct and unchanged.
+- The `randomValue` fix is documentation-only across all affected overloads (range and single-bound); implementation and tests are untouched apart from any added doc-verifying assertions.
+- The `Max-Age` warning uses the library's existing logging facility (Scala Logging) at WARN level; no new logging dependency is introduced.
+- No Java/Kotlin facade changes are required beyond what delegation already provides; facades stay thin (Constitution I).
+- E2e validation for cookie restoration uses the existing WireMock echo overlay in `examples/` (TESTING.md layer 4); no new test infrastructure is added.
+
+## Out of Scope
+
+- Redesigning the cookie model or parsing/supporting `Set-Cookie` attributes that `CookieParser` does not already extract (SameSite, Expires, Partitioned, etc.).
+- Reflection into Gatling's `private[http]` `CookieSupport` to achieve full per-cookie jar fidelity (`path`/`max-age`/`secure`/`httpOnly`). Explicitly rejected for backward-compat/coupling reasons (see Assumptions).
+- Changing `randomValue` runtime semantics to make the maximum inclusive.
+- Any change to intensity units, the `Double` intensity type, or downstream injection-profile math.
+- Broader cookie-jar/session-storage refactors beyond wiring restored cookies into the jar.

--- a/specs/006-config-cookie-fixes/tasks.md
+++ b/specs/006-config-cookie-fixes/tasks.md
@@ -1,0 +1,189 @@
+---
+description: "Task list for Config & Cookie Correctness Fixes (v1.22.0)"
+---
+
+# Tasks: Config & Cookie Correctness Fixes (v1.22.0)
+
+**Input**: Design documents from `specs/006-config-cookie-fixes/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/public-api.md](contracts/public-api.md), [quickstart.md](quickstart.md)
+
+**Tests**: REQUIRED. Constitution III mandates test-first (TDD): write the failing test before the code (red → green → refactor); assert exact values + ≥1 negative/boundary case; ScalaMock only for leaf deps (none needed here); never mock the Gatling runtime where a real path exists.
+
+**Organization**: Grouped by user story. The four fixes touch independent files (`IntensityConverter`, `SessionStorage`, `CookieParser`, `RandomDataGenerators`) and are independently deliverable. The cookie e2e lives in the existing `examples/.../Debug.scala` (no separate simulation file).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1=decimal intensity, US2=cookie restore/switch, US3=Max-Age WARN, US4=randomValue doc
+
+## Path Conventions
+
+Published Scala library, single project. Core: `src/main/scala/org/galaxio/gatling/`. Tests: `src/test/scala/org/galaxio/gatling/`. E2e overlay: `examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a green baseline before changing anything (so later red tests are meaningful).
+
+- [x] T001 Verify clean baseline from repo root: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` passes on branch `006-config-cookie-fixes` before any change.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. The four fixes are independent (separate source files, no shared new infrastructure, no new dependencies — `scalalogging` is already a main dep, `logback`/`scalacheck` already on the test classpath). All user stories may begin immediately after Phase 1.
+
+**Checkpoint**: No blocking work — proceed to any user story.
+
+---
+
+## Phase 3: User Story 1 - Decimal request intensities honored exactly (Priority: P1) 🎯 MVP
+
+**Goal**: `IntensityConverter` parses arbitrary-precision decimals exactly (`0.25 rps` → `0.25`) and throws clearly on malformed input instead of silently truncating (#93).
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.utils.IntensityConverterTest"` — decimals exact, units/defaults preserved, malformed throws. (Pure-parser fix → unit test only; no e2e.)
+
+### Tests for User Story 1 (write first, must FAIL)
+
+- [x] T002 [P] [US1] Add failing regression cases to `src/test/scala/org/galaxio/gatling/utils/IntensityConverterTest.scala`: assert exact values for `"0.25 rps"`→`0.25`, `"123.55 rph"`→`123.55/3600`, `"1.234567 rpm"`→`1.234567/60`, `"1.5   rps"` (extra inner whitespace)→`1.5`; lock the edge cases T003 implements: `" 0.25 rps "` (leading/trailing whitespace)→`0.25` and `"100 RPS"`/`"50 Rps"` (mixed-case unit)→rps; and negative/boundary cases `an[IllegalArgumentException] thrownBy` for `".5"`, `"1."`, `"1.2.3"`, `"abc"`, `""`. Keep existing `"3600.0 rps"`, `"30"`, `"3600.0 jpeg"` cases green. Also add a ScalaCheck property (SC-001 "100% of valid decimals"): for a generated non-negative decimal `d`, `getIntensityFromString(s"$d rps")` round-trips to exactly `d` (no truncation).
+
+### Implementation for User Story 1
+
+- [x] T003 [US1] Fix the regex in `src/main/scala/org/galaxio/gatling/utils/IntensityConverter.scala`: replace `"""(\d+\.?\d?)\s?(\w+)?"""` + `findAllIn`/`group` with an anchored full-match `"""^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$"""` applied to `intensity.trim` (the explicit `.trim` strips leading/trailing whitespace so `" 0.25 rps "` matches; the anchored `^…$` would otherwise reject it) via a `case pattern(value, unit) =>` extractor, default the unit to `rps` when absent, and make the unit `match` exhaustive with an explicit `case _ => throw new IllegalArgumentException("Simulation param for intensity incorrect")` (preserve that exact message/type from the outer `Try`).
+- [x] T004 [US1] Run `sbt "testOnly org.galaxio.gatling.utils.IntensityConverterTest"` → green; confirm no behavior change for previously-correct inputs and that the malformed cases throw with the preserved message.
+
+**Checkpoint**: US1 fully functional and independently testable (MVP).
+
+---
+
+## Phase 4: User Story 2 - Restored cookies are sent on later requests + role switching (Priority: P2)
+
+**Goal**: `restoreCookies` registers cookies in the Gatling jar (public `addCookie` DSL, name/value at runtime, scoped to `domain`, default path `/`) so they auto-send; keeps the existing `session.set` (additive); re-restoring the same name/domain overwrites (revokes the prior role) (#207, FR-004/005/010).
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.storage.SessionStorageSpec"` (component) and, in `examples/scala-sbt-example`, `sbt "Gatling/testOnly org.galaxio.performance.picatinny.Debug"` (e2e auto-send + switching, added to the existing Debug simulation).
+
+### Tests for User Story 2 (write first, must FAIL)
+
+- [x] T005 [P] [US2] Add a DSL/action-component test to `src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala` driving `restoreCookies` via the `transactions/Mocks` ActorSystem harness against a real `Session`: assert (a) a single `Set-Cookie` sets the cookie name→value session attribute (exact value, backward compat / FR-005); (b) a multi-line two-cookie value sets both; (c) no-op when the source attribute is absent (session passes through, no error).
+- [x] T006 [US2] Add the cookie WireMock stubs to the existing `examples/scala-sbt-example/src/test/scala/org/galaxio/performance/picatinny/Debug.scala` server setup: `GET /login/user` and `GET /login/admin` returning the raw Set-Cookie string in the response **body** (e.g. `{"cookie":"sid=user-secret; Path=/"}` / `...admin-secret...`), NOT as a `Set-Cookie` header (so Gatling does not auto-capture — only `restoreCookies` injects); and protected `GET /admin/data` / `GET /user/data` matched on cookie value (`withCookie("sid", equalTo("admin-secret"|"user-secret"))` → 200, lower-priority catch-all for the same path → 403).
+- [x] T007 [US2] Add the 8-step cookie-switch scenario (5 role-gated status checks) to `Debug.scala` and wire it into the simulation's `setUp` (its own scenario at `atOnceUsers(1)`, or appended to the Debug flow): **(1)** login user → save body cookie → `restoreCookies(field, "localhost")`; **(2)** `GET /admin/data` `check(status.is(403))`; **(3)** `GET /user/data` `check(status.is(200))`; **(4)** login admin → `restoreCookies`; **(5)** `/admin/data`(200); **(6)** `/user/data`(403); **(7)** login user → `restoreCookies`; **(8)** `/user/data`(200). Each protected request carries NO explicit `Cookie` header. This must FAIL before T008 and is gated by the existing `.assertions(global.failedRequests.count.is(0))`. (Depends on T006.)
+
+### Implementation for User Story 2
+
+- [x] T008 [US2] Restructure `restoreCookies` in `src/main/scala/org/galaxio/gatling/storage/SessionStorage.scala`: in the `exec { session => }` block, parse the raw `Set-Cookie` via `CookieParser.parse(raw, domain)`, keep `session.set(name, value)` for each cookie (compat), and store the parsed name/value list under a collision-free private session attribute; then `.foreach("#{<thatKey>}", "cookie") { exec(addCookie(Cookie("#{cookie.name}", "#{cookie.value}").withDomain(domain))) }`. Keep the method signature `restoreCookies(setCookieField: String, domain: String): ChainBuilder` unchanged; import `io.gatling.http.Predef.{addCookie, Cookie}`. No-op path: empty/missing source attribute → empty list → `foreach` iterates nothing.
+
+### Verification for User Story 2
+
+- [x] T009 [US2] Run `sbt "testOnly org.galaxio.gatling.storage.SessionStorageSpec"` → green (FR-005, session.set retained, no-op).
+- [x] T010 [US2] From `examples/scala-sbt-example` (after `sbt publishLocal` of the library or `PICATINNY_VERSION` set): run `sbt "Gatling/testOnly org.galaxio.performance.picatinny.Debug"` → green; confirm all 8 steps return their expected status — the 5 role-gated protected calls (steps 2,3,5,6,8) plus the 3 login 200s (steps 1,4,7) (FR-004 auto-send + FR-010 overwrite-revocation).
+
+**Checkpoint**: US2 works independently — cookies auto-send and role switching revokes the prior cookie.
+
+---
+
+## Phase 5: User Story 3 - Malformed `Max-Age` is visible, not silent (Priority: P3)
+
+**Goal**: `CookieParser` logs a WARN naming the offending value when `Max-Age` is present but non-numeric, while still returning `maxAge = None`; valid/absent `Max-Age` stays silent (#111, FR-006/007).
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.storage.CookieParserSpec"` — value + WARN assertions.
+
+### Tests for User Story 3 (write first, must FAIL)
+
+- [x] T011 [P] [US3] Add failing cases to `src/test/scala/org/galaxio/gatling/storage/CookieParserSpec.scala` using the repo's Logback `ListAppender` `captureWarns` idiom (from `AssertionsBuilderSpec.scala:46-59`, logger name `org.galaxio.gatling.storage`). Rule under test: **`max-age` present AND not parseable as `Long` → `maxAge = None` + exactly one WARN naming the value; absent → `None`, silent; parseable (incl. negative) → `Some`, silent.** Cases: (a) `Max-Age=abc` → `None` + 1 WARN containing `abc`; (b) `Max-Age=3600` → `Some(3600L)`, 0 WARNs; (c) absent `Max-Age` → `None`, 0 WARNs; (d) empty `Max-Age=` → `None` + 1 WARN (present but unparseable); (e) negative `Max-Age=-1` → `Some(-1L)`, 0 WARNs (valid `Long`, no throw); (f) overflow `Max-Age=99999999999999999999` → `None` + 1 WARN (unparseable, no throw).
+
+### Implementation for User Story 3
+
+- [x] T012 [US3] In `src/main/scala/org/galaxio/gatling/storage/CookieParser.scala`: `import com.typesafe.scalalogging.StrictLogging`, change `object CookieParser {` to `object CookieParser extends StrictLogging {`, and split the `max-age` handling (currently `attrs.get("max-age").flatMap(_.toLongOption)`) into: key absent → `None`, no log; key present and `toLongOption` succeeds (incl. negative) → `Some`, no log; key present and `toLongOption` is `None` (non-numeric, empty, or overflow) → `None` + `logger.warn(...)` naming the offending raw value. Never throw.
+- [x] T013 [US3] Run `sbt "testOnly org.galaxio.gatling.storage.CookieParserSpec"` → green; confirm the existing attribute cases (`c.maxAge shouldBe Some(3600L)`) still pass.
+
+**Checkpoint**: US3 works independently — bad Max-Age is observable, return shape unchanged.
+
+---
+
+## Phase 6: User Story 4 - `randomValue` range bounds documented correctly (Priority: P3)
+
+**Goal**: Fix the Scaladoc for `randomValue(min, max)` and `randomValue(max)` to state the maximum is **exclusive** (matches the implementation). Doc-only; no behavior change (#207, FR-008).
+
+**Independent Test**: existing `sbt "testOnly org.galaxio.gatling.utils.RandomDataGeneratorsTest"` stays green (behavior guard); doc reads "exclusive".
+
+### Implementation for User Story 4
+
+- [x] T014 [US4] In `src/main/scala/org/galaxio/gatling/utils/RandomDataGenerators.scala`, edit the Scaladoc only: change the `randomValue(min, max)` `@param max` / `@return` wording from "inclusive" to "exclusive" (returned value `>= min` and `< max`), and the single-bound `randomValue(max)` wording from "less than or equal to max" to "less than max (exclusive)". Do not touch any implementation.
+- [x] T015 [US4] Run `sbt "testOnly org.galaxio.gatling.utils.RandomDataGeneratorsTest"` → green (confirms no behavior change; existing property checks already assert `[min, max)`).
+
+**Checkpoint**: US4 complete — docs match runtime, zero behavior change.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Backward-compat guard, formatting, coverage, and full validation across all stories.
+
+- [x] T016 [P] Release notes are generated by git-cliff from conventional-commit messages (per AGENTS.md) — no manual CHANGELOG file to edit. Ensure each commit is semantic (`fix(config):`, `fix(storage):`, `feat(storage):` for the additive cookie-jar behavior, `docs(utils):` for randomValue) so the generated notes are correct. Update any human-facing usage docs only if `restoreCookies` is documented outside Scaladoc.
+- [x] T017 Confirm backward compatibility (FR-009): public signatures unchanged — `IntensityConverter.getIntensityFromString: Double`, `SessionStorage.restoreCookies(String, String): ChainBuilder`, `ParsedCookie` shape, `SimulationConfig.intensity: Double`; Java facade delegations (`javaapi/utils/IntensityConverter`, `javaapi/SimulationConfig`) still compile and delegate (no facade edits).
+- [x] T018 Run `sbt scalafmtAll scalafmtSbt` then the full CI gate `sbt scalafmtCheckAll scalafmtSbtCheck compile test` → green.
+- [x] T019 Run `sbt clean coverage test coverageReport` → statement ≥ 65%, branch ≥ 60% (no regression).
+- [x] T020 Run the full [quickstart.md](quickstart.md) validation (all FRs incl. the `examples/scala-sbt-example` `Gatling/test` Debug e2e) end to end. Note (SC-005): no `it`/`IntegrationTest` sources (Redis/Vault/JDBC) are modified, so the integration suite is out of risk-scope; run `sbt "IntegrationTest / test"` only as an optional belt-and-suspenders pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately.
+- **Foundational (Phase 2)**: empty (no blocking work).
+- **User Stories (Phase 3–6)**: each depends only on Phase 1; all four are mutually independent (separate files) and may run in parallel.
+- **Polish (Phase 7)**: after the user stories targeted for the release are done.
+
+### User Story Dependencies
+
+- **US1 (P1)**, **US2 (P2)**, **US3 (P3)**, **US4 (P3)**: independent. US2's e2e uses `CookieParser.parse` (existing behavior) but does not depend on US3's WARN change. (US2's Debug.scala stubs/scenario and US3's `CookieParserSpec` touch different files.)
+
+### Within Each User Story
+
+- Tests written and FAILING before implementation (TDD, Constitution III).
+- US1: T002 → T003 → T004. US2: (T005 [P], T006 → T007) → T008 → (T009, T010). US3: T011 → T012 → T013. US4: T014 → T015.
+
+### Parallel Opportunities
+
+- After T001, all four stories can proceed in parallel (different files).
+- US2: the component test T005 is parallel with the Debug e2e tasks T006/T007 (different files); T011 (US3), T002 (US1), T014 (US4) are all parallel with each other and with US2.
+
+---
+
+## Parallel Example: kick off all stories after setup
+
+```bash
+# After T001 baseline is green, these failing-test tasks touch different files and can start together:
+Task T002 [US1]: decimal/malformed cases in IntensityConverterTest.scala
+Task T005 [US2]: restoreCookies component test in SessionStorageSpec.scala
+Task T011 [US3]: Max-Age WARN cases in CookieParserSpec.scala
+Task T014 [US4]: randomValue scaladoc fix in RandomDataGenerators.scala
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 (T001 baseline green).
+2. Phase 3 (US1): T002 (red) → T003 (fix) → T004 (green). Ship #93 alone if desired.
+
+### Incremental Delivery
+
+US1 (#93) → US3 (#111) → US4 (randomValue doc) → US2 (#207 cookie restore/switch, the largest). Each is an independent, green, semantic commit. All land on `main` via PR, then v1.22.0 is cut as `release/1.22.0` (MINOR — additive cookie behavior).
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies.
+- No new dependencies; Gatling stays `Provided`.
+- US2 cookie e2e lives in the existing `Debug.scala` (per 2026-06-23 decision) — no separate simulation file; the `SessionStorageSpec` component unit test is kept.
+- US2 uses the supported public `addCookie` DSL only — no reflection into Gatling internals; per-cookie `path`/`max-age`/`secure`/`httpOnly` intentionally not propagated.
+- e2e assertions are Gatling `check` on responses only — never `WireMock.verify`, never re-decode the request (TESTING.md layer 4).
+- Commit after each task or logical group; keep the build green at every commit.

--- a/src/main/scala/org/galaxio/gatling/storage/CookieParser.scala
+++ b/src/main/scala/org/galaxio/gatling/storage/CookieParser.scala
@@ -1,5 +1,7 @@
 package org.galaxio.gatling.storage
 
+import com.typesafe.scalalogging.StrictLogging
+
 final case class ParsedCookie(
     name: String,
     value: String,
@@ -10,7 +12,7 @@ final case class ParsedCookie(
     httpOnly: Boolean = false,
 )
 
-object CookieParser {
+object CookieParser extends StrictLogging {
 
   def parse(rawSetCookie: String, defaultDomain: String): Seq[ParsedCookie] =
     rawSetCookie.split("\n").toSeq.flatMap(parseSingle(_, defaultDomain))
@@ -34,7 +36,12 @@ object CookieParser {
         value = nameValue(1).trim,
         domain = attrs.get("domain").orElse(Some(defaultDomain)),
         path = attrs.get("path"),
-        maxAge = attrs.get("max-age").flatMap(_.toLongOption),
+        maxAge = attrs.get("max-age").flatMap { raw =>
+          val parsed = raw.toLongOption
+          if (parsed.isEmpty)
+            logger.warn(s"Ignoring unparseable Max-Age value '$raw' for cookie '${nameValue(0).trim}' (expected a Long)")
+          parsed
+        },
         secure = attrs.contains("secure"),
         httpOnly = attrs.contains("httponly"),
       ),

--- a/src/main/scala/org/galaxio/gatling/storage/SessionStorage.scala
+++ b/src/main/scala/org/galaxio/gatling/storage/SessionStorage.scala
@@ -2,6 +2,7 @@ package org.galaxio.gatling.storage
 
 import io.gatling.core.Predef._
 import io.gatling.core.feeder.Record
+import io.gatling.core.session.Session
 import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
 
@@ -58,20 +59,43 @@ final class SessionStorage(
 
   // --- Cookie injection ---
 
-  def restoreCookies(setCookieField: String, domain: String): ChainBuilder = exec { session =>
-    session.attributes.get(setCookieField) match {
-      case Some(rawCookie: String) =>
-        val parsed = CookieParser.parse(rawCookie, domain)
-        parsed.foldLeft(session) { (s, cookie) =>
-          s.set(cookie.name, cookie.value)
-        }
-      case _                       => session
+  /** Parse the raw Set-Cookie value from `setCookieField` and (a) set each cookie's name -> value as a session attribute
+    * (backward-compatible with the original behavior) and (b) stash the name/value pairs under
+    * [[SessionStorage.restoreCookiesAttr]] so the `foreach` in [[restoreCookies]] can register each cookie in the Gatling
+    * cookie jar. No-op (only the empty stash is added) when the field is absent or not a String.
+    */
+  private[storage] def restoreCookiesIntoSession(setCookieField: String, domain: String)(session: Session): Session = {
+    val parsed         = session.attributes.get(setCookieField) match {
+      case Some(rawCookie: String) => CookieParser.parse(rawCookie, domain)
+      case _                       => Seq.empty[ParsedCookie]
     }
+    val withAttributes = parsed.foldLeft(session)((s, cookie) => s.set(cookie.name, cookie.value))
+    withAttributes.set(
+      SessionStorage.restoreCookiesAttr,
+      parsed.map(c => Map("name" -> c.name, "value" -> c.value)).toList,
+    )
   }
+
+  /** Restore cookies captured in `setCookieField` into the Gatling cookie jar so they are auto-attached to subsequent requests
+    * to `domain`. Cookies are registered via the supported public `addCookie` DSL (name/value at runtime, scoped to `domain`,
+    * default path `/`); per-cookie path/max-age/secure/httpOnly are not propagated. Re-restoring a cookie of the same
+    * name/domain overwrites the prior value (role switching). Each cookie's name -> value is also kept as a session attribute
+    * for backward compatibility.
+    */
+  def restoreCookies(setCookieField: String, domain: String): ChainBuilder =
+    exec(session => restoreCookiesIntoSession(setCookieField, domain)(session))
+      .foreach(s"#{${SessionStorage.restoreCookiesAttr}}", "cookie") {
+        exec(addCookie(Cookie("#{cookie.name}", "#{cookie.value}").withDomain(domain)))
+      }
+      // Drop the internal stash so it cannot leak into `saveAll`/`persist` records or downstream feeders.
+      .exec(_.remove(SessionStorage.restoreCookiesAttr))
 
 }
 
 object SessionStorage {
+  // Internal session key holding parsed name/value pairs for the cookie-restore `foreach` (collision-free).
+  private[storage] val restoreCookiesAttr = "__picatinny_restore_cookies"
+
   def apply(): SessionStorage                        = new SessionStorage()
   def apply(backend: StorageBackend): SessionStorage = new SessionStorage(Some(backend))
 }

--- a/src/main/scala/org/galaxio/gatling/utils/IntensityConverter.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/IntensityConverter.scala
@@ -1,7 +1,5 @@
 package org.galaxio.gatling.utils
 
-import scala.util.Try
-
 object IntensityConverter {
 
   // implicit conversions to rps
@@ -13,20 +11,48 @@ object IntensityConverter {
     def rps: Double = count
   }
 
-  def getIntensityFromString(intensity: String): Double = {
-    val pattern = """(\d+\.?\d?)\s?(\w+)?""".r
+  // Anchored full-match: arbitrary-precision decimal + optional alphabetic unit. The anchors reject
+  // partial/garbage input (".5", "1.", "1.2.3", "abc", "-5") instead of silently truncating it (issue #93).
+  private val pattern = """^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$""".r
 
-    Try {
-      val matcher        = pattern.findAllIn(intensity)
-      val intensityValue = matcher.group(1).toDouble
-      val intensityParam = Try(matcher.group(2).toLowerCase).getOrElse("rps")
-      intensityParam match {
-        case "rps" => intensityValue rps
-        case "rpm" => intensityValue rpm
-        case "rph" => intensityValue rph
-      }
-    }.getOrElse {
-      throw new IllegalArgumentException("Simulation param for intensity incorrect")
+  // Each step is a total function that builds its `Either` directly (no `Option`->`Either` conversion): a guard, a regex
+  // extractor, `Either.cond`, and a unit match. The for-comprehension just composes them.
+
+  private def trimmedInput(s: String): Either[String, String] =
+    if (s == null) Left("input is null") else Right(s.trim)
+
+  private def split(s: String): Either[String, (String, String)] =
+    s match {
+      case pattern(number, unit) => Right((number, unit))
+      case garbage               => Left(s"not a '<number>[ unit]' value: '$garbage'")
     }
+
+  private def toFinite(number: String): Either[String, Double] = {
+    val value = number.toDouble // the regex guarantees a parseable number
+    Either.cond(value.isFinite, value, s"value out of range: '$number'")
   }
+
+  private def toPerSecond(value: Double, rawUnit: String): Either[String, Double] =
+    Option(rawUnit).map(_.toLowerCase).getOrElse("rps") match {
+      case "rps" => Right(value)
+      case "rpm" => Right(value / 60)
+      case "rph" => Right(value / 3600)
+      case unit  => Left(s"unsupported unit '$unit' (use rps, rpm or rph)")
+    }
+
+  /** Parse a `"<number>[ unit]"` intensity into requests-per-second by composing the steps above. The only
+    * `IllegalArgumentException` is raised at the boundary — keeping the documented `"Simulation param for intensity incorrect"`
+    * prefix and appending the specific cause. Rejected: null input, malformed/garbage strings, an out-of-range (non-finite)
+    * value, and unsupported units. A missing unit defaults to `rps`.
+    */
+  def getIntensityFromString(intensity: String): Double =
+    (for {
+      trimmed    <- trimmedInput(intensity)
+      numAndUnit <- split(trimmed)
+      value      <- toFinite(numAndUnit._1)
+      perSecond  <- toPerSecond(value, numAndUnit._2)
+    } yield perSecond).fold(
+      reason => throw new IllegalArgumentException(s"Simulation param for intensity incorrect: $reason"),
+      identity,
+    )
 }

--- a/src/main/scala/org/galaxio/gatling/utils/RandomDataGenerators.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/RandomDataGenerators.scala
@@ -128,11 +128,11 @@ object RandomDataGenerators {
   /** Generates a random value of type `T` within the specified upper bound.
     *
     * @param max
-    *   the maximum value for the random generation
+    *   the exclusive upper bound for the random generation
     * @param rng
     *   an implicit `RandomProvider` instance used to generate the random value
     * @return
-    *   a randomly generated value of type `T` that is less than or equal to `max`
+    *   a randomly generated value of type `T` that is strictly less than `max` (max exclusive)
     */
   def randomValue[T](max: T)(implicit rng: RandomProvider[T]): T = rng.random(max)
 
@@ -141,13 +141,14 @@ object RandomDataGenerators {
     * @param min
     *   the minimum value of the range (inclusive)
     * @param max
-    *   the maximum value of the range (inclusive)
+    *   the maximum value of the range (exclusive)
     * @param rng
     *   an implicit RandomProvider to generate random values of type T
     * @param ord
     *   an implicit Ordering to compare the minimum and maximum values
     * @return
-    *   a randomly generated value of type T within the specified range
+    *   a randomly generated value of type T within the range `[min, max)` (min inclusive, max exclusive); returns `max` only in
+    *   the degenerate `min == max` case
     * @throws java.lang.IllegalArgumentException
     *   if the minimum value is not less than the maximum value
     */

--- a/src/test/scala/org/galaxio/gatling/storage/CookieParserSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/CookieParserSpec.scala
@@ -1,9 +1,38 @@
 package org.galaxio.gatling.storage
 
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
+import ch.qos.logback.core.AppenderBase
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
 
 class CookieParserSpec extends AnyWordSpec with Matchers {
+
+  /** Capture WARN messages under the `org.galaxio.gatling.storage` logger while `body` runs. Uses a thread-safe queue-backed
+    * appender so events propagated from sibling storage classes (exercised by other suites running in parallel) cannot corrupt
+    * the capture; results are content-filtered to CookieParser's own Max-Age warnings.
+    */
+  private def captureWarns(body: => Unit): List[String] = {
+    val logger   = LoggerFactory.getLogger("org.galaxio.gatling.storage").asInstanceOf[LogbackLogger]
+    val events   = new ConcurrentLinkedQueue[ILoggingEvent]()
+    val appender = new AppenderBase[ILoggingEvent] {
+      override def append(e: ILoggingEvent): Unit = events.add(e)
+    }
+    appender.start()
+    val prev     = logger.getLevel
+    logger.setLevel(Level.WARN)
+    logger.addAppender(appender)
+    try body
+    finally {
+      logger.detachAppender(appender)
+      logger.setLevel(prev)
+    }
+    events.asScala.toList.filter(_.getLevel == Level.WARN).map(_.getFormattedMessage)
+  }
 
   "CookieParser" should {
 
@@ -58,6 +87,57 @@ class CookieParserSpec extends AnyWordSpec with Matchers {
     "use default domain when Domain attribute missing" in {
       val result = CookieParser.parse("x=1", "default.com")
       result.head.domain shouldBe Some("default.com")
+    }
+
+    // Issue #111: a present-but-unparseable Max-Age yields None AND a single WARN naming the value.
+    // Assertions filter on the "Max-Age" marker so they stay deterministic even if other suites log
+    // under the shared `org.galaxio.gatling.storage` logger during parallel execution.
+    "warn and drop a non-numeric Max-Age" in {
+      val warns = captureWarns {
+        val result = CookieParser.parse("sid=x; Max-Age=abc", "example.com")
+        result.head.maxAge shouldBe None
+      }
+      warns.count(w => w.contains("Max-Age") && w.contains("abc")) shouldBe 1
+    }
+
+    "warn and drop an empty Max-Age" in {
+      val warns = captureWarns {
+        val result = CookieParser.parse("sid=x; Max-Age=", "example.com")
+        result.head.maxAge shouldBe None
+      }
+      warns.count(w => w.contains("Max-Age") && w.contains("value ''")) shouldBe 1
+    }
+
+    "warn and drop an overflowing Max-Age" in {
+      val warns = captureWarns {
+        val result = CookieParser.parse("sid=x; Max-Age=99999999999999999999", "example.com")
+        result.head.maxAge shouldBe None
+      }
+      warns.count(_.contains("99999999999999999999")) shouldBe 1
+    }
+
+    "accept a valid Max-Age without warning" in {
+      val warns = captureWarns {
+        val result = CookieParser.parse("sid=x; Max-Age=3600", "example.com")
+        result.head.maxAge shouldBe Some(3600L)
+      }
+      warns.count(_.contains("Max-Age")) shouldBe 0
+    }
+
+    "accept a negative Max-Age without warning" in {
+      val warns = captureWarns {
+        val result = CookieParser.parse("sid=x; Max-Age=-1", "example.com")
+        result.head.maxAge shouldBe Some(-1L)
+      }
+      warns.count(_.contains("Max-Age")) shouldBe 0
+    }
+
+    "not warn when Max-Age is absent" in {
+      val warns = captureWarns {
+        val result = CookieParser.parse("sid=x; Path=/", "example.com")
+        result.head.maxAge shouldBe None
+      }
+      warns.count(_.contains("Max-Age")) shouldBe 0
     }
 
   }

--- a/src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/SessionStorageSpec.scala
@@ -1,6 +1,7 @@
 package org.galaxio.gatling.storage
 
 import io.gatling.core.feeder.Record
+import org.galaxio.gatling.transactions.fixtures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -89,6 +90,41 @@ class SessionStorageSpec extends AnyWordSpec with Matchers {
       val withBe  = storage.withBackend(JsonFileBackend(tmpFile.getAbsolutePath))
       withBe.size shouldBe 1
       withBe.toFeeder.head("key") shouldBe "value"
+    }
+
+    // --- restoreCookies session-attribute behavior (FR-004/005, component layer) ---
+
+    "restoreCookies sets each cookie name -> value as a session attribute" in {
+      val session = fixtures.emptySession("cookie").set("raw", "sid=abc123; Path=/")
+      val result  = SessionStorage().restoreCookiesIntoSession("raw", "localhost")(session)
+      result.attributes("sid") shouldBe "abc123"
+    }
+
+    "restoreCookies handles multiple cookies from a multi-line value" in {
+      val session = fixtures.emptySession("cookie").set("raw", "a=1; Path=/\nb=2; Secure")
+      val result  = SessionStorage().restoreCookiesIntoSession("raw", "localhost")(session)
+      result.attributes("a") shouldBe "1"
+      result.attributes("b") shouldBe "2"
+    }
+
+    "restoreCookies is a no-op when the source attribute is absent" in {
+      val session = fixtures.emptySession("cookie")
+      val result  = SessionStorage().restoreCookiesIntoSession("missing", "localhost")(session)
+      result.attributes.get("missing") shouldBe None
+      result.attributes.keySet should not contain "sid"
+    }
+
+    // Regression: the internal stash key must be namespaced and dropped at the end of the chain so it
+    // cannot leak into saveAll/persist records. `restoreCookies` appends `.exec(_.remove(restoreCookiesAttr))`
+    // after the foreach; this test mirrors that final step's net effect on the key.
+    "restoreCookies does not leak its internal stash key into the session" in {
+      SessionStorage.restoreCookiesAttr should startWith("__picatinny")
+      val seeded = fixtures.emptySession("cookie").set("raw", "sid=abc123; Path=/")
+      val mid    = SessionStorage().restoreCookiesIntoSession("raw", "localhost")(seeded)
+      mid.attributes.keySet should contain(SessionStorage.restoreCookiesAttr) // stashed for the foreach
+      val cleaned = mid.remove(SessionStorage.restoreCookiesAttr) // what the chain's final exec does
+      cleaned.attributes.keySet should not contain SessionStorage.restoreCookiesAttr
+      cleaned.attributes("sid") shouldBe "abc123" // cookie attr still present
     }
 
     "withBackend keeps record queues independent after copying" in {

--- a/src/test/scala/org/galaxio/gatling/utils/IntensityConverterTest.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/IntensityConverterTest.scala
@@ -45,5 +45,49 @@ class IntensityConverterTest extends AnyWordSpec with Matchers with ScalaCheckDr
         getIntensityFromString("3600.0 jpeg")
       }
     }
+
+    // Issue #93: multi-digit decimals must NOT be truncated.
+    "preserve arbitrary-precision decimals (regression for #93)" in {
+      getIntensityFromString("0.25 rps") shouldBe 0.25
+      getIntensityFromString("123.55 rph") shouldBe 123.55 / 3600.0
+      getIntensityFromString("1.234567 rpm") shouldBe 1.234567 / 60.0
+    }
+
+    "tolerate extra inner whitespace between value and unit" in {
+      getIntensityFromString("1.5   rps") shouldBe 1.5
+    }
+
+    "trim leading and trailing whitespace" in {
+      getIntensityFromString(" 0.25 rps ") shouldBe 0.25
+    }
+
+    "accept units case-insensitively" in {
+      getIntensityFromString("100 RPS") shouldBe 100.0
+      getIntensityFromString("50 Rps") shouldBe 50.0
+    }
+
+    "reject malformed intensities instead of silently truncating" in {
+      Seq(".5", "1.", "1.2.3", "abc", "", "-5").foreach { bad =>
+        withClue(s"input '$bad': ") {
+          an[IllegalArgumentException] shouldBe thrownBy(getIntensityFromString(bad))
+        }
+      }
+    }
+
+    "reject null input" in {
+      an[IllegalArgumentException] shouldBe thrownBy(getIntensityFromString(null))
+    }
+
+    "reject out-of-range values that overflow to a non-finite Double" in {
+      an[IllegalArgumentException] shouldBe thrownBy(getIntensityFromString(("9" * 400) + " rps"))
+    }
+
+    // SC-001: 100% of valid decimal inputs round-trip exactly (no truncation).
+    "round-trip every generated decimal exactly" in {
+      forAll(Gen.chooseNum(0L, 1_000_000L), Gen.chooseNum(0, 999_999)) { (whole, frac) =>
+        val s = s"$whole.$frac"
+        getIntensityFromString(s"$s rps") shouldBe s.toDouble
+      }
+    }
   }
 }


### PR DESCRIPTION
Milestone [v1.22.0 — Config & cookies](https://github.com/galax-io/gatling-picatinny/milestone/7). Four independent correctness fixes.

## Fixes
- **[#93](https://github.com/galax-io/gatling-picatinny/issues/93) — decimal intensity truncation** (`IntensityConverter`): anchored full-match regex parses arbitrary-precision decimals exactly (`0.25 rps` → `0.25`); malformed/null/overflow input throws a clear `IllegalArgumentException` with a specific cause instead of silently truncating.
- **[#111](https://github.com/galax-io/gatling-picatinny/issues/111) — silent Max-Age** (`CookieParser`): one WARN naming the offending value when `Max-Age` is present but unparseable (non-numeric/empty/overflow); valid (incl. negative) or absent stays silent. Return shape unchanged.
- **[#207](https://github.com/galax-io/gatling-picatinny/issues/207) — cookie discard** (`SessionStorage.restoreCookies`): now registers cookies in the Gatling cookie jar via the supported public `addCookie` DSL so they auto-send; re-restoring the same name/domain overwrites (role switching). Existing `session.set` retained (additive); internal stash removed after the loop. Signature unchanged.
- **[#207](https://github.com/galax-io/gatling-picatinny/issues/207) — randomValue doc** (`RandomDataGenerators`): scaladoc corrected to state the maximum is exclusive (`[min, max)`); no behavior change.

## Compatibility
No public Scala/Java signature changes; `ParsedCookie` shape and `toRps` DSL unchanged. The cookie-jar registration is an **additive** DSL behavior addition → MINOR (v1.22.0). One behavior delta: negative intensity input (`"-5"`) now throws instead of silently yielding `5` (`requirePositive` already rejected it downstream).

## Testing
- Full gate green: **810 tests** (ScalaTest + JUnit facade), fmt + compile clean.
- Coverage: **stmt 70.31% / branch 67.35%** (≥ floor 65/60).
- Two-role (user/admin) cookie-switch **e2e** in the `scala-sbt` example Debug simulation — proves auto-send + overwrite-revocation via response-status `check` (WireMock echo overlay; no `verify`/request re-decode).

Spec-kit artifacts under `specs/006-config-cookie-fixes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)