### PR TITLE
feat(security): central secret masking & leak prevention (v1.23.0)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/006-config-cookie-fixes"
+  "feature_directory": "specs/007-secret-masking-leak-prevention"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 @AGENTS.md
 
 <!-- SPECKIT START -->
-Active plan: [specs/006-config-cookie-fixes/plan.md](specs/006-config-cookie-fixes/plan.md)
+Active plan: [specs/007-secret-masking-leak-prevention/plan.md](specs/007-secret-masking-leak-prevention/plan.md)
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -278,13 +278,20 @@ Workload defaults are validated when they are first read:
 - `rampDuration` must be `0` or greater
 - `stageDuration` and `testDuration` must be greater than `0`
 
-Config values are logged when they are read. Paths containing words like `password`, `secret`, `token`, `apiKey`, or
-`credential` are masked in logs as `******`.
+Config values are logged when they are read. Keys whose last path segment is a sensitive term (`password`, `secret`,
+`token`, `apiKey`, `clientSecret`, `bearer`, `authorization`, `credentials`, …, plus separator-less forms like
+`dbpassword`) are masked as `******`; benign keys (`roleId`, `tokenBucketSize`) stay visible. You can add your own terms
+via `picatinny.redaction.additionalSensitiveKeys`. Full behavior, the recommended `logback.xml`, and upgrade notes are in
+[docs/logging.md](docs/logging.md).
 
 ### startup banner and diagnostics
 
 Picatinny provides explicit utility methods for startup output. Put them where it makes sense for your project: in a
 simulation class, a shared package object, or another project bootstrap point.
+
+> **Since 1.23.0** the banner and diagnostics go through **SLF4J** (logger `org.galaxio.gatling.diagnostics`), not
+> `println`/`stdout`, and Picatinny ships no `logback.xml`. With no logging config the banner may be filtered by your
+> backend's default level — see [docs/logging.md](docs/logging.md) for the recommended config that renders it prefix-free.
 
 Default behavior:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,277 @@
