### PR TITLE
Linkage gate: check-linkage.sh + tag-only guard hook (restore Milestones section)

### DIFF
--- a/.claude/hooks/linkage-guard.sh
+++ b/.claude/hooks/linkage-guard.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard — gate ONLY release tagging. ~0 tokens. Обычный push/merge не трогает.
+set -uo pipefail
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+[ -n "$cmd" ] || exit 0
+case "$cmd" in *"git "*) ;; *) exit 0 ;; esac
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+checker="$root/scripts/check-linkage.sh"
+block() { printf 'BLOCKED by linkage-guard:\n%s\n' "$1" >&2; exit 2; }
+is_tag=0
+printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+tag[[:space:]]+v?[0-9]+\.[0-9]+\.[0-9]+' && is_tag=1
+if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+push\b' \
+   && printf '%s' "$cmd" | grep -qE '(--tags|refs/tags/|[[:space:]](origin[[:space:]]+)?v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)|release/[0-9])'; then
+  is_tag=1
+fi
+printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+(commit|log|show)\b' && is_tag=0
+[ "$is_tag" = 1 ] || exit 0
+[ -x "$checker" ] || block "checker missing ($checker) — release cannot be verified"
+ver=$(printf '%s' "$cmd" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+[ -n "$ver" ] || block "tag/release push without explicit vX.Y.Z — verify: scripts/check-linkage.sh --for-tag <version>"
+out=$("$checker" --for-tag "$ver" 2>&1) || block "$out"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/linkage-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,15 +58,14 @@ Coverage floor 65/60 (stmt/branch). Every `/speckit-plan` fills the code-free "T
 
 **Never:** force-push or commit to `main`, merge commits in PR branches (rebase only), commit broken code, opportunistic refactors outside scope, mock Gatling runtime where a real integration path exists.
 
-## Linkage (issue ↔ PR ↔ milestone)
+## Milestones (ALWAYS)
 
-Every change traces through one issue, one PR, one milestone. Each entity owes exactly:
+Every piece of work is tied to a milestone. No exceptions unless explicitly told otherwise.
 
-- **Issue** — the *what/why*. In exactly one milestone. Closed only once its fix is on `main`.
-- **PR** — the *how*. Carries its issue's milestone and a real closing link (`Closes #<issue>` in the body, not just `(#NNN)` in the title). One issue per PR; the linked issue shares the PR's milestone.
-- **Milestone** — one release (`vX.Y.Z`); owns its spec (`specs/NNN-*/`). Active = lowest-numbered open milestone. Tag only when every issue is closed and every PR merged.
-
-Verify, don't trust: `scripts/check-linkage.sh [milestone]` (add `--tag` for tag-readiness). It fails on any PR with no milestone or no closing issue, any cross-milestone link, and — in `--tag` mode — any open issue or unmerged PR. Run it before cutting a release branch.
+- **Every PR** must be assigned to the active milestone before merging. No milestone = do not merge.
+- **Every issue** fixed by a PR must be closed when that PR lands on `main`. Do not leave completed issues open.
+- **Spec work** (`specs/NNN-*/`) belongs to the milestone that owns the spec. Link the spec PR to the milestone immediately when creating it.
+- **Active milestone** = the lowest-numbered open milestone that matches the current spec/plan. Check `gh api repos/galax-io/gatling-picatinny/milestones` if unsure.
 
 ## Commits & PRs
 
@@ -101,3 +100,4 @@ Trunk-based with release branches. Trunk is `main`; `release/*` branches are cut
 - **Branch name must match tag version**: `release/1.2.0` → `v1.2.0`, `v1.2.1`, etc.
 - **Never delete a release tag** after Sonatype deployment starts — creates stuck deployments
 - **Never reuse a version number** — Sonatype Central rejects duplicates permanently
+- **Before tagging**: every PR merged since the previous tag must be assigned to the milestone; every issue in the milestone whose fix is on `main` must be closed

--- a/scripts/check-linkage.sh
+++ b/scripts/check-linkage.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #
-# check-linkage.sh — verify the issue ↔ PR ↔ milestone contract (see AGENTS.md "Linkage").
+# check-linkage.sh — verify the issue ↔ PR ↔ milestone contract (see AGENTS.md "Milestones (ALWAYS)").
 # Run `scripts/check-linkage.sh --help` for full usage.
 
 set -euo pipefail
 
 usage() {
   cat <<'EOF'
-check-linkage.sh — verify the issue <-> PR <-> milestone contract (see AGENTS.md "Linkage").
+check-linkage.sh — verify the issue <-> PR <-> milestone contract (see AGENTS.md "Milestones (ALWAYS)").
 
 What each entity owes (this script enforces it):
   Issue      belongs to exactly one milestone; closed only when its fix is on main.
@@ -16,8 +16,10 @@ What each entity owes (this script enforces it):
   Milestone  one release (vX.Y.Z); tag only when every issue is closed and every PR merged.
 
 Usage:
-  scripts/check-linkage.sh [milestone]   # default: lowest-numbered open milestone
-  scripts/check-linkage.sh --tag [ms]    # also assert tag-readiness (all issues closed, all PRs merged)
+  scripts/check-linkage.sh --pr <N>          # GATE one PR: milestone + Closes #issue + same milestone
+  scripts/check-linkage.sh --for-tag vX.Y.Z  # GATE a release: tag-readiness of that version's milestone
+  scripts/check-linkage.sh [milestone]       # audit a milestone (default: lowest-numbered open)
+  scripts/check-linkage.sh --tag [ms]        # also assert tag-readiness (all issues closed, all PRs merged)
   scripts/check-linkage.sh --help
 
 Env:
@@ -35,15 +37,57 @@ REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null 
 
 TAG_MODE=0
 MS=""
+PR_NUM=""
+FOR_TAG=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --tag)      TAG_MODE=1 ;;
+    --pr)       shift; PR_NUM="${1:-}"
+                [[ "$PR_NUM" =~ ^[0-9]+$ ]] || { echo "error: --pr needs a numeric PR id" >&2; exit 2; } ;;
+    --for-tag)  shift; FOR_TAG="${1:-}"
+                [[ "$FOR_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: --for-tag needs vX.Y.Z" >&2; exit 2; } ;;
     --help|-h)  usage; exit 0 ;;
     [0-9]*)     MS="$1" ;;
     *)          echo "error: unknown argument '$1'" >&2; usage; exit 2 ;;
   esac
   shift
 done
