### PR TITLE
docs(agents): codify commit/PR conventions + idiomatic Scala rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 **/.gradle/
 **/build/
 .claude/settings.local.json
+.claude/skills/speckit-worktrees-*/
+.specify/extensions/
+.specify/presets/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,14 @@ Coverage floor 65/60 (stmt/branch). Every `/speckit-plan` fills the code-free "T
 
 **Never:** force-push or commit to `main`, merge commits in PR branches (rebase only), commit broken code, opportunistic refactors outside scope, mock Gatling runtime where a real integration path exists.
 
+## Commits & PRs
+
+- **Spec-first.** `specs/NNN-*/` artifacts → `docs(speckit): add NNN-<feature> spec/plan/tasks` commit BEFORE any `feat`/`fix`. Never folded into implementation.
+- **1 issue = 1 commit.** Each tracked GitHub issue maps to one semantic commit (`feat(scope): … (#NNN)`), green on its own (`sbt compile test`). Docs, tweaks, and out-of-scope improvements go in separate PRs — never mixed with issue commits.
+- **Intent, not path.** No add-then-remove within a PR. Squash churn before review.
+- **1 concern per PR.** Feature ≠ docs/README. Stack dependent PRs; update with `--force-with-lease`.
+- **Idiomatic Scala.** `Try`/`Option`/`Either`, pattern matching, `flatMap`/`collect`. No `try/catch` for control flow, `== null`, `indexOf`/`substring`, or double conversions.
+
 ## Release Process (MANDATORY)
 
 Trunk-based with release branches. Trunk is `main`; `release/*` branches are cut from `main` for stabilization. Pushing a `vX.Y.Z` tag on `main` or a `release/*` branch publishes to Maven Central (via sbt-ci-release / dynver) and creates a GitHub Release with git-cliff notes.


### PR DESCRIPTION
## What
Add a **Commits & PRs** section to `AGENTS.md` (imported by `CLAUDE.md`), codifying the conventions that came up repeatedly in review this milestone.

## Rules added
- **One tracked issue = one logical fix** — group commits by milestone issue, not sub-steps; each commit compiles + passes tests on its own; reference the issue (`feat(scope): … (#NNN)`).
- **History reflects intent** — no add-then-remove churn within a PR; rebase/squash before review.
- **One concern per PR** — feature vs docs/restructure apart; stack with `--force-with-lease`.
- **Idiomatic functional Scala** — `Try`/`Option`/`Either`, pattern matching, `flatMap`/`collect`; avoid Java-isms (`try/catch` control flow, `== null`, `indexOf`/`substring`, `.toList….toSet`).

## Notes
- Docs-only; no code. Fits the existing terse AGENTS.md style, placed between **Boundaries** and **Release Process**.
- Narrower domain rules (masking superset, migration-doc format, deprecation-note format) intentionally left out — can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)