### PR TITLE
test(testutil): make LogCapture deterministic under parallel suites

### DIFF
--- a/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
+++ b/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
@@ -6,40 +6,73 @@ import ch.qos.logback.core.AppenderBase
 import org.slf4j.LoggerFactory
 
 import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 /** Shared log capture for tests — safe under ScalaTest's PARALLEL suite execution.
   *
-  * Capturing mutates the GLOBAL logback `LoggerContext` (a logger's level + attached appenders), which is shared across suites.
-  * Two independent safeguards make it deterministic without serializing the whole test run:
+  * Capturing mutates the GLOBAL logback `LoggerContext` (a logger's level), which is shared across suites. Three independent
+  * safeguards make it deterministic without serializing the whole test run:
   *
-  *   1. `synchronized` — serializes the level save/set/restore + appender attach/detach so two captures never corrupt each
-  *      other's level restore (the part that genuinely needs mutual exclusion).
-  *   2. thread-name filter + a thread-safe queue — while a capture window is open, OTHER (non-capturing) suites running in
-  *      parallel may still log to the same logger on their own threads. The appender is backed by a `ConcurrentLinkedQueue` (so
-  *      concurrent foreign appends can't corrupt it), and the result keeps only events emitted on the capturing thread (the
-  *      body logs synchronously on the caller thread), discarding foreign noise.
+  *   1. `synchronized` — serializes the level save/set/restore + sink swap so two captures never corrupt each other's level
+  *      restore (the part that genuinely needs mutual exclusion).
+  *   2. attach-once appender — a recording appender is added to the target logger exactly ONCE (lazily, at the logger's resting
+  *      level where foreign WARNs are suppressed) and NEVER detached. Detaching/attaching per capture mutates the logger's
+  *      appender list, which can race against concurrent foreign dispatch through the same logger (logback's `COWArrayList`
+  *      refreshes its cached snapshot non-atomically) and intermittently drop the capturing thread's own event — observed as a
+  *      flaky "0 was not equal to 1". Keeping the appender attached means no list mutation ever happens while a foreign suite
+  *      is logging through the subtree. Activity is toggled via a `@volatile` sink instead: events are recorded only while a
+  *      capture window is open.
+  *   3. eager thread-name + a thread-safe queue — while a capture window is open, OTHER (non-capturing) suites running in
+  *      parallel may still log to the same logger subtree on their own threads. The sink is a `ConcurrentLinkedQueue` (so
+  *      concurrent foreign appends can't corrupt it), the appender resolves each event's (lazily-computed) thread name on the
+  *      EMITTING thread, and the result keeps only events emitted on the capturing thread (the body logs synchronously on the
+  *      caller thread), discarding foreign noise.
   *
   * All log-capturing suites must go through this object so the guarantee holds.
   */
 object LogCapture {
 
+  /** A recording appender attached ONCE per logger and never detached. While a capture is active its `sink` is the capturing
+    * queue; otherwise `null` and the appender ignores events. `append` NEVER mutates the logger's appender list, so it can't
+    * race with concurrent foreign dispatch through the same logger (see the object doc).
+    */
+  private final class RecordingAppender extends AppenderBase[ILoggingEvent] {
+    @volatile var sink: ConcurrentLinkedQueue[ILoggingEvent] = _
+
+    override def append(event: ILoggingEvent): Unit = {
+      val queue = sink
+      if (queue != null) {
+        event.getThreadName // resolve the lazily-computed thread name on the EMITTING thread (keeps the thread filter honest)
+        queue.add(event)
+      }
+    }
+  }
+
+  /** One appender per logger name; all access is under `synchronized`, so a plain map suffices. */
+  private val appenders = mutable.Map.empty[String, RecordingAppender]
+
   /** Capture the events `body` emits under `loggerName` at `level` (inclusive), on the calling thread only. */
   def events(loggerName: String, level: Level)(body: => Unit): List[ILoggingEvent] = synchronized {
-    val logger        = logbackLogger(loggerName)
+    val logger   = logbackLogger(loggerName)
+    val appender = appenders.getOrElseUpdate(
+      loggerName, {
+        val recorder = new RecordingAppender
+        recorder.start()
+        logger.addAppender(recorder) // one-time attach at the resting level (foreign WARNs suppressed → no list race)
+        recorder
+      },
+    )
+
     val captured      = new ConcurrentLinkedQueue[ILoggingEvent]()
-    val appender      = new AppenderBase[ILoggingEvent] {
-      override def append(event: ILoggingEvent): Unit = captured.add(event)
-    }
-    appender.start()
     val captureThread = Thread.currentThread().getName
     val previousLevel = logger.getLevel
+    appender.sink = captured
     logger.setLevel(level)
-    logger.addAppender(appender)
     try body
     finally {
-      logger.detachAppender(appender)
       logger.setLevel(previousLevel)
+      appender.sink = null
     }
     captured.asScala.iterator.filter(_.getThreadName == captureThread).toList
   }


### PR DESCRIPTION
## What

Fixes the flaky `CookieParserSpec` test `should warn and drop a non-numeric Max-Age`, which intermittently failed on the **Java-17 CI job** with `0 was not equal to 1` (captured 0 WARN lines instead of 1). Surfaced while merging docs PR #233; unrelated to docs. Test-only change — `CookieParser` production behavior is untouched.

## Root cause (a logback data race, not a parsing bug)

`LogCapture` attached/detached its appender to `org.galaxio.gatling.storage` **per capture**. Raising that logger to `WARN` also enables every `org.galaxio.gatling.storage.*` child, so under **parallel suite execution** foreign children dispatch WARNs up through the same logger's appender list concurrently.

logback-core 1.5.17's `COWArrayList` refreshes its cached snapshot via a **non-atomic** `markAsStale`/`refreshCopy` pair (guarded only by an `AtomicBoolean`). A concurrent **mutate** (our `addAppender`/`detachAppender`) + **iterate** (foreign dispatch) lost-update can publish a snapshot that omits our appender → the capturing thread's own WARN is never recorded → count `0`.

Java-21-green and passes-on-rerun are both consistent with a timing window.

## Reproduction (Java 17)

A standalone harness replicating the exact mechanism:

| Foreign load | Failing JVMs |
|---|---|
| none | 0/60 |
| different logger subtree | 0/60 |
| **same subtree** (children of the capture target) | **16/40** |

Confirms the race requires concurrent same-subtree dispatch through the shared appender list.

## Fix (`src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala`)

1. **Attach-once appender, never detach.** The only appender-list mutation is the one-time attach at the logger's resting level, where foreign WARNs are suppressed (no concurrent iteration → safe). Per-capture activity is toggled via a `@volatile` sink, so no list mutation ever races foreign dispatch — this removes the under-count.
2. **Eager thread-name resolution** inside `append`, on the *emitting* thread. Previously the (lazily-computed) thread name resolved on the *filtering* thread, stamping foreign events with the capture thread's name and leaking them past the thread filter (a latent over-count); foreign noise is now correctly discarded.
3. Kept the existing `synchronized` serialization and the `logbackLogger` SLF4J-init retry.

## Verification (Java 17)

- Final-design harness: **0/150 fresh JVMs**, 12,000 captures under heavy foreign load (was 26/60 with the old order).
- `CookieParserSpec`: 13/13 green.
- Full `sbt test`: **825 passed, 0 failed** across **4** fresh runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)