+
+# Gate one PR (the merge gate). Fails if the PR is missing a milestone, closes no
+# issue, or closes an issue in a different milestone. Strict: requires a registered
+# GitHub closing link (no body-text fallback — that lenient path is audit-mode only).
+if [ -n "$PR_NUM" ]; then
+  pj=$(gh pr view "$PR_NUM" --repo "$REPO" --json number,title,state,milestone,closingIssuesReferences) \
+    || { echo "error: PR #$PR_NUM not found in $REPO" >&2; exit 2; }
+  p_title=$(jq -r '.title' <<<"$pj")
+  p_ms=$(jq -r '.milestone.title // ""' <<<"$pj")
+  p_closes=$(jq -r '.closingIssuesReferences[]?.number' <<<"$pj")
+  e=0
+  printf 'PR #%s  %s\n' "$PR_NUM" "$p_title"
+  if [ -z "$p_ms" ]; then printf '  ✗ no milestone — assign one (gh pr edit %s --milestone "…")\n' "$PR_NUM"; e=1
+  else printf '  ✓ milestone: %s\n' "$p_ms"; fi
+  if [ -z "$p_closes" ]; then
+    printf '  ✗ closes no issue — add "Closes #<issue>" to the PR body\n'; e=1
+  else
+    for i in $p_closes; do
+      i_ms=$(gh issue view "$i" --repo "$REPO" --json milestone -q '.milestone.title // ""' 2>/dev/null || echo "")
+      if [ "$i_ms" = "$p_ms" ]; then printf '  ✓ closes #%s (same milestone)\n' "$i"
+      else printf '  ✗ closes #%s but its milestone is "%s", not "%s"\n' "$i" "${i_ms:-none}" "$p_ms"; e=1; fi
+    done
+  fi
+  if [ "$e" = 0 ]; then printf 'PASS: PR #%s is well-formed.\n' "$PR_NUM"; exit 0; fi
+  printf 'FAIL: PR #%s is malformed — fix the above before merge.\n' "$PR_NUM"; exit 1
+fi
+
+# Map a release version (vX.Y.Z) to its milestone, then assert tag-readiness on it.
+# Patch versions map to the vX.Y.0 milestone (e.g. v1.23.1 -> "v1.23.0 …").
+if [ -n "$FOR_TAG" ]; then
+  v="${FOR_TAG#v}"; minor="v${v%.*}.0"
+  MS=$(gh api "repos/$REPO/milestones?state=all&per_page=100" \
+        | jq -r --arg t "$minor" 'map(select(.title | startswith($t))) | .[0].number // empty')
+  [ -n "$MS" ] || { echo "error: no milestone whose title starts with '$minor' for tag $FOR_TAG" >&2; exit 2; }
+  TAG_MODE=1
+fi
 
 # Default to the lowest-numbered open milestone (the "active" one).
 if [ -z "$MS" ]; then


### PR DESCRIPTION
## What

A zero-token, deterministic gate that keeps release tags honest about issue ↔ PR ↔ milestone linkage. Replaces the unenforced prose from #244 (reverted in #246) with an executable check + a local hook.

| File | Role |
|------|------|
| `scripts/check-linkage.sh` | Engine. `--pr <N>` gate one PR · `--for-tag vX.Y.Z` gate a release (maps version → its milestone; patch `vX.Y.Z` → `vX.Y.0`) · `[milestone]` / `--tag` audit. Exit `0` ok / `1` violation / `2` prereq. |
| `.claude/hooks/linkage-guard.sh` | PreToolUse(Bash) guard. Fires **only** on release tagging. |
| `.claude/settings.json` | Registers the guard. |
| `AGENTS.md` | Restores the concise `Milestones (ALWAYS)` section. |

## How the gate works

- `git tag vX.Y.Z`, a tag push, or a `release/<N>` push → runs `check-linkage.sh --for-tag <version>` → **blocks (exit 2)** if that milestone is not link-clean (a PR with no milestone / no `Closes #issue` / cross-milestone link, an open issue, or an unmerged PR).
- `gh pr merge`, ordinary `git push`, commits — untouched. Routine work is never gated.
- Policy: tag = fail-closed (won't release unverified); missing checker = block on tag. Runs as a shell script → **~0 LLM tokens**.
- Version inside a commit message / log / show is ignored (no false trigger).

## Activate

The hook loads at session start — restart Claude Code after merge. On a fresh clone the gate is repo-wide (config is committed under `.claude/`).

## Not gated (by design)

Per-PR linkage is enforced once, at release, via `--for-tag` (the whole milestone is checked) rather than on every merge — less friction, caught before the tag.