+# Logging & Secret Masking
+
+## Contents
+
+- [Recommended configuration](#recommended-configuration)
+- [Overriding / suppressing output](#overriding--suppressing-output)
+- [Secret masking](#secret-masking)
+  - [Adding project-specific sensitive keys](#adding-project-specific-sensitive-keys)
+- [Migration — upgrading to 1.23.0](#migration--upgrading-to-1230)
+- [Startup banner & diagnostics (usage)](#startup-banner--diagnostics-usage)
+
+Picatinny logs through **SLF4J** (via `scala-logging`). It deliberately ships **no** `logback.xml` on its
+main/compile classpath — a published library must not impose a logging backend or auto-discovered config on
+consumers (it would collide with your own `logback.xml`, "Resource [logback.xml] occurs multiple times on the
+classpath", with non-deterministic first-match wins). You stay in full control of logging configuration.
+
+## Recommended configuration
+
+Picatinny's startup banner and diagnostics are emitted through SLF4J as a **single log event** per block, under the
+logger category `org.galaxio.gatling.diagnostics`. To keep the ASCII banner aligned (no per-line timestamp/level
+prefix) while keeping ordinary logs prefixed, bind that category to a bare `%msg%n` appender with
+`additivity="false"`.
+
+Copy this into your project's `src/test/resources/logback.xml` (Gatling simulations run in the test scope):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{20} - %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Banner/diagnostics: prefix-free, single event, suppressible by level. -->
+    <appender name="BANNER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.galaxio.gatling.diagnostics" level="INFO" additivity="false">
+        <appender-ref ref="BANNER"/>
+    </logger>
+
+    <root level="ERROR">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>
+```
+
+The canonical, runnable copy of this file lives in the example overlay:
+[`examples/scala-sbt-example/src/test/resources/logback.xml`](../examples/scala-sbt-example/src/test/resources/logback.xml).
+
+## Overriding / suppressing output
+
+- **Turn the banner / diagnostics on or off — the canonical way:** the Picatinny flags
+  `picatinny.startup.banner.enabled` (default `true`) and `picatinny.diagnostics.enabled` (default `false`), set in
+  `simulation.conf` or overridden with `-Dpicatinny.startup.banner.enabled=false`. Use these — not the logging level — to
+  toggle output.
+- **Backend-level control (only if you don't own the simulation config):** set the `org.galaxio.gatling.diagnostics`
+  logger level (`INFO` shows, `OFF`/`WARN` hides), or point at another file with `-Dlogback.configurationFile=…`. A
+  `logback-test.xml` on the test classpath wins over `logback.xml`.
+
+## Secret masking
+
+Picatinny redacts secrets at every log/print/exception sink. A value is masked when its key's **last path segment**
+matches a sensitive term (whole-word / suffix-run match, not raw substring): `password`, `secret`, `token`,
+`apiKey`, `clientSecret`, `bearer`, `authorization`, `passphrase`, `privateKey`, `accessKey`, `credential`, and
+their case/`_`/`-` variants. Non-secret identifiers like `roleId` and benign compounds like `tokenBucketSize` stay
+visible. JWT signing keys never print their material (`StringSecret(******)`), and URLs have their `user:password@`
+userinfo stripped before logging.
+
+### Adding project-specific sensitive keys
+
+The term list is the built-in floor **merged** with your own (you can only ADD, never remove a built-in):
+
+```hocon
+picatinny.redaction {
+  additionalSensitiveKeys = ["myCorpToken", "internalPass"]
+  replacement = "******"   # optional; defaults to ******
+}
+```
+
+## Migration — upgrading to 1.23.0
+
+1.23.0 hardens secret handling. These are the consumer-visible behavior changes and how to adapt.
+
+### Banner & diagnostics now go through SLF4J (not `stdout`)
+
+`Utility.banner(...)` / `Utility.diagnostics()` previously wrote with `println`. They now emit a single
+`logger.info` event under `org.galaxio.gatling.diagnostics`.
+
+- **If you saw the banner on `stdout` with no logging config**: add the [recommended configuration](#recommended-configuration)
+  so the banner renders (prefix-free) again. Without any logging config it may be filtered by your backend's default level.
+- **If you grep/parse `stdout` in CI for the banner**: switch to capturing the logging output, or point the
+  `org.galaxio.gatling.diagnostics` category at a file/console appender.
+- The existing `picatinny.startup.banner.enabled` / `picatinny.diagnostics.enabled` flags still gate emission — no change.
+
+### The library no longer ships a `logback.xml`
+
+If you relied (knowingly or not) on a logging config arriving transitively from picatinny, **add your own** (copy the
+[recommended snippet](#recommended-configuration)). This removes the `Resource [logback.xml] occurs multiple times on the
+classpath` warning when your app already has one.
+
+### Masking is now whole-word, not substring
+
+Old behavior masked any key whose path **contained** a sensitive token. New behavior matches on the key's **last path
+segment** by whole word / compound run. Net differences you may notice in logs:
+
+| Key | Before (≤1.22) | After (1.23.0) |
+|-----|----------------|----------------|
+| `tokenBucketSize`, `apiKeyboard`, `secretariat` | masked (false positive) | **visible** |
+| `passwordHash`, `tokenValue`, `secret_id` | visible (missed) | **masked** |
+| `roleId`, `roleIdPrefix` | visible | visible (unchanged) |
+| `db.password`, `apiKey`, `clientSecret` | masked | masked (unchanged) |
+
+If a project-specific key now logs in clear (or you want a previously-visible one masked), add it under
+[`picatinny.redaction.additionalSensitiveKeys`](#adding-project-specific-sensitive-keys) — the built-in floor can only
+be extended, never weakened.
+
+### New (optional) config surface
+
+`picatinny.redaction.{additionalSensitiveKeys, replacement}` is additive and optional — no action needed unless you want
+to extend masking. Absent block = built-in defaults.
+
+## Startup banner & diagnostics (usage)
+
+Picatinny provides explicit utility methods for startup output. Put them where it makes sense for your project: in a
+simulation class, a shared package object, or another project bootstrap point. Output goes through SLF4J under
+`org.galaxio.gatling.diagnostics` — see [Recommended configuration](#recommended-configuration) to render it.
+
+Default behavior:
+
+```text
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = false
+```
+
+Disable the banner for quiet runs:
+
+```bash
+-Dpicatinny.startup.banner.enabled=false
+```
+
+Enable JVM/runtime diagnostics when you need extra debug information:
+
+```bash
+-Dpicatinny.diagnostics.enabled=true
+```
+
+Pass the same Gatling injection steps to `Utility.banner(...)` that you pass to `inject`/`injectOpen`. The banner parses
+the actual injector objects and renders the effective workload. If no injectors are passed, it falls back to
+`simulation.conf`.
+
+Example `simulation.conf`:
+
+```hocon
+baseUrl = "http://localhost"
+intensity = "60 rpm"
+stagesNumber = 2
+rampDuration = 1 minute
+stageDuration = 5 minutes
+
+picatinny.startup.banner.enabled = true
+picatinny.diagnostics.enabled = false
+```
+
+Scala usage:
+
+```scala
+import io.gatling.core.Predef._
+import org.galaxio.gatling.config.SimulationConfig._
+import org.galaxio.gatling.utils.Utility
+
+class Stability extends Simulation {
+  val injectionProfile = (
+    rampUsersPerSec(0).to(intensity).during(rampDuration),
+    constantUsersPerSec(intensity).during(stageDuration),
+  )
+
+  Utility.banner(injectionProfile)
+  Utility.diagnostics()
+
+  setUp(
+    scn.inject(injectionProfile._1, injectionProfile._2),
+  ).protocols(http.baseUrl(baseUrl))
+}
+```
+
+Java usage:
+
+```java
+import io.gatling.javaapi.core.OpenInjectionStep;
+import io.gatling.javaapi.core.Simulation;
+import org.galaxio.gatling.javaapi.Utility;
+import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
+import static io.gatling.javaapi.core.CoreDsl.rampUsersPerSec;
+import static org.galaxio.gatling.javaapi.SimulationConfig.*;
+
+public final class Stability extends Simulation {
+    {
+        OpenInjectionStep[] injectionProfile = {
+            rampUsersPerSec(0).to(intensity()).during(rampDuration()),
+            constantUsersPerSec(intensity()).during(stageDuration())
+        };
+
+        Utility.banner(injectionProfile);
+        Utility.diagnostics();
+
+        setUp(scn.injectOpen(injectionProfile));
+    }
+}
+```
+
+Kotlin usage:
+
+```kotlin
+import io.gatling.javaapi.core.CoreDsl.constantUsersPerSec
+import io.gatling.javaapi.core.CoreDsl.rampUsersPerSec
+import io.gatling.javaapi.core.OpenInjectionStep
+import io.gatling.javaapi.core.Simulation
+import org.galaxio.gatling.javaapi.Utility
+import org.galaxio.gatling.javaapi.SimulationConfig.*
+
+class Stability : Simulation() {
+    init {
+        val injectionProfile = arrayOf<OpenInjectionStep>(
+            rampUsersPerSec(0.0).to(intensity()).during(rampDuration()),
+            constantUsersPerSec(intensity()).during(stageDuration()),
+        )
+
+        Utility.banner(*injectionProfile)
+        Utility.diagnostics()
+
+        setUp(scn.injectOpen(*injectionProfile))
+    }
+}
+```
+
+Startup output:
+
+```text
+================================================================================
+ Picatinny Gatling Run
+================================================================================
+ Simulation   : Stability
+ Base URL     : http://localhost
+
+ Workload
+   intensity      : 1.00 rps
+   profile        : provided-open-injection
+   ramp duration  : 1m
+   stage duration : 5m
+   total duration : 6m
+
+ Timeline
+   00:00 - 01:00  ramp   0.00 -> 1.00 rps
+   01:00 - 06:00  plateau  1.00 rps
+
+ ASCII preview
+   rps
+    1.00 |           //___________________________________________________________
+    0.89 |          /
+    0.78 |         /
+    0.67 |        /
+    0.56 |      //
+    0.44 |     /
+    0.33 |    /
+    0.22 |   /
+    0.11 | //
+    0.00 |/
+         +------------------------------------------------------------------------
+          00:00                                                            06:00
+================================================================================
+```
+

--- a/examples/scala-sbt-example/src/test/resources/logback.xml
+++ b/examples/scala-sbt-example/src/test/resources/logback.xml
@@ -6,6 +6,20 @@
         </encoder>
     </appender>
 
+    <!-- Picatinny startup banner / diagnostics: rendered prefix-free so the ASCII box stays aligned.
+         The whole multi-line block arrives as ONE log event, so %msg%n prints it verbatim.
+         Suppress it by setting this logger to OFF (or WARN); additivity="false" stops it also
+         printing through the prefixed root appender (which would duplicate it). -->
+    <appender name="BANNER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.galaxio.gatling.diagnostics" level="INFO" additivity="false">
+        <appender-ref ref="BANNER"/>
+    </logger>
+
     <root level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/specs/007-secret-masking-leak-prevention/checklists/requirements.md
+++ b/specs/007-secret-masking-leak-prevention/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Secret Masking & Leak Prevention
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec ready for `/speckit-plan`.

--- a/specs/007-secret-masking-leak-prevention/contracts/public-api.md
+++ b/specs/007-secret-masking-leak-prevention/contracts/public-api.md
@@ -1,0 +1,39 @@
+# Contract: Public & Internal Surface
+
+This feature is compatibility-sensitive (published library). This contract records what stays stable and what is added.
+
+## Unchanged public API (MUST stay green — Constitution II)
+
+- `SigningKey` sealed trait + companion `object SigningKey`.
+- `final case class StringSecret(value: String) extends SigningKey` — type, field `value: String`, `apply`/`unapply`/`copy`/`value` accessor all unchanged. **Only `toString` overridden.**
+- `final case class AsymmetricKey(value: PrivateKey) extends SigningKey` — same; **only `toString` overridden.**
+- `SimulationConfig` / Java facade `org.galaxio.gatling.javaapi.SimulationConfig` — all getters and types unchanged. No facade change.
+- `jwt(...)` factory behavior (selects `StringSecret`/`AsymmetricKey`) unchanged.
+
+**Compat note:** `toString` of a secret-holder is not a behavioral contract consumers may rely on; redacting it is safe under a MINOR bump (v1.23.0).
+
+## Internal surface (not public API)
+
+- `ConfigValueMasking`: visibility widened `private[config]` → `private[gatling]`. Still NOT public. Methods `isSensitive`, `displayValue` (kept), `displayConfig`, `redactUserInfo` (new).
+
+## New serialized config surface (additive, optional — Constitution II)
+
+`picatinny.redaction` block (HOCON), all optional:
+
+```hocon
+picatinny.redaction {
+  additionalSensitiveKeys = ["myCorpToken", "internalPass"]   # merged with built-ins, never replaces
+  replacement = "******"                                       # optional override of the sentinel
+}
+```
+
+**Contract:**
+- Absent block → built-in defaults; no behavior change for existing configs.
+- `additionalSensitiveKeys` ADDS to the built-in floor; it cannot remove a built-in term.
+- Terms are case-insensitive whole-word terms compared on a path's last segment — NOT regexes.
+
+## Logging contract (FR-008/009/011)
+
+- Diagnostics/banner output is emitted via SLF4J under category `org.galaxio.gatling.diagnostics`, one event per block.
+- Recommended consumer config (docs + `examples/scala-sbt-example/src/test/resources/logback.xml`): a `BANNER` `ConsoleAppender` with `%msg%n` bound to that category with `additivity="false"`; suppress by setting the category level to `OFF`/`WARN`.
+- The library ships NO `logback.xml`/`logback-test.xml` on its main classpath (FR-010).

--- a/specs/007-secret-masking-leak-prevention/data-model.md
+++ b/specs/007-secret-masking-leak-prevention/data-model.md
@@ -1,0 +1,57 @@
+# Phase 1 Data Model: Secret Masking & Leak Prevention
+
+No persistence. These are the in-code entities the feature introduces or changes. Masking is a **presentation-layer** concern — no in-memory config object is mutated.
+
+## RedactionSettings (new, internal)
+
+Resolved once at config-load from the optional `picatinny.redaction` block; passed into the masking helper.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `additionalSensitiveKeys` | `List[String]` | `Nil` | User-supplied extra terms; lowercased, merged with built-ins (never replaces). |
+| `replacement` | `String` | `"******"` | Sentinel substituted for sensitive values. Fixed-width; reveals no entropy. |
+
+**Validation / rules**
+- Absent `picatinny.redaction` block → all defaults (FR-012 boundary). Guarded by `config.hasPath`.
+- Effective term set = `BuiltinSensitiveTerms ++ additionalSensitiveKeys`, normalized (lowercase, de-duplicated). **Merge-not-replace**: a user cannot remove a built-in term.
+
+## Sensitive Term (built-in set, hardened)
+
+The curated floor. Compared against a path's **last segment**, split into camelCase/snake/kebab words; a term matches when it equals a whole word (or forms a recognized `…Password/Secret/Token/Key` compound).
+
+- Existing (kept): `password`, `passwd`, `pwd`, `secret`, `token`, `apikey`/`api-key`/`api_key`, `credential`, `privatekey`/`private_key`, `clientsecret`/`client_secret`, `accesskey`/`access_key`, `secretkey`/`secret_key`.
+- Added (FR-003): `authorization`, `bearer`, `passphrase`, and `key` only as a recognized compound suffix (NOT a bare word — avoids `publicKey`/`keyboard` over-mask).
+
+**Negative invariants (must NOT match):** `roleId`, `roleIdPrefix`, `tokenBucketSize`, `apiKeyboard`, `secretariat`, `baseUrl`.
+
+## ConfigValueMasking (changed, `private[config]` → `private[gatling]`)
+
+The single central helper. Public-within-library surface:
+
+| Member | Signature | Purpose |
+|--------|-----------|---------|
+| `isSensitive` | `(path: String): Boolean` | Last-segment word-boundary sensitivity test (kept name; hardened logic). Reused by D4 JVM-arg redaction. |
+| `displayValue` | `(path: String, value: Any): String` | Scalar masking (kept). |
+| `displayConfig` | `(cfg: com.typesafe.config.Config): String` | **New.** Leaf-walk a nested block via `entrySet()`, mask per-leaf (FR-004). |
+| `redactUserInfo` | `(raw: String): String` | **New.** Fail-safe URL userinfo stripper (FR-007). |
+
+State: effective term set + replacement, resolved once from `RedactionSettings`.
+
+## SigningKey subtypes (changed — toString only)
+
+| Type | Field (unchanged) | `toString` (new) |
+|------|-------------------|------------------|
+| `StringSecret` | `value: String` | `"StringSecret(******)"` |
+| `AsymmetricKey` | `value: PrivateKey` | `"AsymmetricKey(******)"` |
+
+**Invariant:** `value` accessor, `apply`/`unapply`/`copy`, and case-class status unchanged — only the rendered string changes.
+
+## Redacted JVM Argument (transient, FR-006)
+
+Not a stored type — a transform over `mxBean.getInputArguments`:
+- `-Dkey=value` with `isSensitive(key)` → `-Dkey=******`.
+- Non-`-D`, value-less, or non-sensitive args → unchanged.
+
+## Banner Log Event (FR-008/009)
+
+The full multi-line banner/diagnostics block emitted as ONE `logger.info` event under category `org.galaxio.gatling.diagnostics`. Embedded `\n` preserved; ASCII-alignment chars (`|`, `/`, `_`) intact. Rendered prefix-free under the recommended `BANNER` appender (`%msg%n`, `additivity="false"`).

--- a/specs/007-secret-masking-leak-prevention/plan.md
+++ b/specs/007-secret-masking-leak-prevention/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Secret Masking & Leak Prevention (v1.23.0)
+
+**Branch**: `007-secret-masking-leak-prevention` | **Date**: 2026-06-24 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/007-secret-masking-leak-prevention/spec.md`
+
+## Summary
+
+Close credential-leak paths for milestone [v1.23.0](https://github.com/galax-io/gatling-picatinny/milestone/8) (issues [#208](https://github.com/galax-io/gatling-picatinny/issues/208), [#87](https://github.com/galax-io/gatling-picatinny/issues/87), [#88](https://github.com/galax-io/gatling-picatinny/issues/88)). One central redaction helper (`ConfigValueMasking`) applied at every sink, plus routing diagnostics through SLF4J and delivering recommended logging config without polluting the consumer classpath.
+
+1. **#208 central masking — harden + extend `ConfigValueMasking`**: today it matches a 17-token list by raw lowercase `contains` against the full path (over-matches `roleIdPrefix`/`tokenBucketSize`/`apiKeyboard`), masks only scalar `(path, value)` calls, and is hardcoded/`private[config]`. Harden to **last-path-segment + word-boundary** matching; add FR-003 terms (`authorization`, `bearer`, `passphrase`, `key`-as-compound); make the term list **config-extensible** (merge-not-replace via optional `picatinny.redaction`); widen to `private[gatling]` (internal — compat-exempt) so `diagnostics`/`feeders` can reuse it.
+2. **#208 nested-config leak — leaf-walk masking**: `SimulationConfigUtils.getValueByType` has ONE log site (line 51) that calls `displayValue(path, value)` for every read type. When the read value is a nested `Config` (the `case ConfigTag` value-read at line 68), `displayValue` checks only the **parent** path and stringifies the whole block — a benign block name (`http`) leaks secret child leaves (`http.token`) at INFO. Add `displayConfig(cfg)` walking `Config.entrySet()` (already-flattened leaves), masking each leaf by its own last segment; at line 51, when the value is a `Config`, render via `displayConfig` instead of `displayValue`.
+3. **#208 SigningKey leak — redact toString**: `StringSecret(value: String)` and `AsymmetricKey(value: PrivateKey)` are case classes; derived `toString` leaks the HMAC secret / provider-dependent key bytes. Override `toString` on both to `…(******)`. Keep types/fields/`apply`/`unapply`/`copy`/`value` intact (published API).
+4. **#208 `-D` args leak — redact JVM args**: `Diagnostics.scala:21` joins `mxBean.getInputArguments` raw → `-DvaultToken=…` echoed. Split each `-Dkey=value`, run the key through `ConfigValueMasking.isSensitive`, replace sensitive values with `******` keeping `-Dkey=******`.
+5. **#208 URL userinfo leak — strip credentials**: add a fail-safe `redactUserInfo(raw)` (java.net.URI + string surgery; never throws; regex+constant fallback) and apply at the `StartupBanner` base-URL sink (line 54).
+6. **#87 println → SLF4J**: replace the 4 `println` sites (`StartupBanner` 15/27/30, `Diagnostics` 13) with `StrictLogging`, emitting each multi-line block as a **single** `logger.info` event under the `org.galaxio.gatling.diagnostics` category (alignment-safe). Keep existing `isEnabled` flags gating emission.
+7. **#88 recommended logging config — NOT on the library main classpath**: ship no logback in library main (compile dep stays `scala-logging` only); deliver the recommended config via docs + the runnable `examples/scala-sbt-example` overlay `logback.xml` (dedicated `BANNER` `%msg%n` appender, `additivity="false"`, suppressible by category/level).
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18
+
+**Primary Dependencies**: Gatling 3.13.5 (`Provided`), `com.typesafe.scala-logging` 3.9.6 (compile, SLF4J-backed), Typesafe Config (transitive via PureConfig/Gatling), PureConfig 0.17.10. **No new dependencies.** logback stays Test-scope only (transitive via Gatling).
+
+**Storage**: N/A (config lives in Typesafe `Config`; no persistence).
+
+**Testing**: ScalaTest (`AnyWordSpec` + `Matchers`); logback `ListAppender` for log capture (the `captureWarns` idiom in `AssertionsBuilderSpec`, retargeted to `org.galaxio.gatling.diagnostics` and the config logger); `Console.withOut(ByteArrayOutputStream)` to assert stdout is now empty; full Gatling e2e in `examples/scala-sbt-example` (`sbt Gatling/test`) for the overlay config.
+
+**Target Platform**: JVM (compile target Java 17; CI Temurin 21).
+
+**Project Type**: Published Scala library with thin Java/Kotlin facade.
+
+**Performance Goals**: N/A (security/observability hardening). The config-extensible term list is resolved ONCE at config-load and passed in — no per-log-line config read. `entrySet()` leaf-walk runs only on nested-block display (rare), O(leaves).
+
+**Constraints**: Backward compatibility (Constitution II) — no public Scala/Java signature change. `SigningKey`/`StringSecret`/`AsymmetricKey` types, fields, `value` accessors unchanged (only `toString` overridden). `ConfigValueMasking` is `private[config]` → widened to `private[gatling]` (internal, compat-exempt). New `picatinny.redaction` config keys are **additive and optional** (absent = built-in defaults). Coverage floor 65%/60%.
+
+**Scale/Scope**: 5 source files + 3–4 test files + 1 overlay `logback.xml` + docs. ~Small–Medium.
+
+## Test Model *(mandatory — real cases + test sketches, NO implementation)*
+
+| Req | Real case to test | Layer | Test sketch (no code) |
+|-----|-------------------|-------|-----------------------|
+| FR-001 | A sensitive param (`db.password=s3cr3t`) read via `SimulationConfigUtils.getValueByType` is logged masked | Unit / Functional | Extend `ConfigValueMaskingSpec`: assert `displayValue("db.password","s3cr3t") == "******"` (exact). Capture the INFO line emitted by `getValueByType` for a sensitive path via `ListAppender` on the config logger; assert it contains `******` and NOT `s3cr3t`. Negative: a non-sensitive path (`baseUrl`) logs the literal value unchanged. |
+| FR-002 | The same one term-set drives config masking, JVM-arg redaction, and (when keyed) URL handling | Unit / Functional | Add an extension term via `picatinny.redaction` (D8) and assert it now masks in BOTH `displayValue` AND the `-Dcustomsecret=…` JVM-arg redactor — proving a single shared `ConfigValueMasking` decision. Negative: a term absent from built-ins + config stays visible in both. |
+| FR-003 | Each required term masks: `token`/`password`/`secret`/`key`/`authorization`/`bearer`/`passphrase` (+ `roleId` must NOT) | Unit / Functional | Parameterized `isSensitive`/`displayValue`: `authorizationHeader`, `bearerToken`, `passphrase`, `apiKey`, `clientSecret` → `******`. Boundary/negative (the core of #208 hardening): `roleId`, `roleIdPrefix`, `tokenBucketSize`, `apiKeyboard`, `secretariat` → `isSensitive == false` (word-boundary on last segment, not `contains`). |
+| FR-004 | A benignly-named block `http { url=…, token="abc" }` displayed as a whole | Unit / Functional | Build a HOCON `Config`; assert `displayConfig(cfg)` contains `http.url = …` visibly and `http.token = ******`, and does NOT contain `abc`. Boundary: deeply nested `a.b.c.secret` leaf masked; a block with no sensitive leaf renders every value visibly (no over-mask). |
+| FR-005 | `StringSecret`/`AsymmetricKey` interpolated into a log or exception message | Unit / Functional | New `SigningKeySpec`: assert `StringSecret("topsecret").toString == "StringSecret(******)"` and contains neither `topsecret`; assert `AsymmetricKey(key).toString == "AsymmetricKey(******)"`. Exact-value API guard: `StringSecret("topsecret").value == "topsecret"` still returns the raw secret (accessor intact). |
+| FR-006 | A run launched with `-DvaultToken=hunter2` reaches diagnostics | Unit / Functional | Unit-test the per-arg redactor over `Seq("-Xmx2g","-DvaultToken=hunter2","-Dapp.name=foo")` → yields `-DvaultToken=******`, leaves `-Xmx2g` and `-Dapp.name=foo` untouched (exact list). Negative: `-DvaultToken` with no `=value` passes through; result never contains `hunter2`. |
+| FR-007 | Base URL `https://user:pass@host:8080/p` printed in the banner | Unit / Functional | Assert `redactUserInfo("https://user:pass@host:8080/p") == "https://******@host:8080/p"`; `redactUserInfo("https://host/p")` returned unchanged (no userinfo). Fail-safe/boundary: malformed `"ht!tp://u:p@x"` does NOT throw and returns a string containing neither `:p@` nor the raw password; opaque `mailto:a@b` unchanged. |
+| FR-008 | The startup banner goes through SLF4J, not stdout | Unit / Functional | Attach `ListAppender` to `org.galaxio.gatling.diagnostics`; emit banner with the flag enabled; assert exactly one captured event whose message contains `Picatinny Gatling Run`. Negative (proves no `println`): wrap the call in `Console.withOut(ByteArrayOutputStream)` and assert stdout is empty. |
+| FR-009 | The multi-line ASCII banner stays aligned as a single event | Unit / Functional | With `ListAppender` on `org.galaxio.gatling.diagnostics`: assert `appender.list.size == 1` (one `ILoggingEvent`, NOT one-per-line), `getLoggerName` starts with `org.galaxio.gatling.diagnostics`, and `getMessage` contains embedded `\n` plus the ASCII-preview chars (`|`, `/`, `_`) intact. Boundary: assert it is NOT split into multiple events. |
+| FR-010 | Library main classpath ships no logback config | Compile Guard | A `Test` guard asserting the library declares no first-party logback and ships no `logback.xml` on the main classpath: assert `getClass.getResource("/logback.xml")` resolves only to the **test** resource (not a main artifact entry) and that `project/Dependencies.scala` lists logback nowhere at compile scope (documented + asserted by scanning the resolved Compile classpath for absence of `ch.qos.logback`). Negative: the same scan finds logback present in the Test classpath (transitive), proving it is Test-only. |
+| FR-011 | The example overlay ships the recommended banner config and runs prefix-free | Full Gatling e2e (examples) | In `examples/scala-sbt-example`, run the example (`sbt Gatling/test`) with the updated `logback.xml` (BANNER `%msg%n` appender + `additivity="false"` on `org.galaxio.gatling.diagnostics`); assert the run completes green and the captured banner line carries NO date/level prefix. Negative: a non-diagnostics log line in the same run still carries the normal prefixed pattern (proves the category scoping, not a global pattern change). |
+| FR-012 | A user adds `myCorpToken` via `picatinny.redaction.additionalSensitiveKeys` | Unit / Functional | Construct `ConfigValueMasking` from a `Config` with `picatinny.redaction.additionalSensitiveKeys=["mycorptoken"]`; assert `displayValue("mycorptoken","v") == "******"` while built-ins still mask. Boundary: ABSENT `picatinny.redaction` → built-ins still mask (defaults applied); merge-not-replace — a user list that omits `password` does NOT un-mask `password`. |
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **I. Scala DSL as Source of Truth** — All masking/logging logic lives in Scala core (`config`, `utils/jwt`, `diagnostics`). No Java/Kotlin facade change required (the facade does not log config); if any facade later logs, it must delegate to `ConfigValueMasking`, not reimplement. ✓
+- [x] **II. Backward Compatibility** — No public signature change. `SigningKey`/`StringSecret`/`AsymmetricKey` types/fields/`value`/`apply`/`unapply`/`copy` unchanged (only `toString` overridden — observable string changes, but `toString` of a secret holder is not a compat contract). `ConfigValueMasking` is `private[config]` → `private[gatling]` (internal refactor, explicitly compat-exempt per Constitution II). New `picatinny.redaction.*` keys are additive + optional (absent = defaults), not a format change to existing keys. Justifies the v1.23.0 MINOR bump. ✓
+- [x] **III. Test Discipline** — Test Model above is filled per FR (FR-001..FR-012) with real case + layer + code-free sketch and ≥1 negative/boundary each; work is test-first. Layers follow TESTING.md: pure-function + logging units (ScalaTest + `ListAppender`), one Full-Gatling-e2e overlay test (FR-011), one Compile Guard (FR-010). No Testcontainers needed (no Redis/Vault/JDBC container surface). No Gatling-runtime mocking. Coverage stays ≥ floor. ✓
+- [x] **IV. Small, Focused Changes** — No new deps. **Note (principle bent, justified in Complexity Tracking):** (a) `ConfigValueMasking` matching is restructured (contains → last-segment word-boundary) — required to fix the #208 over-match, not opportunistic; (b) visibility widened `private[config]` → `private[gatling]` — minimal, internal. `VaultFeeder.scala:201`'s ad-hoc userinfo strip is NOT consolidated in this change (would be out-of-scope refactor) — noted as follow-up. ✓
+- [x] **V. Release Integrity** *(release PRs only)* — Fixes land on `main` via PR first; v1.23.0 is a MINOR release cut as `release/1.23.0` from `main` per the release process. Not exercised at plan stage. ✓
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-secret-masking-leak-prevention/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (D1–D8 decisions)
+├── data-model.md        # Phase 1 output (redaction entities)
+├── quickstart.md        # Phase 1 output (how to validate each leak path)
+├── contracts/
+│   └── public-api.md    # Phase 1 output (unchanged public surface + new internal/config surface)
+└── tasks.md             # /speckit-tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/
+├── config/
+│   ├── ConfigValueMasking.scala       # FR-001/002/003/004/007/012 — central helper: word-boundary match,
+│   │                                  #   displayConfig leaf-walk, redactUserInfo, config-extensible terms,
+│   │                                  #   widen private[config] → private[gatling]
+│   └── SimulationConfigUtils.scala    # FR-004/012 — at line-51 sink, render Config values via displayConfig;
+│                                      #   build masking term-set from optional picatinny.redaction
+├── utils/jwt/
+│   └── SigningKey.scala               # FR-005 — override toString on StringSecret + AsymmetricKey
+└── diagnostics/
+    ├── Diagnostics.scala              # FR-006/008/009 — println → StrictLogging single event; -D arg redaction
+    └── StartupBanner.scala            # FR-007/008/009 — println → StrictLogging single event; redactUserInfo on baseUrl
+
+src/test/scala/org/galaxio/gatling/
+├── config/
+│   └── SimulationConfigUtilsSpec.scala  # FR-001/002/003/004/012 — extend ConfigValueMaskingSpec:
+│                                        #   over-match negatives, displayConfig nested, extensible terms, masked log line
+├── utils/jwt/
+│   └── SigningKeySpec.scala             # FR-005 — toString redaction + value accessor intact (NEW)
+└── diagnostics/
+    └── DiagnosticsSpec.scala            # FR-006/008/009 — -D redaction unit; banner single-event via ListAppender; stdout empty
+
+src/test/scala/org/galaxio/gatling/          # FR-010 — compile/classpath guard (location TBD in tasks)
+
+examples/scala-sbt-example/src/test/resources/
+└── logback.xml                          # FR-011 — add BANNER %msg%n appender + diagnostics category (additivity=false)
+
+docs/logging.md                          # FR-011 — recommended logback snippet + override path; references the overlay logback.xml as canonical
+```
+
+**Structure Decision**: Single published-library project (Option 1). Changes are confined to `config/`, `utils/jwt/`, `diagnostics/` in Scala core plus their existing/new test specs, with the recommended-config delivery in the `scala-sbt-example` overlay (the authoritative copy CI overlays onto the template) and docs. No facade files change (masking is core-side; delegation already covers the facade).
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| `ConfigValueMasking` matching restructured (raw `contains` → last-segment word-boundary) (Principle IV — minimal-change bent) | The #208 over-match (`roleIdPrefix`, `tokenBucketSize`, `apiKeyboard` falsely masked; future broad terms worsen it) cannot be fixed by adding tokens — the matching rule itself is the defect. | Adding the FR-003 terms to the existing `contains` list directly amplifies false positives (e.g. `passphrase` token would mask any `pass…`); regex-valued config pushes over-match onto users. |
+| `ConfigValueMasking` visibility widened `private[config]` → `private[gatling]` (Principle IV — internal scope change) | `Diagnostics` (`-D` arg redaction) and `StartupBanner` (`redactUserInfo`) live in package `org.galaxio.gatling.diagnostics` and must reuse the single central helper (FR-002), which `private[config]` hides. | A duplicate token list / strip helper in `diagnostics` violates FR-002 (single central list) and the constitution's single-source-of-truth principle. Public API exposure is unnecessary and would be a compat surface. |
+| `picatinny.redaction.*` config keys added (Principle IV / Constitution II — serialized config surface) | FR-012 requires user-extensible terms; merge-not-replace semantics keep it a security floor. | A compile-time-only list (status quo) fails FR-012; replace-semantics would let a user un-mask the library's known secrets. Keys are additive + optional (absent = defaults), so no existing config breaks. |

--- a/specs/007-secret-masking-leak-prevention/quickstart.md
+++ b/specs/007-secret-masking-leak-prevention/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Validate Secret Masking & Leak Prevention
+
+How to prove each leak path is closed. Run from repo root.
+
+## Prerequisites
+
+```bash
+sbt scalafmtAll scalafmtSbt          # format
+sbt scalafmtCheckAll compile         # green build before validating
+```
+
+## Unit / functional (the bulk of FR coverage)
+
+```bash
+sbt "testOnly org.galaxio.gatling.config.SimulationConfigUtilsSpec"   # FR-001/002/003/004/012
+sbt "testOnly org.galaxio.gatling.utils.jwt.SigningKeySpec"           # FR-005
+sbt "testOnly org.galaxio.gatling.diagnostics.DiagnosticsSpec"        # FR-006/008/009
+```
+
+Expected:
+- **FR-003 over-match guard**: `isSensitive("roleIdPrefix") == false`, `isSensitive("tokenBucketSize") == false`, while `isSensitive("bearerToken") == true`. (The #208 regression guard.)
+- **FR-004 nested**: `displayConfig` of `http { url=…, token="abc" }` shows `http.url` but `http.token = ******` and never `abc`.
+- **FR-005**: `StringSecret("topsecret").toString` contains `******`, not `topsecret`; `.value` still returns `topsecret`.
+- **FR-006**: `-DvaultToken=hunter2` → `-DvaultToken=******`; `-Xmx2g` untouched.
+- **FR-007**: `redactUserInfo("https://user:pass@host/p") == "https://******@host/p"`; malformed input does not throw.
+- **FR-008/009**: banner is exactly ONE captured `ILoggingEvent` under `org.galaxio.gatling.diagnostics`; stdout is empty (no `println`).
+
+## Compile / classpath guard (FR-010)
+
+```bash
+sbt compile        # library compiles with scala-logging only; no logback at compile scope
+```
+
+Confirm `project/Dependencies.scala` declares no first-party logback; the library main classpath ships no `logback.xml`.
+
+## Full Gatling e2e (FR-011) — recommended overlay config
+
+```bash
+cd examples/scala-sbt-example
+sbt Gatling/test
+```
+
+Expected: run completes green; the startup banner line carries NO date/level prefix (rendered via the `BANNER` `%msg%n` appender), while ordinary log lines keep the normal prefixed pattern — proving the dedicated `org.galaxio.gatling.diagnostics` category with `additivity="false"`.
+
+## Manual smoke (optional)
+
+Launch any example with a secret-bearing `-D` and a userinfo base URL, then scan output:
+
+```bash
+# none of the secret values should appear in captured output
+sbt -DvaultToken=hunter2 Gatling/test 2>&1 | grep -c 'hunter2'   # expect 0
+```
+
+## Reference
+
+- Decisions: [research.md](research.md) (D1–D8)
+- Entities: [data-model.md](data-model.md)
+- Stable surface: [contracts/public-api.md](contracts/public-api.md)

--- a/specs/007-secret-masking-leak-prevention/research.md
+++ b/specs/007-secret-masking-leak-prevention/research.md
@@ -1,0 +1,87 @@
+# Phase 0 Research: Secret Masking & Leak Prevention (v1.23.0)
+
+Consolidated decisions for spec 007 (issues #208/#87/#88). Each decision: what was chosen, why, and what was rejected. No new dependencies — `scala-logging` (compile), Typesafe Config + PureConfig (present), logback (Test-scope transitive) cover everything.
+
+## Repo facts that shaped the design
+
+- `ConfigValueMasking` (in `config/ConfigValueMasking.scala`) is the **only** masking decision point today: `private[config] object`, two methods `displayValue(path, value): String` and `isSensitive(path): Boolean`, a hardcoded 17-token `Seq[String]`, matched by lowercase **`contains`** against the full path, sentinel `"******"`. Not config-extensible.
+- The **only** call site is `SimulationConfigUtils.scala:51` (`logger.info(s"Simulation param for $path is set to: ${ConfigValueMasking.displayValue(path, value)}")`). The class uses `LazyLogging` (SLF4J). When a param is read as a nested `Config` (the `getConfig`/`ConfigTag` branch, ~line 68), `displayValue` receives the **whole block** with only the parent path checked → secret leaves inside a benign block print in clear. **This is the real #208 "config block leak".**
+- `SigningKey.scala`: `sealed trait` with `final case class StringSecret(value: String)` and `final case class AsymmetricKey(value: PrivateKey)`. Default case-class `toString` leaks the secret / provider-dependent key bytes. No override today.
+- `Diagnostics.scala:21` joins `mxBean.getInputArguments` raw → `-D` secrets echoed. `StartupBanner.scala:54` prints `baseUrl` raw. Four `println` sites total (`StartupBanner` 15/27/30, `Diagnostics` 13); zero `System.out/err`. Each block is already built as one string and printed in one `println` (single-event ready).
+- `scala-logging` 3.9.6 is a **compile** dep, used repo-wide via `StrictLogging`/`LazyLogging` (e.g. `CookieParser`, `TransactionTracker`). No first-party logback; logback reaches **Test** only, transitively via Gatling. Test log capture idiom: `ListAppender` (`AssertionsBuilderSpec.captureWarns`).
+- `examples/scala-sbt-example` is the only runnable overlay; it already ships `src/test/resources/logback.xml`. The Java/Kotlin overlays are non-runnable stubs (out of scope).
+
+## D1 — Central redaction helper shape
+
+**Decision.** Extend `ConfigValueMasking` into the single helper for ALL sinks. Keep `displayValue`/`isSensitive`; add `displayConfig` (D2), reuse `isSensitive` for JVM args (D4), add `redactUserInfo` (D5), make the term list injectable (D8). **Harden matching:** split path on `.`/`/`, test the **last segment only**, normalize into camelCase/snake/kebab words, require a token to equal a whole word (or a recognized `…Password/Secret/Token/Key` compound) — not raw `contains`. Add FR-003 terms (`authorization`, `bearer`, `passphrase`, `key`-as-compound). Keep the `"******"` sentinel. Widen `private[config]` → `private[gatling]`.
+
+**Rationale.** One helper already exists and is the sole decision point — reuse satisfies FR-002 with no API churn. Word-boundary + last-segment kills the documented over-match (`tokenBucketSize`, `apiKeyboard`, `roleIdPrefix`) while keeping every currently-green assertion. Fixed-width sentinel reveals no entropy (OWASP: redact classified fields, never partial-reveal).
+
+**Alternatives rejected.** New parallel helper (violates FR-002, two sources of truth); keep `contains` + add tokens (amplifies false positives — `passphrase` term would mask any `pass…`); regex token list (pushes over-match onto user config).
+
+## D2 — Nested config leaf-walk masking
+
+**Decision.** Add `displayConfig(cfg: com.typesafe.config.Config): String` that walks `cfg.entrySet().asScala` (already-flattened leaves), sorts by key, and for each leaf applies `displayValue(entry.getKey, entry.getValue.unwrapped)`, joining `s"$key = $shown"` with `\n`. At the single line-51 log site in `getValueByType`, when the read value is a `Config` (the `case ConfigTag` value-read), render via `displayConfig` instead of `displayValue`. Do **not** call `cfg.resolve()` on the display path (avoid materializing `${env}` secrets). `scala.jdk.CollectionConverters._` already imported.
+
+**Rationale.** `Config.entrySet()` returns fully-flattened leaf paths with resolved values, so each leaf's last segment is testable via D1 — no manual recursion. Closes the benign-block-hides-secret-child hole (FR-004). Sorting → diff-stable output.
+
+**Alternatives rejected.** `config.root().render()` raw (emits secrets — the current bug); manual `ConfigObject` recursion (`entrySet` already flattens; risks missing array/object leaves); rebuild masked `Config` via `withValue` + `render` (heavier; no current sink needs HOCON output).
+
+## D3 — SigningKey / StringSecret toString redaction
+
+**Decision.** Override `toString` ONLY: `StringSecret.toString = "StringSecret(******)"`, `AsymmetricKey.toString = "AsymmetricKey(******)"`. Do not rename types, change fields (`value: String`, `value: PrivateKey`), or drop case-class status.
+
+**Rationale.** Default case-class `toString` leaks the raw HMAC secret and can leak provider-dependent key bytes (`AsymmetricKey`). Overriding `toString` is the minimal binary/source-compatible change — `value`, `apply`, `unapply`, `copy` all unchanged, so call sites and tests keep working.
+
+**Alternatives rejected.** Make `value` private / rename (breaks API + `unapply`); convert to plain class (loses `apply/copy/unapply`); mask only `StringSecret` (`AsymmetricKey.value.toString` can also emit key material).
+
+## D4 — `-D` JVM args redaction reusing the central list
+
+**Decision.** In `Diagnostics.scala:21`, before joining, map each arg: for `-Dkey=value` (and `-Dkey:value`), split on the first `=`/`:`, strip leading `-D`, run the key through `ConfigValueMasking.isSensitive`; if sensitive replace the value with `"******"` keeping `-Dkey=******`. Non-`-D` args and value-less flags pass through. Same term set as D1.
+
+**Rationale.** Leak originates at `getInputArguments`. Reusing `isSensitive` keeps a single list (FR-002); a config-extended term (D8) automatically covers JVM args. Preserving the key keeps ops debuggability while redacting only the value.
+
+**Alternatives rejected.** Drop all `-D` args (loses non-secret flags); separate JVM-arg list (violates FR-002); regex over the whole joined string (fragile against quoting/spacing).
+
+## D5 — URL userinfo stripping (API + fail-safe)
+
+**Decision.** Add `private[gatling]` `redactUserInfo(raw: String): String`. Algorithm: (1) `try new java.net.URI(raw)`; (2) candidate userinfo = `Option(uri.getRawUserInfo) orElse Option(uri.getRawAuthority).filter(_.contains('@')).map(_.takeWhile(_ != '@'))`; empty → return `raw` unchanged; present → string-level replace of the exact `userinfo + "@"` run with `"******@"`; (3) on `URISyntaxException` / any `Throwable`, fall back to `raw.replaceFirst("://[^/@\\s]*@", "://******@")`, and if still no match return a conservative fully-redacted constant — NEVER throw, NEVER return the raw credential. Apply at `StartupBanner.scala:54`.
+
+**Rationale.** `java.net.URI` single-arg parses `user:pass@host`; `getRawUserInfo` + `getRawAuthority` `@`-fallback catches registry-based authorities where `getUserInfo` returns null. String surgery preserves the original byte-for-byte except the credential — the 7-arg `URI` constructor re-quotes `%` and can re-encode reserved chars (JDK-8151244), unacceptable for a log line. Catch-all guarantees fail-safe (FR-007).
+
+**Alternatives rejected.** 7-arg `URI` rebuild (double-encoding, not byte-faithful); `URI.create` (throws unchecked `IllegalArgumentException` — see `THttpClient.scala:111`); `getUserInfo` only (misses registry-based authorities); let exceptions propagate (violates fail-safe FR).
+
+## D6 — println → SLF4J for StartupBanner + Diagnostics
+
+**Decision.** Replace `println` in both with `extends StrictLogging` (in-repo idiom). Emit the WHOLE multi-line block in a SINGLE `logger.info(block)` call. Emitters live under `org.galaxio.gatling.diagnostics` → logger names fall under that category. Keep `isEnabled` flags gating emission (now gating a log call, not a print).
+
+**Rationale.** One `logger.info(String)` = exactly one SLF4J/logback event, so the layout pattern applies once and embedded newlines pass through verbatim via `%msg` — alignment preserved (FR-009). A per-line loop re-applies the pattern N times and breaks alignment. `StrictLogging` names the logger by runtime FQN (confirmed in scala-logging 3.9.6 source); logback's dotted hierarchy binds a Scala object's `…StartupBanner$` to the package category. No new main dependency (FR-010).
+
+**Alternatives rejected.** `println`/`Console.out` (the leak/uncategorized-output bug; unsuppressible by log config); `logger.info` per line (N events, alignment destroyed); drop the enable flags (regresses existing `DiagnosticsSpec`/`UtilityIntegrationSpec` and removes operator control).
+
+## D7 — logback NOT on main classpath; recommended config via docs + overlay
+
+**Decision.** Add NO logback to library main (compile logging dep stays `scala-logging`). Deliver recommended config (FR-011) via (1) docs and (2) the `examples/scala-sbt-example` overlay `logback.xml`: a dedicated `BANNER` `ConsoleAppender` with bare `<pattern>%msg%n</pattern>`, bound by `<logger name="org.galaxio.gatling.diagnostics" level="INFO" additivity="false"><appender-ref ref="BANNER"/></logger>` so the banner renders prefix-free, exactly once, and stays suppressible by setting that logger to `OFF`/`WARN`.
+
+**Rationale.** A published library must not impose a backend (FR-010, SLF4J FAQ, constitution non-runnable/Provided). The dedicated category + `additivity="false"` prevents double output (event hitting both BANNER and root). Bare `%msg%n` is what makes the single-event banner render without prefixes — pairs with D6. Overlay is the FR-011-mandated delivery vehicle.
+
+**Alternatives rejected.** Bundle logback + `logback.xml` in main (pollutes consumer classpath — `"Resource [logback.xml] occurs multiple times"`, FR-010 violation); banner category without `additivity="false"` (printed twice); docs-only without the overlay (fails FR-011's overlay requirement).
+
+## D8 — Config-extensible masking list
+
+**Decision.** Make the term list + placeholder injectable into `ConfigValueMasking`, loaded ONCE at config-load from an OPTIONAL block `picatinny.redaction` (`additionalSensitiveKeys: List[String] = Nil`, `replacement: String = "******"`), guarded by `config.hasPath` (the repo's `getOpt` idiom) so an absent block → built-in defaults (FR-012). Effective terms = built-in ++ user list, normalized/lowercased/de-duplicated — **MERGE, never replace** (users can only ADD to the floor). Resolve once, pass into the helper. Terms are case-insensitive whole-word terms (per D1), not regexes.
+
+**Rationale.** PureConfig + typesafe-config already present (no new dep). Optional source + case-class defaults make absence safe. Merge-not-replace prevents configuring the library into leaking its own known secrets. Resolve-once keeps the hot logging path allocation-free.
+
+**Alternatives rejected.** Replace-semantics (a user could delete `password`/`token` from coverage — unacceptable for a security feature); per-log-line config read (hot-path overhead); regex-valued config (re-introduces over-match D1 removes); no extensibility (fails FR-012).
+
+## Sources
+
+- SLF4J FAQ / error codes — libraries must not configure the backend; depend on `slf4j-api` at compile, backend at test.
+- logback manual (Configuration, Layouts, Architecture) — `%msg` emits the whole message including newlines; pattern applied once per event; logger hierarchy + `additivity`.
+- scala-logging 3.9.6 source (`Logging.scala`, `Logger.scala`) — `StrictLogging` logger named by `getClass.getName` (runtime FQN, trailing `$` for objects; bound by parent category).
+- JDK 17 `java.net.URI` Javadoc + JDK-8151244 — `getRawUserInfo`/`getRawAuthority`, single-arg vs multi-arg constructor double-encoding.
+- Typesafe Config Javadoc — `Config.entrySet()` returns flattened leaf entries; `ConfigRenderOptions`.
+- PureConfig docs — optional sources / case-class defaults.
+- OWASP Logging Cheat Sheet — redact classified fields, never log-and-pattern.
+- In-repo: `ConfigValueMasking.scala`, `SimulationConfigUtils.scala`, `SigningKey.scala`, `Diagnostics.scala`, `StartupBanner.scala`, `VaultFeeder.scala:201`, `THttpClient.scala:111`, `AssertionsBuilderSpec.scala`, `project/Dependencies.scala`.

--- a/specs/007-secret-masking-leak-prevention/spec.md
+++ b/specs/007-secret-masking-leak-prevention/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: Secret Masking & Leak Prevention
+
+**Feature Branch**: `007-secret-masking-leak-prevention`
+
+**Created**: 2026-06-24
+
+**Status**: Draft
+
+**Input**: GitHub Milestone 8 — v1.23.0: Secret-masking & leak prevention (issues #208, #87, #88)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Secrets Never Appear in Logs (Priority: P1)
+
+A load test developer configures a simulation with sensitive credentials: Vault tokens, HMAC signing keys, bearer tokens, role IDs, and passwords embedded in connection URLs. When the simulation runs, none of those values appear in plaintext in any log output, console output, or exception message — regardless of log level.
+
+**Why this priority**: Credential leaks in CI/CD logs are a direct security risk. This is the core purpose of the milestone. Every other story depends on a working central masking foundation.
+
+**Independent Test**: Run a simulation configured with known secret values; capture all log/stdout output at the most verbose level; assert none of the secret values appear in plaintext. Delivers the core security guarantee on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** a config key whose name matches a known sensitive pattern (token, password, secret, key, authorization, bearer, passphrase), **When** the library logs or prints config state, **Then** the value is replaced with a redacted placeholder and the original value is absent from all output.
+2. **Given** a config block containing a nested child key matching a sensitive pattern, **When** the entire parent block is logged as a string, **Then** only sensitive leaf values are redacted while non-sensitive sibling keys remain visible.
+3. **Given** a cryptographic signing object created with an HMAC secret, **When** that object is converted to a string (in an exception, log, or interpolation), **Then** the secret material is not present in the resulting string.
+4. **Given** a JVM started with sensitive `-Dkey=value` system arguments (e.g. `-DvaultToken=…`), **When** startup diagnostics print the input arguments, **Then** values for sensitive keys are redacted.
+5. **Given** a key name that is NOT in the masking list, **When** the library logs config, **Then** the value appears unredacted (masking is not over-broad).
+
+---
+
+### User Story 2 - URL Credentials Stripped from Output (Priority: P2)
+
+A CI/CD operator reviews build logs after a load test. A simulation base URL contains embedded credentials (`http://user:secret@host/path`). When picatinny prints the startup banner or logs any URL, the userinfo credential component is stripped, so passwords never appear in build logs.
+
+**Why this priority**: Embedded URL credentials are a common, distinct leak path. URL userinfo is structurally different from key-value config and needs its own handling.
+
+**Independent Test**: Configure a URL with userinfo; capture startup banner output; assert the password portion is absent while the host remains.
+
+**Acceptance Scenarios**:
+
+1. **Given** a base URL of the form `http://user:pass@host`, **When** the startup banner is printed, **Then** the output contains the host but not the password.
+2. **Given** a base URL with no userinfo, **When** the startup banner is printed, **Then** the URL appears unchanged.
+3. **Given** a malformed URL that cannot be parsed, **When** it would be printed, **Then** no exception is raised and no credential is exposed.
+
+---
+
+### User Story 3 - Diagnostic Output Routable via Standard Logging (Priority: P3)
+
+A load test developer wants to suppress or redirect verbose startup diagnostic output in CI. Because diagnostic and banner output flows through the standard logging framework rather than directly to stdout, they can set a log level to quiet, redirect, or structure this output — without modifying picatinny source.
+
+**Why this priority**: Controllability is a correctness property. Direct stdout writes cannot be silenced or captured by a logging sink; framework writes can. Also enables structured log collection in enterprise environments.
+
+**Independent Test**: Capture stdout and the logging framework output separately. With a suppressing log config, stdout has zero diagnostic lines. With a permissive config, the same messages appear via the logging framework.
+
+**Acceptance Scenarios**:
+
+1. **Given** a logging configuration that sets the diagnostics category to OFF, **When** a simulation starts, **Then** no startup banner or diagnostic messages appear on stdout.
+2. **Given** a logging configuration that sets the diagnostics category to INFO, **When** a simulation starts, **Then** banner and diagnostic messages are emitted through the logging framework (not raw stdout).
+
+---
+
+### User Story 4 - Recommended Logging Config Without Classpath Pollution (Priority: P4)
+
+A developer adds picatinny to a new project and wants sensible, quiet logging. Picatinny does NOT force a logging configuration onto their classpath (which would silently override their own config). Instead, picatinny documents a recommended minimal logging configuration and ships a working reference in its runnable example overlay, so the developer copies it into their own project and stays in full control.
+
+**Why this priority**: Good out-of-box guidance without the classpath-conflict anti-pattern. A library that ships an auto-discovered logging config on its main classpath collides with the consumer's own config (non-deterministic first-match wins) and steals their control — forbidden by the constitution's non-runnable/Provided posture and by SLF4J's own library guidance. Lowest priority because it is consumer guidance, not a security guarantee.
+
+**Independent Test**: Inspect the published library artifact and assert it contains no `logback.xml`/`logback-test.xml` on the main classpath; confirm a consumer that supplies the documented snippet gets quiet, configurable output with no "occurs multiple times on the classpath" warning attributable to picatinny.
+
+**Acceptance Scenarios**:
+
+1. **Given** the published library artifact, **When** its contents are inspected, **Then** no auto-discovered logging configuration (`logback.xml` / `logback-test.xml`) is present on the main/compile classpath.
+2. **Given** a consumer project that already has its own logging configuration, **When** picatinny is on the classpath, **Then** the consumer's configuration is the only one applied — picatinny contributes no competing config and no duplicate output or classpath-conflict warning.
+3. **Given** a consumer following picatinny's documented logging snippet, **When** a simulation runs, **Then** output is quiet and configurable (root level no noisier than necessary, no uncontrolled DEBUG/TRACE flood) and the startup banner renders with correct alignment.
+
+---
+
+### Edge Cases
+
+- A config key name partially matches a sensitive token (e.g., `roleIdPrefix`) — masking applies to clearly sensitive matches, not arbitrary substrings, and never leaks the underlying value.
+- A sensitive value is `null` or empty — redaction handles it gracefully with no error.
+- A URL is malformed and cannot be parsed for userinfo stripping — the print path fails safe (no exception, no credential exposure).
+- A consumer already ships their own logging configuration — picatinny contributes none of its own on the main classpath, so the consumer's config is the sole authority (no "occurs multiple times on the classpath" conflict, no first-match ambiguity).
+- The multi-line ASCII banner is routed through the logging framework — it MUST be emitted as a single log event (never line-by-line) so a per-line prefix cannot break box-drawing alignment; the recommended config renders the banner category without a per-line prefix.
+- Masking is applied to a deeply nested config structure — all matching leaf values are redacted at every depth.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The library MUST apply secret masking consistently at every output channel: log statements, console/diagnostic output, startup banner, and string representations of configuration or cryptographic objects.
+- **FR-002**: The library MUST consult a single centralized, authoritative list of sensitive key-name patterns; masking MUST be applied via this one list rather than scattered ad-hoc checks.
+- **FR-003**: Sensitive key-name patterns MUST include at minimum: `token`, `password`, `secret`, `key`, `authorization`, `bearer`, `passphrase`, and their common variants. Matching MUST be by whole-word on a key's last path segment (NOT raw substring), so non-secret identifiers like `roleId`/`roleIdPrefix` and benign compounds like `tokenBucketSize`/`apiKeyboard` are NOT masked.
+- **FR-004**: When logging or printing a nested configuration block, the library MUST walk all leaf entries and redact any whose key name matches a sensitive pattern — not only top-level keys.
+- **FR-005**: Cryptographic objects (e.g., signing keys) MUST NOT expose their secret material in any string representation.
+- **FR-006**: JVM input system arguments printed by startup diagnostics MUST have values redacted for keys matching sensitive patterns.
+- **FR-007**: URL values logged or printed by the library MUST have any userinfo (`user:password@`) component stripped or redacted before output, failing safe on unparseable URLs.
+- **FR-008**: All startup banner and diagnostic messages MUST be emitted through the standard logging framework and MUST NOT write directly to stdout or stderr.
+- **FR-009**: The multi-line ASCII banner and diagnostics block MUST each be emitted as a single log event (not one event per line) under a dedicated logger category, so that a per-line layout prefix cannot break the box-drawing alignment.
+- **FR-010**: The library MUST NOT place any auto-discovered logging configuration (`logback.xml` or `logback-test.xml`) on its main/compile classpath (`src/main/resources/`); it MUST NOT override or conflict with a consumer's logging configuration. The library MUST depend only on a logging API (`scala-logging`/SLF4J) at compile scope and MUST NOT force a concrete logging backend on consumers. (A `logback.xml` in the library's own `src/test/resources/`, which is excluded from the published artifact, is permitted for the library's test runs only.)
+- **FR-011**: The project MUST provide a recommended logging configuration to consumers via (a) documentation containing a copy-pasteable minimal configuration and the override path, and (b) a working reference configuration in the runnable `examples/scala-sbt-example` overlay test scope.
+- **FR-012**: The masking key-pattern list MUST be extensible via configuration so project-specific sensitive key names can be added without modifying library code.
+
+### Key Entities
+
+- **Sensitive Key Pattern**: A name or name fragment designating a config key whose value must be redacted (e.g., `token`, `password`, `bearer`).
+- **Redacted Placeholder**: The string substituted for a masked secret value in all output.
+- **Config Leaf**: A terminal key-value pair in a possibly-nested configuration structure; the atomic unit of a masking decision.
+- **URL Userinfo**: The `user:password@` component of a URL that must be stripped before any URL is logged or displayed.
+- **Recommended Logging Configuration**: A documented, copy-pasteable logging configuration snippet plus a working reference in the runnable example overlay — provided to consumers, NOT auto-loaded from the library's classpath.
+- **Banner Log Event**: The full multi-line ASCII banner/diagnostics block emitted as one logging event under a dedicated category, so layout prefixes cannot break alignment.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero known secret-bearing values (matching the defined sensitive patterns) appear in plaintext across all log output, console output, banner, and exception messages during a test simulation run — verified by scanning captured output for the known test secret strings.
+- **SC-002**: URL password components are absent from startup banner output in 100% of cases where a userinfo-bearing URL is configured.
+- **SC-003**: Startup and diagnostic output can be fully suppressed by setting the relevant log category to OFF — zero diagnostic lines on stdout when suppressed.
+- **SC-004**: The published library artifact contains NO `logback.xml` or `logback-test.xml` on the main classpath (verified by inspecting the packaged JAR); a consumer with its own logging config sees no "Resource [logback.xml] occurs multiple times on the classpath" warning attributable to picatinny.
+- **SC-005**: A consumer following the documented logging snippet achieves quiet, configurable output (no uncontrolled DEBUG/TRACE flood) with picatinny dictating nothing; the snippet is present in docs and exercised by the `scala-sbt-example` overlay, and the banner renders with correct alignment under it.
+
+## Assumptions
+
+- The existing `ConfigValueMasking` infrastructure is the intended home for the centralized masking list; this spec assumes it is extended, not replaced.
+- Masking is a presentation-layer concern — output is redacted; in-memory config objects are not mutated.
+- The sensitive-pattern list is a curated set; fuzzy/regex matching of arbitrary key names is out of scope beyond what the authoritative list defines.
+- Logging defaults are delivered as consumer-facing guidance (docs + example overlay), NOT as a config file packaged on the library's main classpath — a published library that ships an auto-discovered `logback.xml` collides with the consumer's own config (SLF4J/logback guidance + constitution non-runnable/Provided posture). The library's existing `src/test/resources/logback.xml` stays test-scoped (excluded from the artifact).
+- The `examples/java-maven-example` and `examples/kotlin-gradle-example` overlays are currently non-runnable stubs (no build file); shipping a reference logging config to them is out of scope until they become runnable builds.
+- URL userinfo stripping applies only to URLs picatinny itself prints or logs; it does not scan arbitrary free-text strings for URL patterns.
+- This milestone does not change the public DSL or existing serialized config/profile keys — but it ADDS an optional `picatinny.redaction.*` config surface, which is a MINOR version bump (v1.23.0) per Constitution II.
+- Related issues #87 (println → SLF4J) and #88 (recommended logging config, NOT a packaged `logback.xml`) are in-scope sub-tasks; #87 is a prerequisite for #88 (documented config is only meaningful once diagnostics route through the logging framework).

--- a/specs/007-secret-masking-leak-prevention/tasks.md
+++ b/specs/007-secret-masking-leak-prevention/tasks.md
@@ -1,0 +1,209 @@
+---
+description: "Task list for Secret Masking & Leak Prevention (v1.23.0)"
+---
+
+# Tasks: Secret Masking & Leak Prevention (v1.23.0)
+
+**Input**: Design documents from `specs/007-secret-masking-leak-prevention/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/public-api.md](contracts/public-api.md), [quickstart.md](quickstart.md)
+
+**Tests**: REQUIRED. Constitution III mandates test-first (TDD): write the failing test before the code (red → green → refactor); assert exact values + ≥1 negative/boundary case; logback `ListAppender` for log capture (the `captureWarns` idiom in `AssertionsBuilderSpec`); `Console.withOut(ByteArrayOutputStream)` to assert stdout is empty; ScalaMock only for leaf deps (none needed here); never mock the Gatling runtime where a real path exists.
+
+**Organization**: Grouped by user story (P1→P4). The central masking engine (`ConfigValueMasking`) is the shared prerequisite (Phase 2), realizing the single-central-list / term-coverage / extensibility requirements every sink consumes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1=secrets-never-in-logs (P1), US2=URL-userinfo (P2), US3=diagnostics-via-SLF4J (P3), US4=recommended-config-no-pollution (P4)
+
+## Path Conventions
+
+Published Scala library, single project. Core: `src/main/scala/org/galaxio/gatling/`. Tests: `src/test/scala/org/galaxio/gatling/`. E2e overlay: `examples/scala-sbt-example/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm a green baseline so later red tests are meaningful.
+
+- [X] T001 Verify clean baseline from repo root: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` passes on branch `007-secret-masking-leak-prevention` before any change.
+
+---
+
+## Phase 2: Foundational (Central Masking Engine — Blocking Prerequisites)
+
+**Purpose**: The single central helper every sink consumes. Realizes FR-002 (single list), FR-003 (term coverage), FR-012 (config-extensible) and the #208 over-match fix. **No user story can be correctly implemented until this is complete** — US1 sinks, US2's `redactUserInfo`, and US3/US4 all build on `ConfigValueMasking`.
+
+**⚠️ CRITICAL**: BLOCKS all user stories.
+
+- [X] T002 [P] Write FAILING unit tests for the hardened matching in `src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala` (extend `ConfigValueMaskingSpec`): assert FR-003 positives (`authorizationHeader`, `bearerToken`, `passphrase`, `apiKey`, `clientSecret` → `isSensitive == true` / `displayValue == "******"`) AND the #208 negatives (`roleId`, `roleIdPrefix`, `tokenBucketSize`, `apiKeyboard`, `secretariat`, `baseUrl` → `isSensitive == false`). Keep existing masking assertions green.
+- [X] T003 [P] Write FAILING unit tests for config-extensibility (FR-012) in the same spec: build `ConfigValueMasking` from a `Config` with `picatinny.redaction.additionalSensitiveKeys=["mycorptoken"]` → `displayValue("mycorptoken","v") == "******"`; ABSENT `picatinny.redaction` → built-ins still mask (defaults); merge-not-replace boundary → a user list omitting `password` does NOT un-mask `password`.
+- [X] T004 Harden `src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala`: replace raw `contains` with **last-path-segment + word-boundary** matching (split on `.`/`/`, normalize camelCase/snake/kebab words, whole-word term match + `…Password/Secret/Token/Key` compound rule); add FR-003 terms (`authorization`, `bearer`, `passphrase`, `key`-as-compound); keep `"******"` sentinel; **widen visibility `private[config]` → `private[gatling]`** (internal, compat-exempt). Makes T002 green.
+- [X] T005 Add `RedactionSettings(additionalSensitiveKeys: List[String] = Nil, replacement: String = "******")` + config-extensible term load to `ConfigValueMasking` and wire its resolution ONCE from the optional `picatinny.redaction` block (guarded by `config.hasPath`) in `src/main/scala/org/galaxio/gatling/config/SimulationConfigUtils.scala`; effective terms = built-in ++ user (lowercased, de-duplicated, **merge-not-replace**). Makes T003 green. (Depends on T004.)
+
+**Checkpoint**: Central masking engine hardened, extensible, reusable from any package. User stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Secrets Never Appear in Logs (Priority: P1) 🎯 MVP
+
+**Goal**: No secret value (config leaves, nested blocks, signing keys, `-D` args) appears in plaintext in any sink, at any log level.
+
+**Independent Test**: Run a simulation configured with known secret values; capture all log output; assert none appear in plaintext; assert non-sensitive values still visible.
+
+### Tests for User Story 1 (write FIRST, ensure they FAIL)
+
+- [X] T006 [P] [US1] Write FAILING test for nested-config leaf-walk (FR-004) in `src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala`: build HOCON `http { url=…, token="abc" }`; `displayConfig(cfg)` contains `http.url = …` visibly, `http.token = ******`, never `abc`; boundary: deeply nested `a.b.c.secret` masked; block with no sensitive leaf renders all values visibly.
+- [X] T007 [P] [US1] Write FAILING test for `SigningKey` toString redaction (FR-005) in a NEW `src/test/scala/org/galaxio/gatling/utils/jwt/SigningKeySpec.scala`: `StringSecret("topsecret").toString == "StringSecret(******)"` and excludes `topsecret`; `AsymmetricKey(key).toString == "AsymmetricKey(******)"`; exact-value API guard: `StringSecret("topsecret").value == "topsecret"`.
+- [X] T008 [P] [US1] Write FAILING test for `-D` JVM-arg redaction (FR-006) in `src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala`: redactor over `Seq("-Xmx2g","-DvaultToken=hunter2","-Dapp.name=foo")` → `-DvaultToken=******`, others untouched; negative: `-DvaultToken` (no `=value`) passes through; output never contains `hunter2`.
+- [X] T009 [US1] Write FAILING test for end-to-end masked param log line (FR-001) in `SimulationConfigUtilsSpec.scala`: attach `ListAppender` to the config logger, read a sensitive path via `getValueByType`, assert the INFO line contains `******` not the raw value; negative: a non-sensitive path logs the literal value. (Same file as T006 → after T006.)
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Add `displayConfig(cfg: com.typesafe.config.Config): String` to `src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala`: walk `cfg.entrySet().asScala`, sort by key, mask each leaf via `displayValue(entry.getKey, entry.getValue.unwrapped)`, join `s"$key = $shown"` with `\n`; do NOT `resolve()`. Makes T006 green. (Depends on T004.)
+- [X] T011 [US1] At the single line-51 log site of `getValueByType` in `src/main/scala/org/galaxio/gatling/config/SimulationConfigUtils.scala`, when the read value is a `com.typesafe.config.Config` (the `case ConfigTag` value-read at ~line 68), render it via `ConfigValueMasking.displayConfig(value)` instead of `displayValue(path, value)` (which stringifies the whole block checking only the parent path). Scalars still go through `displayValue`. Makes T009 green. (Depends on T010.)
+- [X] T012 [P] [US1] Override `toString` on `StringSecret` and `AsymmetricKey` in `src/main/scala/org/galaxio/gatling/utils/jwt/SigningKey.scala` to `"StringSecret(******)"` / `"AsymmetricKey(******)"`; do NOT change types/fields/`value`/`apply`/`unapply`/`copy`. Makes T007 green.
+- [X] T013 [US1] Add per-arg `-D` redaction in `src/main/scala/org/galaxio/gatling/diagnostics/Diagnostics.scala:21`: split each `-Dkey=value`/`-Dkey:value`, run the key through `ConfigValueMasking.isSensitive`, replace sensitive values with `******` keeping `-Dkey=******`; non-`-D`/value-less args pass through. Makes T008 green. (Reuses the Phase-2 engine; `private[gatling]` visibility from T004 required.)
+
+**Checkpoint**: All secret sinks (config scalar + nested block, signing keys, `-D` args) masked. US1 fully testable independently.
+
+---
+
+## Phase 4: User Story 2 - URL Credentials Stripped from Output (Priority: P2)
+
+**Goal**: Any URL the library prints/logs has its `user:password@` userinfo stripped, fail-safe on unparseable input.
+
+**Independent Test**: Configure a userinfo-bearing base URL; capture banner output; assert the password is absent, host present.
+
+### Tests for User Story 2 (write FIRST, ensure they FAIL)
+
+- [X] T014 [P] [US2] Write FAILING tests for `redactUserInfo` (FR-007) in `src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala`: `redactUserInfo("https://user:pass@host:8080/p") == "https://******@host:8080/p"`; `redactUserInfo("https://host/p")` unchanged; fail-safe boundary: malformed `"ht!tp://u:p@x"` does NOT throw and returns a string containing neither `:p@` nor `pass`; opaque `mailto:a@b` unchanged.
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Add `private[gatling] redactUserInfo(raw: String): String` to `src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala`: parse via `new java.net.URI(raw)` in try; userinfo = `Option(getRawUserInfo) orElse Option(getRawAuthority).filter(_.contains('@')).map(_.takeWhile(_!='@'))`; empty→return raw; present→string-replace `userinfo+"@"` with `"******@"`; on any `Throwable`→`raw.replaceFirst("://[^/@\\s]*@","://******@")` then conservative constant; never throw/leak. Makes T014 green.
+- [X] T016 [US2] Apply `ConfigValueMasking.redactUserInfo` to the base-URL value in `src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala:54`.
+
+**Checkpoint**: URL userinfo stripped at the banner sink, independent of US1/US3.
+
+---
+
+## Phase 5: User Story 3 - Diagnostic Output Routable via Standard Logging (Priority: P3)
+
+**Goal**: Banner + diagnostics flow through SLF4J as a single event per block under a dedicated category — suppressible/redirectable, alignment-safe.
+
+**Independent Test**: Capture stdout and the logging framework separately; suppress the category → stdout empty; enable → one event through the framework.
+
+**⚠️ File-overlap note**: `Diagnostics.scala` also edited in T013 (US1), `StartupBanner.scala` in T016 (US2). Sequence US3 edits after those (not `[P]` with them).
+
+### Tests for User Story 3 (write FIRST, ensure they FAIL)
+
+- [X] T017 [P] [US3] Write FAILING tests for single-event banner via SLF4J (FR-008/009) in `src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala`: attach `ListAppender` to `org.galaxio.gatling.diagnostics`, emit banner with flag enabled → `appender.list.size == 1`, `getLoggerName` starts with `org.galaxio.gatling.diagnostics`, `getMessage` contains embedded `\n` + ASCII chars (`|`,`/`,`_`); boundary: NOT split into multiple events.
+- [X] T018 [P] [US3] Write/Update FAILING test asserting stdout is empty (no `println`) in `src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala`: with `Console.withOut(ByteArrayOutputStream)` around banner+diagnostics emit, assert captured stdout is empty while the event is captured via `ListAppender`.
+
+### Implementation for User Story 3
+
+- [X] T019 [US3] Convert `src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala` from `println` to `extends StrictLogging`, converting ALL THREE emit sites (lines 15, 27, 30) so EACH emits its whole banner string as a single `logger.info(render(...))` call (one event per emission, never line-by-line); keep `isEnabled` gating. (After T016.)
+- [X] T020 [US3] Convert `src/main/scala/org/galaxio/gatling/diagnostics/Diagnostics.scala` from `println` to `extends StrictLogging`, emitting the whole block in ONE `logger.info(render())` call (line 13); keep `isEnabled` gating. (After T013.)
+- [X] T021 [US3] Update `Utility` / existing diagnostics specs that asserted stdout (`UtilityIntegrationSpec`, `DiagnosticsSpec`) to assert via `ListAppender` on `org.galaxio.gatling.diagnostics` instead of `Console.withOut`. Makes T017/T018 green.
+
+**Checkpoint**: Banner/diagnostics fully routed through SLF4J, single event, suppressible by category.
+
+---
+
+## Phase 6: User Story 4 - Recommended Logging Config Without Classpath Pollution (Priority: P4)
+
+**Goal**: Library ships no logback on its main classpath; recommended config delivered via docs + the runnable example overlay (prefix-free banner, suppressible).
+
+**Independent Test**: Inspect the published artifact → no `logback.xml`/`logback-test.xml` on main classpath; consumer with own config sees no conflict; example overlay renders the banner prefix-free.
+
+**⚠️ Depends on US3**: the overlay BANNER category only has effect once the banner routes through SLF4J (T019). Run US4 after US3.
+
+### Tests for User Story 4 (write FIRST, ensure they FAIL)
+
+- [X] T022 [P] [US4] Write a compile/classpath guard test (FR-010) in `src/test/scala/org/galaxio/gatling/` asserting the library main classpath ships no logback config: `getClass.getResource("/logback.xml")` resolves only to the test resource, and document/assert `project/Dependencies.scala` declares no compile-scope logback; negative: logback IS present on the Test classpath (transitive).
+
+### Implementation for User Story 4
+
+- [X] T023 [US4] Confirm `build.sbt` / `project/Dependencies.scala` declare no first-party logback at compile scope and the library has no `src/main/resources/logback.xml` (no-op if already absent — verify + document the FR-010 invariant). Makes T022 green.
+- [X] T024 [P] [US4] Update `examples/scala-sbt-example/src/test/resources/logback.xml`: add a `BANNER` `ConsoleAppender` with bare `<pattern>%msg%n</pattern>`; bind `<logger name="org.galaxio.gatling.diagnostics" level="INFO" additivity="false"><appender-ref ref="BANNER"/></logger>` so the banner renders prefix-free, once, and stays suppressible (set OFF/WARN). (FR-011)
+- [X] T025 [P] [US4] Add `docs/logging.md` (recommended logback snippet + override path: `-Dlogback.configurationFile`, logback-test.xml precedence, the diagnostics category) that references `examples/scala-sbt-example/src/test/resources/logback.xml` as the canonical example (single source — no divergent second copy of the config). (FR-011)
+- [ ] T026 [US4] E2e validation (FR-011): from `examples/scala-sbt-example` run `sbt Gatling/test`; assert green and the banner line carries NO date/level prefix while ordinary log lines keep the prefixed pattern. (After T024, T019.) — **DEFERRED TO CI**: this is the overlay publish+WireMock flow (needs `PICATINNY_VERSION` published to mavenLocal). Overlay `logback.xml` verified well-formed + correct here; the prefix-free single-event behavior it exercises is proven green at the unit layer (T017/T018).
+
+**Checkpoint**: All four stories independently functional; recommended config delivered without polluting consumer classpaths.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T027 Run `sbt scalafmtAll scalafmtSbt` then `sbt scalafmtCheckAll scalafmtSbtCheck compile test` — full green.
+- [X] T028 Confirm coverage ≥ floor (65% stmt / 60% branch) via `sbt clean coverage test coverageReport`; no padding on generated code.
+- [ ] T029 [P] Run [quickstart.md](quickstart.md) validation end-to-end, including the `grep -c 'hunter2'` smoke (expect 0). — **PARTIAL**: unit/functional + compile-guard + coverage steps all ran green here; the `grep` smoke runs a real sim and is **DEFERRED TO CI** with T026.
+- [X] T030 [P] Update CHANGELOG / release notes for v1.23.0 (security: secret-masking + leak prevention; #208/#87/#88).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none.
+- **Foundational (Phase 2)**: after Setup. **BLOCKS US1–US4** (central engine).
+- **US1 (Phase 3)**: after Foundational. MVP.
+- **US2 (Phase 4)**: after Foundational. Independent of US1/US3 (adds `redactUserInfo` to the same helper file → sequence its `ConfigValueMasking` edit after T010/T015 ordering within the file).
+- **US3 (Phase 5)**: after Foundational. Edits `Diagnostics.scala` (after T013) and `StartupBanner.scala` (after T016) — file overlap with US1/US2.
+- **US4 (Phase 6)**: after **US3** (overlay BANNER category needs SLF4J routing from T019).
+- **Polish (Phase 7)**: after all desired stories.
+
+### Within Each User Story
+
+- Tests written and FAILING before implementation (red → green → refactor).
+- Engine (Phase 2) before any sink application.
+- `displayConfig` (T010) before its sink wiring (T011); `redactUserInfo` (T015) before its sink (T016).
+
+### Parallel Opportunities
+
+- T002, T003 (Phase 2 tests) in parallel.
+- US1 tests T006, T007, T008 in parallel (different files); T009 after T006 (same file).
+- US1 impl: T012 (`SigningKey.scala`) parallel with config-side T010/T011 and diagnostics T013 (different files).
+- Across stories after Foundational: US1 and US2 can proceed in parallel (different sink files), but both add methods to `ConfigValueMasking.scala` — serialize the edits to that one file.
+- US4 T024 (overlay logback), T025 (docs) in parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Failing tests first (different files → parallel):
+Task: "T006 nested-config leaf-walk test in SimulationConfigUtilsSpec.scala"
+Task: "T007 SigningKey toString test in SigningKeySpec.scala"
+Task: "T008 -D arg redaction test in DiagnosticsSpec.scala"
+
+# Then implementation across different files:
+Task: "T012 toString override in SigningKey.scala"
+Task: "T010 displayConfig in ConfigValueMasking.scala"
+Task: "T013 -D redaction in Diagnostics.scala"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (central engine, CRITICAL) → 3. Phase 3 US1 → **STOP & VALIDATE** secrets masked at every sink → demo. This alone closes the core #208 security gap.
+
+### Incremental Delivery
+
+1. Setup + Foundational → engine ready.
+2. US1 (P1) → secrets never in logs → MVP.
+3. US2 (P2) → URL userinfo stripped.
+4. US3 (P3) → diagnostics via SLF4J (single event).
+5. US4 (P4) → recommended config + overlay (needs US3).
+
+### Notes
+
+- [P] = different files, no dependencies. Edits to the shared `ConfigValueMasking.scala` (T004/T005/T010/T015) are serialized.
+- Backward compat: no public signature change; `SigningKey` `toString`-only; `private[config]`→`private[gatling]` internal; `picatinny.redaction.*` additive+optional. → v1.23.0 MINOR.
+- Commit after each task or logical group; keep the build green.

--- a/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
+++ b/src/main/scala/org/galaxio/gatling/config/ConfigValueMasking.scala
@@ -1,31 +1,184 @@
 package org.galaxio.gatling.config
 
-private[config] object ConfigValueMasking {
-  private val SensitivePathTokens = Seq(
-    "password",
-    "passwd",
-    "pwd",
-    "secret",
-    "token",
-    "apikey",
-    "api-key",
-    "api_key",
-    "credential",
-    "privatekey",
-    "private_key",
-    "clientsecret",
-    "client_secret",
-    "accesskey",
-    "access_key",
-    "secretkey",
-    "secret_key",
-  )
+import com.typesafe.config.Config
 
-  def displayValue(path: String, value: Any): String =
-    if (isSensitive(path)) "******" else String.valueOf(value)
+import java.net.URI
+import java.util.regex.{Matcher, Pattern}
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+/** Central secret-redaction helper applied at every log/print/exception sink.
+  *
+  * Sensitivity is decided on a key's LAST path segment, split into words across camelCase/snake/kebab boundaries, by three
+  * rules (NOT raw substring):
+  *   - '''compound''' — a contiguous word run equals a multi-word secret term (`apiKey`→`apikey`, `client_secret`,
+  *     `private_key`); also how user-supplied terms match;
+  *   - '''strong''' — a single standalone secret word (`password`, `secret`, `token`, `bearer`, …) appears, UNLESS it is
+  *     immediately followed by a benign structural tail (`tokenBucketSize`, `passwordLength` → not masked);
+  *   - '''suffix floor''' — a separator-less key whose joined segment ENDS WITH a secret noun (`dbpassword`, `apisecret`,
+  *     `accesstoken`) is masked, so coverage is never narrower than the old substring matcher; the head-noun anchor keeps
+  *     prefix-only compounds (`tokenBucketSize`) visible.
+  *
+  * This masks `apiKey`, `bearerToken`, `clientSecret`, `db.password`, `passwordHash`, `tokenValue`, `secret_id` while leaving
+  * non-secret identifiers (`roleId`, `roleIdPrefix`) and benign compounds (`tokenBucketSize`, `apiKeyboard`, `secretariat`)
+  * visible. The term set is the built-in floor MERGED with any user-supplied `picatinny.redaction.additionalSensitiveKeys`
+  * (merge-not-replace). Use [[ConfigValueMasking.fromConfig]] for the config-aware instance; the object-level methods use the
+  * built-in floor only.
+  */
+private[gatling] final class ConfigValueMasking(
+    strongTerms: Set[String],
+    compoundTerms: Set[String],
+    benignTails: Set[String],
+    replacement: String,
+) {
 
   def isSensitive(path: String): Boolean = {
-    val normalized = Option(path).getOrElse("").toLowerCase
-    SensitivePathTokens.exists(normalized.contains)
+    val segmentWords = ConfigValueMasking.words(path)
+    compoundMatch(segmentWords) || strongMatch(segmentWords) || suffixFloor(segmentWords)
   }
+
+  def displayValue(path: String, value: Any): String =
+    if (isSensitive(path)) replacement else String.valueOf(value)
+
+  /** The placeholder this instance substitutes for sensitive values (built-in `******` unless overridden in config). */
+  def placeholder: String = replacement
+
+  /** Render a (possibly nested) config block leaf-by-leaf, masking each leaf by its own key. `entrySet()` returns
+    * already-flattened leaf paths (e.g. `a.b.secret`), so each leaf's last segment drives the masking decision — a benign block
+    * name can no longer hide a secret child.
+    */
+  def displayConfig(cfg: Config): String =
+    cfg
+      .entrySet()
+      .asScala
+      .toSeq
+      .sortBy(_.getKey)
+      .map(entry => s"${entry.getKey} = ${displayValue(entry.getKey, entry.getValue.unwrapped)}")
+      .mkString("\n")
+
+  private def compoundMatch(segmentWords: List[String]): Boolean =
+    ConfigValueMasking.suffixRuns(segmentWords).exists(compoundTerms.contains)
+
+  private def strongMatch(segmentWords: List[String]): Boolean =
+    segmentWords.zipWithIndex.exists { case (word, idx) =>
+      strongTerms.contains(word) && segmentWords.lift(idx + 1).forall(next => !benignTails.contains(next))
+    }
+
+  /** Safety floor against masking regressions: a separator-less key (`dbpassword`, `apisecret`, `accesstoken`) is a single word
+    * that the word-boundary rules miss, yet it ends with a secret noun. Mask when the joined segment ENDS WITH a strong or
+    * compound term — this is the head-noun, so `tokenBucketSize`/`secretariat`/`apiKeyboard` (secret word is a prefix, head is
+    * benign) stay visible. Masking may only loosen, never tighten, versus the prior substring behavior.
+    */
+  private def suffixFloor(segmentWords: List[String]): Boolean = {
+    val joined = segmentWords.mkString
+    joined.nonEmpty && (strongTerms.exists(joined.endsWith) || compoundTerms.exists(joined.endsWith))
+  }
+}
+
+private[gatling] object ConfigValueMasking {
+
+  /** Standalone secret words — match in any position on the segment (subject to the benign-tail guard). */
+  private val StrongTerms: Set[String] =
+    Set("password", "passwd", "pwd", "secret", "token", "credential", "credentials", "passphrase", "authorization", "bearer")
+
+  /** Multi-word secret terms — match only as an exact contiguous (suffix-anchored) word run, e.g. `apiKey`→`apikey`. */
+  private val CompoundTerms: Set[String] =
+    Set("apikey", "privatekey", "clientsecret", "accesskey", "secretkey")
+
+  /** Structural words that, immediately AFTER a strong term, mark a non-secret metadata key (count/duration/size), e.g.
+    * `tokenBucketSize`, `passwordLength`, `secretRotation`. Deliberately excludes ambiguous tails like `id`/`name` so genuine
+    * credentials (`secret_id`) stay masked.
+    */
+  private val BenignTails: Set[String] =
+    Set("bucket", "size", "count", "limit", "length", "timeout", "ttl", "interval", "expiry", "rotation", "age")
+
+  val Replacement: String = "******"
+
+  private val ExtraKeysPath      = "picatinny.redaction.additionalSensitiveKeys"
+  private val ReplacementCfgPath = "picatinny.redaction.replacement"
+
+  /** Precompiled once — `String.replaceAll` would recompile this on every call. */
+  private val CamelBoundary: Pattern = Pattern.compile("([a-z0-9])([A-Z])")
+
+  /** The built-in-floor instance (no user-configured terms). Used by the object-level helpers and as the explicit argument when
+    * a caller has no `Config` to derive from (e.g. tests).
+    */
+  private[gatling] val builtin = new ConfigValueMasking(StrongTerms, CompoundTerms, BenignTails, Replacement)
+
+  def isSensitive(path: String): Boolean             = builtin.isSensitive(path)
+  def displayValue(path: String, value: Any): String = builtin.displayValue(path, value)
+  def displayConfig(cfg: Config): String             = builtin.displayConfig(cfg)
+
+  /** Build a config-aware masking instance: built-in terms MERGED with `picatinny.redaction.additionalSensitiveKeys` (never
+    * replaced; user terms join the compound set). An absent block falls back to the built-in floor. The placeholder may be
+    * overridden via `picatinny.redaction.replacement`.
+    */
+  def fromConfig(config: Config): ConfigValueMasking = {
+    val extra       = stringListAt(config, ExtraKeysPath).iterator.flatMap(normalizedTerm).toSet
+    val replacement = stringAt(config, ReplacementCfgPath).getOrElse(Replacement)
+    new ConfigValueMasking(StrongTerms, CompoundTerms ++ extra, BenignTails, replacement)
+  }
+
+  /** Strip URL userinfo (`user:password@`) before logging. Fail-safe: never throws, never returns the raw credential.
+    *   - parses with [[java.net.URI]]; if userinfo present, replaces the FIRST `userinfo@` run with the placeholder
+    *   - parsed but no userinfo → original returned unchanged (incl. opaque URIs like `mailto:`)
+    *   - unparseable → regex strip, then a conservative fully-redacted placeholder if even that fails to match
+    *   - `null` input → empty string (callers log the result; never a NPE)
+    */
+  def redactUserInfo(raw: String): String =
+    Option(raw).fold("") { value =>
+      Try(new URI(value)).fold(
+        _ => fallbackRedact(value),
+        uri =>
+          userInfoOf(uri)
+            .filter(_.nonEmpty)
+            .fold(value)(userInfo =>
+              value.replaceFirst(Pattern.quote(s"$userInfo@"), Matcher.quoteReplacement(s"$Replacement@")),
+            ),
+      )
+    }
+
+  private def userInfoOf(uri: URI): Option[String] =
+    Option(uri.getRawUserInfo)
+      .orElse(Option(uri.getRawAuthority).filter(_.contains('@')).map(_.takeWhile(_ != '@')))
+
+  private def fallbackRedact(value: String): String =
+    value.replaceFirst("://[^/@\\s]*@", s"://$Replacement@") match {
+      case stripped if stripped != value => stripped
+      case _ if value.contains('@')      => Replacement
+      case unchanged                     => unchanged
+    }
+
+  private def stringListAt(config: Config, path: String): collection.Seq[String] =
+    if (config.hasPath(path)) config.getStringList(path).asScala else Nil
+
+  private def stringAt(config: Config, path: String): Option[String] =
+    Option.when(config.hasPath(path))(config.getString(path))
+
+  private def words(path: String): List[String] =
+    splitWords(lastSegment(path))
+
+  private def lastSegment(path: String): String =
+    Option(path).getOrElse("") match {
+      case ""      => ""
+      case present => present.split(Array('.', '/')).filter(_.nonEmpty).lastOption.getOrElse(present)
+    }
+
+  /** Split a path segment into lowercase words across camelCase, snake_case and kebab-case boundaries. */
+  private def splitWords(segment: String): List[String] =
+    Option(segment)
+      .filter(_.nonEmpty)
+      .toList
+      .flatMap(seg => CamelBoundary.matcher(seg).replaceAll("$1 $2").split(Array('_', '-', ' ')))
+      .filter(_.nonEmpty)
+      .map(_.toLowerCase)
+
+  /** Contiguous word runs that END at the last word: for `[a,b,c]` → `"abc"`, `"bc"`, `"c"`. The secret noun is the head (last
+    * element) of an English compound (`bearer token`, `client secret`, `api key`), so suffix-anchored runs match those while
+    * sparing prefix uses like `token bucket size`.
+    */
+  private def suffixRuns(segmentWords: List[String]): List[String] =
+    segmentWords.tails.collect { case run if run.nonEmpty => run.mkString }.toList
+
+  private def normalizedTerm(term: String): Option[String] = Some(splitWords(term).mkString).filter(_.nonEmpty)
 }

--- a/src/main/scala/org/galaxio/gatling/config/SimulationConfigUtils.scala
+++ b/src/main/scala/org/galaxio/gatling/config/SimulationConfigUtils.scala
@@ -12,6 +12,7 @@ import com.typesafe.config.ConfigException
 import com.typesafe.scalalogging.LazyLogging
 
 private[gatling] class SimulationConfigUtils(config: Config) extends LazyLogging {
+  private[gatling] val masking  = ConfigValueMasking.fromConfig(config)
   private val StringTag         = typeTag[String]
   private val FiniteDurationTag = typeTag[FiniteDuration]
   private val StringListTag     = typeTag[List[String]]
@@ -48,7 +49,11 @@ private[gatling] class SimulationConfigUtils(config: Config) extends LazyLogging
     readValueByType(cfg, path)
       .map(_.asInstanceOf[T])
       .map { value =>
-        logger.info(s"Simulation param for $path is set to: ${ConfigValueMasking.displayValue(path, value)}")
+        val shown = value match {
+          case cfgValue: Config => masking.displayConfig(cfgValue)
+          case other            => masking.displayValue(path, other)
+        }
+        logger.info(s"Simulation param for $path is set to: $shown")
         value
       }
       .recoverWith(configReadFailure(path, tag))

--- a/src/main/scala/org/galaxio/gatling/diagnostics/Diagnostics.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/Diagnostics.scala
@@ -2,23 +2,46 @@ package org.galaxio.gatling.diagnostics
 
 import java.lang.management.ManagementFactory
 
-import org.galaxio.gatling.config.ConfigManager
+import com.typesafe.scalalogging.StrictLogging
+import org.galaxio.gatling.config.{ConfigManager, ConfigValueMasking}
 
 import scala.jdk.CollectionConverters._
 
-object Diagnostics {
+object Diagnostics extends StrictLogging {
   private val EnabledPath = "picatinny.diagnostics.enabled"
 
   def printIfEnabled(): Unit =
-    if (isEnabled) println(render())
+    if (isEnabled) logger.info(render())
 
   private[gatling] def isEnabled: Boolean =
     ConfigManager.simulationConfig.get(EnabledPath, false)
 
+  /** Redact the value of a sensitive `-Dkey=value` (or `-Dkey:value`) JVM argument, keeping the key visible. Uses the SAME
+    * config-aware masking instance as config logging, so `picatinny.redaction.additionalSensitiveKeys` / `replacement` also
+    * apply to JVM args. Non-`-D` or value-less args pass through unchanged.
+    */
+  private[diagnostics] def redactArg(arg: String, masking: ConfigValueMasking): String =
+    Option(arg)
+      .filter(_.startsWith("-D"))
+      .map(_.drop(2))
+      .flatMap(splitKeyValue)
+      .collect {
+        case (key, separator) if masking.isSensitive(key) => s"-D$key$separator${masking.placeholder}"
+      }
+      .getOrElse(arg)
+
+  /** Split a `-D` body into `(key, separator)` at the first `=`/`:`, or `None` when there is no value (key stays intact). */
+  private def splitKeyValue(body: String): Option[(String, Char)] =
+    body.indexWhere(c => c == '=' || c == ':') match {
+      case idx if idx > 0 => Some((body.take(idx), body.charAt(idx)))
+      case _              => None
+    }
+
   private[diagnostics] def render(): String = {
     val runtime = Runtime.getRuntime
     val mxBean  = ManagementFactory.getRuntimeMXBean
-    val args    = mxBean.getInputArguments.asScala.mkString(" ")
+    val masking = ConfigManager.simulationConfig.masking
+    val args    = mxBean.getInputArguments.asScala.map(redactArg(_, masking)).mkString(" ")
 
     s"""Diagnostics
        |   java           : ${System.getProperty("java.version")} ${System.getProperty("java.vendor")}

--- a/src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala
+++ b/src/main/scala/org/galaxio/gatling/diagnostics/StartupBanner.scala
@@ -1,18 +1,19 @@
 package org.galaxio.gatling.diagnostics
 
+import com.typesafe.scalalogging.StrictLogging
 import io.gatling.core.controller.inject.closed.ClosedInjectionStep
 import io.gatling.core.controller.inject.open.OpenInjectionStep
-import org.galaxio.gatling.config.ConfigManager
+import org.galaxio.gatling.config.{ConfigManager, ConfigValueMasking}
 import org.galaxio.gatling.utils.IntensityConverter.getIntensityFromString
 
 import scala.concurrent.duration.FiniteDuration
 
-object StartupBanner {
+object StartupBanner extends StrictLogging {
   private val EnabledPath        = "picatinny.startup.banner.enabled"
   private val InternalStackNames = Set("Utility", "StartupBanner", "Diagnostics")
 
   def printIfEnabled(): Unit =
-    if (isEnabled) println(render())
+    if (isEnabled) logger.info(render())
 
   def printOpenIfEnabled(openSteps: Iterable[OpenInjectionStep]): Unit =
     printSettingsIfEnabled(InjectionProfileParser.fromOpen(openSteps))
@@ -24,10 +25,10 @@ object StartupBanner {
     printSimulationIfEnabled(Some(simulationClass))
 
   private[gatling] def printSettingsIfEnabled(settings: Option[WorkloadSettings]): Unit =
-    if (isEnabled) println(settings.map(render).getOrElse(render()))
+    if (isEnabled) logger.info(settings.map(render).getOrElse(render()))
 
   private def printSimulationIfEnabled(simulationClass: Option[Class[_]]): Unit =
-    if (isEnabled) println(render(simulationClass, None))
+    if (isEnabled) logger.info(render(simulationClass, None))
 
   private[gatling] def isEnabled: Boolean =
     ConfigManager.simulationConfig.get(EnabledPath, true)
@@ -51,7 +52,7 @@ object StartupBanner {
        | Picatinny Gatling Run
        |$line
        | Simulation   : $name
-       | Base URL     : ${config.get[String]("baseUrl", "<undefined>")}
+       | Base URL     : ${ConfigValueMasking.redactUserInfo(config.get[String]("baseUrl", "<undefined>"))}
        |
        |${providedSettings.map(workloadBlock).getOrElse(configWorkloadBlock(name, stages))}
        |$line

--- a/src/main/scala/org/galaxio/gatling/utils/jwt/SigningKey.scala
+++ b/src/main/scala/org/galaxio/gatling/utils/jwt/SigningKey.scala
@@ -17,11 +17,18 @@ sealed trait SigningKey
 
 object SigningKey {
 
-  /** HMAC secret as a plain string. Used with HS256, HS384, HS512. */
-  final case class StringSecret(value: String) extends SigningKey
+  /** HMAC secret as a plain string. Used with HS256, HS384, HS512. `toString` is redacted so the secret never leaks via logs,
+    * exceptions, or string interpolation; the `value` accessor still returns the raw secret.
+    */
+  final case class StringSecret(value: String) extends SigningKey {
+    override def toString: String = "StringSecret(******)"
+  }
 
   /** Asymmetric private key for RSA or EC algorithms. Used with RS256, RS384, RS512, ES256, ES384, ES512. Load keys via
-    * [[JwtKeys]] helpers.
+    * [[JwtKeys]] helpers. `toString` is redacted so provider-dependent key material never leaks; the `value` accessor still
+    * returns the raw key.
     */
-  final case class AsymmetricKey(value: PrivateKey) extends SigningKey
+  final case class AsymmetricKey(value: PrivateKey) extends SigningKey {
+    override def toString: String = "AsymmetricKey(******)"
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/LogbackPackagingGuardSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/LogbackPackagingGuardSpec.scala
@@ -1,0 +1,34 @@
+package org.galaxio.gatling
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
+
+/** Regression guard for FR-010: the published library MUST NOT ship an auto-discovered logback configuration on its
+  * main/compile classpath, which would collide with a consumer's own config. logback config is permitted ONLY in the library's
+  * own test scope (`src/test/resources`, excluded from the artifact). Run from the project root.
+  */
+class LogbackPackagingGuardSpec extends AnyWordSpec with Matchers {
+
+  "the published library" should {
+    "ship no logback configuration under src/main/resources (FR-010)" in {
+      val mainResources = new File("src/main/resources")
+      val offenders     =
+        if (!mainResources.isDirectory) Nil
+        else
+          mainResources
+            .listFiles()
+            .toList
+            .map(_.getName)
+            .filter(name => name == "logback.xml" || name == "logback-test.xml")
+
+      offenders shouldBe empty
+    }
+
+    "keep logback config in test scope only" in {
+      // The library's own test logback config is expected (excluded from the published artifact).
+      new File("src/test/resources/logback.xml").isFile shouldBe true
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/assertions/AssertionsBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/assertions/AssertionsBuilderSpec.scala
@@ -1,17 +1,12 @@
 package org.galaxio.gatling.assertions
 
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
-import ch.qos.logback.core.read.ListAppender
 import io.gatling.commons.stats.assertion.Assertion
 import io.gatling.core.Predef._
 import io.gatling.core.assertion.AssertionPathParts
 import io.gatling.core.config.GatlingConfiguration
+import org.galaxio.gatling.testutil.LogCapture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.slf4j.LoggerFactory
-
-import scala.jdk.CollectionConverters._
 
 /** Unit tests for the Scala [[AssertionsBuilder]] (test-model layer 1). Driven through the `assertionsFrom` test seam, which
   * takes a [[GatlingConfiguration]] explicitly, so `GatlingConfiguration.loadForTest()` builds against the `nfr.yml` fixture
@@ -43,20 +38,8 @@ class AssertionsBuilderSpec extends AnyWordSpec with Matchers {
     details(grp("GET /test/uuid")).responseTime.max.lt(1000),
   )
 
-  private def captureWarns(body: => Unit): List[String] = {
-    val logger   = LoggerFactory.getLogger("org.galaxio.gatling.assertions").asInstanceOf[LogbackLogger]
-    val appender = new ListAppender[ILoggingEvent]()
-    appender.start()
-    val prev     = logger.getLevel
-    logger.setLevel(Level.WARN)
-    logger.addAppender(appender)
-    try body
-    finally {
-      logger.detachAppender(appender)
-      logger.setLevel(prev)
-    }
-    appender.list.asScala.toList.filter(_.getLevel == Level.WARN).map(_.getFormattedMessage)
-  }
+  private def captureWarns(body: => Unit): List[String] =
+    LogCapture.warns("org.galaxio.gatling.assertions")(body)
 
   "AssertionsBuilder.assertionsFrom" should {
 

--- a/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/config/SimulationConfigUtilsSpec.scala
@@ -1,6 +1,7 @@
 package org.galaxio.gatling.config
 
 import com.typesafe.config.ConfigFactory
+import org.galaxio.gatling.testutil.LogCapture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -161,6 +162,122 @@ class ConfigValueMaskingSpec extends AnyWordSpec with Matchers {
     "handle null display inputs defensively" in {
       ConfigValueMasking.displayValue(null, "value") shouldBe "value"
       ConfigValueMasking.displayValue("token", null) shouldBe "******"
+    }
+
+    "match required sensitive terms by whole word on the last path segment (FR-003)" in {
+      val sensitive = Seq(
+        "authorization",
+        "bearerToken",
+        "passphrase",
+        "client.apiKey",
+        "vault.clientSecret",
+        "db.password",
+        "auth.token",
+        // prefix-secret compounds: the secret word is the HEAD, not the tail
+        "passwordHash",
+        "tokenValue",
+        "secretValue",
+        "vault.secret_id",
+      )
+      sensitive.foreach(p => withClue(p) { ConfigValueMasking.isSensitive(p) shouldBe true })
+    }
+
+    // Regression guard: the old substring matcher masked separator-less keys; whole-word matching must not LEAK them.
+    // Covered by the suffix floor (the secret noun is the tail) so the over-match fix for tokenBucketSize/secretariat holds.
+    "mask separator-less and plural secret keys (no masking regression vs substring)" in {
+      val sensitive = Seq(
+        "dbpassword",
+        "apisecret",
+        "accesstoken",
+        "apitoken",
+        "authtoken",
+        "adminpwd",
+        "userpassword",
+        "jwtsecret",
+        "myapikey",
+        "credentials",
+        "app.credentials",
+      )
+      sensitive.foreach(p => withClue(p) { ConfigValueMasking.isSensitive(p) shouldBe true })
+    }
+
+    "not mask a strong term followed by a benign structural tail (FR-003 boundary)" in {
+      val benignTails = Seq(
+        "tokenBucketSize",
+        "passwordLength",
+        "secretRotation",
+        "tokenTtl",
+      )
+      benignTails.foreach(p => withClue(p) { ConfigValueMasking.isSensitive(p) shouldBe false })
+    }
+
+    "not over-match non-secret identifiers or benign compounds (FR-003 negatives)" in {
+      val benign = Seq(
+        "roleId",
+        "roleIdPrefix",
+        "tokenBucketSize",
+        "apiKeyboard",
+        "secretariat",
+        "baseUrl",
+      )
+      benign.foreach(p => withClue(p) { ConfigValueMasking.isSensitive(p) shouldBe false })
+    }
+
+    "merge user-supplied sensitive keys without dropping built-ins (FR-012)" in {
+      val masking = ConfigValueMasking.fromConfig(
+        ConfigFactory.parseString("""picatinny.redaction.additionalSensitiveKeys = ["tenantRef"]"""),
+      )
+      masking.displayValue("tenantRef", "v") shouldBe "******"   // user-added
+      masking.displayValue("db.password", "v") shouldBe "******" // built-in still masks (merge, not replace)
+      masking.displayValue("baseUrl", "http://x") shouldBe "http://x"
+
+      val defaults = ConfigValueMasking.fromConfig(ConfigFactory.empty())
+      defaults.displayValue("db.password", "v") shouldBe "******" // absent block → built-ins apply
+      defaults.displayValue("tenantRef", "v") shouldBe "v"        // not a built-in
+    }
+
+    "mask secret leaves inside a benignly-named nested block (FR-004)" in {
+      val cfg = ConfigFactory.parseString(
+        """url = "http://h"
+          |token = "abc"
+          |nested { inner { secret = "deep" } }
+          |size = 10
+          |""".stripMargin,
+      )
+      val out = ConfigValueMasking.displayConfig(cfg)
+      out should include("url = http://h")
+      out should include("token = ******")
+      out should include("nested.inner.secret = ******")
+      out should include("size = 10")
+      out should not include "abc"
+      out should not include "deep"
+    }
+
+    "strip URL userinfo fail-safely (FR-007)" in {
+      ConfigValueMasking.redactUserInfo("https://user:pass@host:8080/p") shouldBe "https://******@host:8080/p"
+      ConfigValueMasking.redactUserInfo("https://host/p") shouldBe "https://host/p"
+      ConfigValueMasking.redactUserInfo("mailto:a@b") shouldBe "mailto:a@b"
+      val malformed = ConfigValueMasking.redactUserInfo("https://user:p%ss@host/path")
+      malformed should include("******")
+      malformed should not include "p%ss"
+      malformed should not include "user:p"
+    }
+
+    "mask the logged param value at the config sink and leave others visible (FR-001)" in {
+      val utils   = SimulationConfigUtils(
+        ConfigFactory.parseString("""db { password = "s3cr3t", url = "http://localhost" }"""),
+      )
+      val logs    = LogCapture
+        .infoEvents("org.galaxio.gatling.config.SimulationConfigUtils") {
+          utils.get[String]("db.password")
+          utils.get[String]("db.url")
+        }
+        .map(_.getFormattedMessage)
+      val pwdLine = logs.find(_.contains("db.password")).getOrElse("")
+      pwdLine should include("******")
+      pwdLine should not include "s3cr3t"
+      val urlLine = logs.find(_.contains("db.url")).getOrElse("")
+      urlLine should include("http://localhost")
     }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/DiagnosticsSpec.scala
@@ -1,6 +1,9 @@
 package org.galaxio.gatling.diagnostics
 
+import com.typesafe.config.ConfigFactory
 import io.gatling.core.Predef._
+import org.galaxio.gatling.config.ConfigValueMasking
+import org.galaxio.gatling.testutil.LogCapture
 import org.scalatest.OptionValues
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -289,6 +292,39 @@ class DiagnosticsSpec extends AnyWordSpec with Matchers with OptionValues {
     "respect enabled flags from test resources" in {
       StartupBanner.isEnabled shouldBe true
       Diagnostics.isEnabled shouldBe false
+    }
+
+    "redact sensitive -D JVM arguments while leaving others intact (FR-006)" in {
+      val masking = ConfigValueMasking.builtin
+      Diagnostics.redactArg("-Xmx2g", masking) shouldBe "-Xmx2g"
+      Diagnostics.redactArg("-DvaultToken=hunter2", masking) shouldBe "-DvaultToken=******"
+      Diagnostics.redactArg("-Dapp.name=foo", masking) shouldBe "-Dapp.name=foo"
+      Diagnostics.redactArg("-DvaultToken", masking) shouldBe "-DvaultToken" // no value → unchanged
+      Diagnostics.redactArg("-Dpassword:hunter2", masking) shouldBe "-Dpassword:******"
+    }
+
+    "honor config-extended terms and replacement for -D args (FR-002/FR-012)" in {
+      val masking = ConfigValueMasking.fromConfig(
+        ConfigFactory.parseString(
+          """picatinny.redaction { additionalSensitiveKeys = ["tenantRef"], replacement = "######" }""",
+        ),
+      )
+      Diagnostics.redactArg("-DtenantRef=abc", masking) shouldBe "-DtenantRef=######" // custom term + custom placeholder
+      Diagnostics.redactArg("-Dpassword=x", masking) shouldBe "-Dpassword=######"     // built-in still masks
+      Diagnostics.redactArg("-Dother=keep", masking) shouldBe "-Dother=keep"          // unknown term untouched
+    }
+
+    "emit the startup banner as a single SLF4J event under the diagnostics category (FR-008/009)" in {
+      val events  = LogCapture.infoEvents("org.galaxio.gatling.diagnostics") {
+        StartupBanner.printIfEnabled()
+      }
+      events should have size 1
+      val event   = events.head
+      event.getLoggerName should startWith("org.galaxio.gatling.diagnostics")
+      val message = event.getMessage
+      message should include("Picatinny Gatling Run")
+      message should include("\n") // one multi-line event, NOT split per line
+      message should include("|")
     }
 
   }

--- a/src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/diagnostics/UtilityIntegrationSpec.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.diagnostics
 
+import org.galaxio.gatling.testutil.LogCapture
 import org.galaxio.gatling.utils.Utility
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -7,14 +8,17 @@ import org.scalatest.wordspec.AnyWordSpec
 class UtilityIntegrationSpec extends AnyWordSpec with Matchers {
 
   "Utility.banner" should {
-    "print startup banner with a continuous workload chart" in {
-      val output = new java.io.ByteArrayOutputStream()
-
-      Console.withOut(output) {
-        Utility.banner()
+    "emit the startup banner through SLF4J (not stdout) as a single event" in {
+      val stdout = new java.io.ByteArrayOutputStream()
+      val events = LogCapture.infoEvents("org.galaxio.gatling.diagnostics") {
+        Console.withOut(stdout) {
+          Utility.banner()
+        }
       }
 
-      val text = output.toString("UTF-8")
+      stdout.toString("UTF-8") shouldBe empty // routed through the logging framework, no println
+      events should have size 1
+      val text = events.head.getFormattedMessage
       text should include("Picatinny Gatling Run")
       text should include("ASCII preview")
       text should include("|")
@@ -25,15 +29,16 @@ class UtilityIntegrationSpec extends AnyWordSpec with Matchers {
   }
 
   "Utility.diagnostics" should {
-    "print nothing when disabled in test resources" in {
-      val output = new java.io.ByteArrayOutputStream()
-
-      Console.withOut(output) {
-        Utility.diagnostics()
+    "emit nothing when disabled in test resources" in {
+      val stdout = new java.io.ByteArrayOutputStream()
+      val events = LogCapture.infoEvents("org.galaxio.gatling.diagnostics") {
+        Console.withOut(stdout) {
+          Utility.diagnostics()
+        }
       }
 
-      output.toString("UTF-8") shouldBe empty
+      stdout.toString("UTF-8") shouldBe empty
+      events shouldBe empty
     }
   }
-
 }

--- a/src/test/scala/org/galaxio/gatling/storage/CookieParserSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/storage/CookieParserSpec.scala
@@ -1,38 +1,16 @@
 package org.galaxio.gatling.storage
 
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
-import ch.qos.logback.core.AppenderBase
+import org.galaxio.gatling.testutil.LogCapture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.slf4j.LoggerFactory
-
-import java.util.concurrent.ConcurrentLinkedQueue
-import scala.jdk.CollectionConverters._
 
 class CookieParserSpec extends AnyWordSpec with Matchers {
 
-  /** Capture WARN messages under the `org.galaxio.gatling.storage` logger while `body` runs. Uses a thread-safe queue-backed
-    * appender so events propagated from sibling storage classes (exercised by other suites running in parallel) cannot corrupt
-    * the capture; results are content-filtered to CookieParser's own Max-Age warnings.
+  /** Capture WARN messages under the `org.galaxio.gatling.storage` logger while `body` runs, via the shared JVM-serialized
+    * [[LogCapture]] (capture mutates the global logback context — see its docs).
     */
-  private def captureWarns(body: => Unit): List[String] = {
-    val logger   = LoggerFactory.getLogger("org.galaxio.gatling.storage").asInstanceOf[LogbackLogger]
-    val events   = new ConcurrentLinkedQueue[ILoggingEvent]()
-    val appender = new AppenderBase[ILoggingEvent] {
-      override def append(e: ILoggingEvent): Unit = events.add(e)
-    }
-    appender.start()
-    val prev     = logger.getLevel
-    logger.setLevel(Level.WARN)
-    logger.addAppender(appender)
-    try body
-    finally {
-      logger.detachAppender(appender)
-      logger.setLevel(prev)
-    }
-    events.asScala.toList.filter(_.getLevel == Level.WARN).map(_.getFormattedMessage)
-  }
+  private def captureWarns(body: => Unit): List[String] =
+    LogCapture.warns("org.galaxio.gatling.storage")(body)
 
   "CookieParser" should {
 

--- a/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
+++ b/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
@@ -1,0 +1,69 @@
+package org.galaxio.gatling.testutil
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
+import ch.qos.logback.core.AppenderBase
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
+
+/** Shared log capture for tests — safe under ScalaTest's PARALLEL suite execution.
+  *
+  * Capturing mutates the GLOBAL logback `LoggerContext` (a logger's level + attached appenders), which is shared across suites.
+  * Two independent safeguards make it deterministic without serializing the whole test run:
+  *
+  *   1. `synchronized` — serializes the level save/set/restore + appender attach/detach so two captures never corrupt each
+  *      other's level restore (the part that genuinely needs mutual exclusion).
+  *   2. thread-name filter + a thread-safe queue — while a capture window is open, OTHER (non-capturing) suites running in
+  *      parallel may still log to the same logger on their own threads. The appender is backed by a `ConcurrentLinkedQueue` (so
+  *      concurrent foreign appends can't corrupt it), and the result keeps only events emitted on the capturing thread (the
+  *      body logs synchronously on the caller thread), discarding foreign noise.
+  *
+  * All log-capturing suites must go through this object so the guarantee holds.
+  */
+object LogCapture {
+
+  /** Capture the events `body` emits under `loggerName` at `level` (inclusive), on the calling thread only. */
+  def events(loggerName: String, level: Level)(body: => Unit): List[ILoggingEvent] = synchronized {
+    val logger        = logbackLogger(loggerName)
+    val captured      = new ConcurrentLinkedQueue[ILoggingEvent]()
+    val appender      = new AppenderBase[ILoggingEvent] {
+      override def append(event: ILoggingEvent): Unit = captured.add(event)
+    }
+    appender.start()
+    val captureThread = Thread.currentThread().getName
+    val previousLevel = logger.getLevel
+    logger.setLevel(level)
+    logger.addAppender(appender)
+    try body
+    finally {
+      logger.detachAppender(appender)
+      logger.setLevel(previousLevel)
+    }
+    captured.asScala.iterator.filter(_.getThreadName == captureThread).toList
+  }
+
+  /** Capture INFO+ events (raw, for asserting logger name / single-event / message structure). */
+  def infoEvents(loggerName: String)(body: => Unit): List[ILoggingEvent] =
+    events(loggerName, Level.INFO)(body)
+
+  /** Capture WARN messages (formatted) emitted under `loggerName`. */
+  def warns(loggerName: String)(body: => Unit): List[String] =
+    events(loggerName, Level.WARN)(body).filter(_.getLevel == Level.WARN).map(_.getFormattedMessage)
+
+  /** Resolve the logback `Logger`, retrying past SLF4J's initialization window.
+    *
+    * Under parallel suite STARTUP, `LoggerFactory.getLogger` returns a temporary `org.slf4j.helpers.SubstituteLogger` until
+    * logback finishes binding — casting that to `ch.qos.logback.classic.Logger` throws `ClassCastException`. The first real
+    * call triggers binding; we retry briefly until the backend is installed (bounded so a genuine misbind still surfaces a
+    * clear cast error rather than hanging).
+    */
+  @annotation.tailrec
+  private def logbackLogger(loggerName: String, attemptsLeft: Int = 2000): LogbackLogger =
+    LoggerFactory.getLogger(loggerName) match {
+      case logback: LogbackLogger => logback
+      case _ if attemptsLeft > 0  => Thread.sleep(1); logbackLogger(loggerName, attemptsLeft - 1)
+      case other                  => other.asInstanceOf[LogbackLogger] // exhausted → surface a clear cast error
+    }
+}

--- a/src/test/scala/org/galaxio/gatling/utils/UtilitySpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/UtilitySpec.scala
@@ -1,29 +1,27 @@
 package org.galaxio.gatling.utils
 
 import io.gatling.core.Predef._
+import org.galaxio.gatling.testutil.LogCapture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 
 /** Unit tests for the [[Utility]] banner overloads (test-model layer 1). The test `simulation.conf` enables the startup banner,
-  * so each overload prints; output is captured via `Console.withOut` and asserted to contain the banner header. This exercises
-  * the open/closed/list/tuple injection-step parsing paths (`StartupBanner.printOpen/Closed/SettingsIfEnabled`) that the no-arg
-  * `banner()` test does not reach.
+  * so each overload emits one log event; output is captured via the diagnostics logger (banner now routes through SLF4J, not
+  * stdout) and asserted to contain the banner header. This exercises the open/closed/list/tuple injection-step parsing paths
+  * (`StartupBanner.printOpen/Closed/SettingsIfEnabled`) that the no-arg `banner()` test does not reach.
   */
 class UtilitySpec extends AnyWordSpec with Matchers {
 
   private val BannerHeader = "Picatinny Gatling Run"
 
-  private def capture(f: => Unit): String = {
-    val out = new java.io.ByteArrayOutputStream()
-    Console.withOut(out)(f)
-    out.toString("UTF-8")
-  }
+  private def capture(f: => Unit): String =
+    LogCapture.infoEvents("org.galaxio.gatling.diagnostics")(f).map(_.getFormattedMessage).mkString("\n")
 
-  // The no-arg banner renders the workload from simulation.conf. Each step-parsing overload must render the workload PARSED
-  // from its argument, which differs from the conf fallback — so `should not be fallback` catches a silent fall-through to
-  // banner() (e.g. the printFromValues default case) that asserting only the static header would miss.
+  // The no-arg banner renders the workload from simulation.conf. Each step-parsing overload must render the workload
+  // PARSED from its argument, which differs from the conf fallback — so `should not be fallback` catches a silent
+  // fall-through to banner() (e.g. the printFromValues default case) that asserting only the static header would miss.
   private val fallback = capture(Utility.banner())
 
   "Utility.banner" should {

--- a/src/test/scala/org/galaxio/gatling/utils/jwt/SigningKeySpec.scala
+++ b/src/test/scala/org/galaxio/gatling/utils/jwt/SigningKeySpec.scala
@@ -1,0 +1,32 @@
+package org.galaxio.gatling.utils.jwt
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.security.{KeyPairGenerator, PrivateKey}
+
+/** Unit tests (test-model layer 1) for [[SigningKey]] secret redaction (FR-005). `toString` must never expose the HMAC secret
+  * or asymmetric key material, while the `value` accessor still returns the raw material (API intact).
+  */
+class SigningKeySpec extends AnyWordSpec with Matchers {
+
+  "SigningKey.StringSecret" should {
+    "redact the secret in toString while keeping the value accessor intact" in {
+      val key = SigningKey.StringSecret("topsecret")
+      key.toString shouldBe "StringSecret(******)"
+      key.toString should not include "topsecret"
+      s"key=$key" should not include "topsecret"
+      key.value shouldBe "topsecret"
+    }
+  }
+
+  "SigningKey.AsymmetricKey" should {
+    "redact the key material in toString while keeping the value accessor intact" in {
+      val privateKey: PrivateKey = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPrivate
+      val key                    = SigningKey.AsymmetricKey(privateKey)
+      key.toString shouldBe "AsymmetricKey(******)"
+      key.toString should not include privateKey.toString
+      key.value shouldBe privateKey
+    }
+  }
+}


### PR DESCRIPTION
## What

Milestone 8 (v1.23.0): close credential-leak paths with **one central redaction helper** applied at every log/print/exception sink. Resolves #208, #87, #88.

## Why

Vault tokens, HMAC secrets, bearer tokens, URL passwords and `-DvaultToken=…` JVM args could appear in plaintext in CI logs. The existing `ConfigValueMasking` also over-matched benign keys (`roleIdPrefix`, `tokenBucketSize`) via raw substring.

## Changes

**Masking core (`ConfigValueMasking`)**
- Raw `contains` → **last-path-segment word-boundary** matching: compound runs (`apiKey`→`apikey`) + strong standalone words (`password`/`secret`/`token`/…) guarded by a **benign-tail denylist** (`tokenBucketSize`, `passwordLength` stay visible).
- Now masks **prefix-secret compounds** that suffix-only matching missed: `passwordHash`, `tokenValue`, `secret_id`.
- Added terms: `authorization`, `bearer`, `passphrase`.
- **Config-extensible** via optional `picatinny.redaction.additionalSensitiveKeys` / `replacement` (merge-not-replace — users can only ADD to the floor).
- Visibility `private[config]` → `private[gatling]` (internal; reused by diagnostics).

**Leak sinks**
- Nested config: `getConfig` value rendered via per-leaf `entrySet` walk (`displayConfig`) — a benign block name can't hide a secret child.
- `SigningKey.StringSecret`/`AsymmetricKey` `toString` redacted (`value` accessor unchanged).
- `Diagnostics`: redact sensitive `-Dkey=value` JVM args; `println` → SLF4J single event.
- `StartupBanner`: strip URL userinfo (fail-safe, never throws); `println` → SLF4J single event.

**Logging delivery (#88)**
- Library ships **no logback on its main classpath** (avoids consumer classpath conflict). Recommended config in [`docs/logging.md`](docs/logging.md) + the `scala-sbt-example` overlay: dedicated `org.galaxio.gatling.diagnostics` category, bare `%msg%n`, `additivity="false"` (banner renders prefix-free, single event, suppressible). `LogbackPackagingGuardSpec` locks the invariant.

**Tests / quality**
- Shared `org.galaxio.gatling.testutil.LogCapture` replaces 4 duplicated capture helpers.
- Precompiled camelCase `Pattern` (no per-call regex compile).
- Functional style (`Try`/`Option`/pattern matching).

## Reviewer notes

- **No public API change** → MINOR (v1.23.0). `SigningKey` change is `toString`-only.
- New `picatinny.redaction.*` config keys are additive + optional (absent = built-in defaults).
- **Performance**: masking runs only at config-read/startup, not in Gatling's per-request path; `scala-logging` macros skip it entirely when the logger is above INFO.
- Coverage **70.77% stmt / 67.17% branch** (floor 65/60). Full suite 823 tests, green across 3 consecutive runs.
- Spec/plan/tasks under [`specs/007-secret-masking-leak-prevention/`](specs/007-secret-masking-leak-prevention/).
- 2 tasks (T026 e2e overlay run, T029 grep smoke) **deferred to CI** — they need the artifact published to mavenLocal; the behavior they exercise is covered at the unit layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)