### PR TITLE
fix(flaky): CookieParserSpec

### DIFF
--- a/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
+++ b/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
@@ -14,48 +14,50 @@ import scala.jdk.CollectionConverters._
   * Capturing mutates the GLOBAL logback `LoggerContext` (a logger's level), which is shared across suites. Three independent
   * safeguards make it deterministic without serializing the whole test run:
   *
-  *   1. `synchronized` — serializes the level save/set/restore + sink swap so two captures never corrupt each other's level
+  *   1. `synchronized` — serializes the level save/set/restore + queue swap so two captures never corrupt each other's level
   *      restore (the part that genuinely needs mutual exclusion).
   *   2. attach-once appender — a recording appender is added to the target logger exactly ONCE (lazily, at the logger's resting
   *      level where foreign WARNs are suppressed) and NEVER detached. Detaching/attaching per capture mutates the logger's
   *      appender list, which can race against concurrent foreign dispatch through the same logger (logback's `COWArrayList`
   *      refreshes its cached snapshot non-atomically) and intermittently drop the capturing thread's own event — observed as a
   *      flaky "0 was not equal to 1". Keeping the appender attached means no list mutation ever happens while a foreign suite
-  *      is logging through the subtree. Activity is toggled via a `@volatile` sink instead: events are recorded only while a
-  *      capture window is open.
-  *   3. eager thread-name + a thread-safe queue — while a capture window is open, OTHER (non-capturing) suites running in
-  *      parallel may still log to the same logger subtree on their own threads. The sink is a `ConcurrentLinkedQueue` (so
-  *      concurrent foreign appends can't corrupt it), the appender resolves each event's (lazily-computed) thread name on the
-  *      EMITTING thread, and the result keeps only events emitted on the capturing thread (the body logs synchronously on the
-  *      caller thread), discarding foreign noise.
+  *      is logging through the subtree. Activity is toggled via a `ThreadLocal` instead: events are recorded only while a
+  *      capture window is open on the calling thread.
+  *   3. `ThreadLocal` capture queue — while a capture window is open, OTHER (non-capturing) suites running in parallel may
+  *      still log to the same logger subtree on their own threads. Because each thread reads its OWN `ThreadLocal` slot,
+  *      foreign threads see `null` and their events are silently dropped. This replaces the previous thread-name-equality
+  *      check, which was fragile: thread names are not guaranteed unique across JVM pools and can be mutated by test runners
+  *      at suite boundaries, causing spurious inclusions or exclusions.
   *
   * All log-capturing suites must go through this object so the guarantee holds.
   */
 object LogCapture {
 
-  /** A recording appender attached ONCE per logger and never detached. While a capture is active its `sink` is the capturing
-    * queue; otherwise `null` and the appender ignores events. `append` NEVER mutates the logger's appender list, so it can't
-    * race with concurrent foreign dispatch through the same logger (see the object doc).
+  /** A recording appender attached ONCE per logger and never detached. Events are forwarded to the calling thread's
+    * [[activeQueue]] slot; foreign threads (those not holding the capture window) see `null` and are ignored. `append`
+    * NEVER mutates the logger's appender list, so it can't race with concurrent foreign dispatch through the same logger
+    * (see the object doc).
     */
   private final class RecordingAppender extends AppenderBase[ILoggingEvent] {
-    @volatile var sink: ConcurrentLinkedQueue[ILoggingEvent] = _
-
     override def append(event: ILoggingEvent): Unit = {
-      val queue = sink
-      if (queue != null) {
-        event.getThreadName // resolve the lazily-computed thread name on the EMITTING thread (keeps the thread filter honest)
-        queue.add(event)
-      }
+      val queue = activeQueue.get()
+      if (queue != null) queue.add(event)
     }
   }
+
+  /** Set only on the thread that currently holds the capture window; `null` on all other threads. Using a `ThreadLocal`
+    * makes the capturing side-channel invisible to foreign threads by construction, without relying on thread names
+    * (which are not guaranteed unique and can be mutated by test runners at suite boundaries).
+    */
+  private val activeQueue = new ThreadLocal[ConcurrentLinkedQueue[ILoggingEvent]]()
 
   /** One appender per logger name; all access is under `synchronized`, so a plain map suffices. */
   private val appenders = mutable.Map.empty[String, RecordingAppender]
 
   /** Capture the events `body` emits under `loggerName` at `level` (inclusive), on the calling thread only. */
   def events(loggerName: String, level: Level)(body: => Unit): List[ILoggingEvent] = synchronized {
-    val logger   = logbackLogger(loggerName)
-    val appender = appenders.getOrElseUpdate(
+    val logger = logbackLogger(loggerName)
+    appenders.getOrElseUpdate(
       loggerName, {
         val recorder = new RecordingAppender
         recorder.start()
@@ -65,16 +67,15 @@ object LogCapture {
     )
 
     val captured      = new ConcurrentLinkedQueue[ILoggingEvent]()
-    val captureThread = Thread.currentThread().getName
     val previousLevel = logger.getLevel
-    appender.sink = captured
+    activeQueue.set(captured)
     logger.setLevel(level)
     try body
     finally {
       logger.setLevel(previousLevel)
-      appender.sink = null
+      activeQueue.remove()
     }
-    captured.asScala.iterator.filter(_.getThreadName == captureThread).toList
+    captured.asScala.toList
   }
 
   /** Capture INFO+ events (raw, for asserting logger name / single-event / message structure). */

--- a/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
+++ b/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
@@ -27,7 +27,9 @@ import scala.jdk.CollectionConverters._
   *      still log to the same logger subtree on their own threads. Because each thread reads its OWN `ThreadLocal` slot,
   *      foreign threads see `null` and their events are silently dropped. This replaces the previous thread-name-equality
   *      check, which was fragile: thread names are not guaranteed unique across JVM pools and can be mutated by test runners at
-  *      suite boundaries, causing spurious inclusions or exclusions.
+  *      suite boundaries, causing spurious inclusions or exclusions. Nested captures on the same thread (a capture whose `body`
+  *      opens another capture) save/restore the slot rather than clearing it, so the outer window keeps recording once the
+  *      inner one closes.
   *
   * All log-capturing suites must go through this object so the guarantee holds.
   */
@@ -68,12 +70,13 @@ object LogCapture {
 
     val captured      = new ConcurrentLinkedQueue[ILoggingEvent]()
     val previousLevel = logger.getLevel
+    val previousQueue = activeQueue.get()
     activeQueue.set(captured)
     logger.setLevel(level)
     try body
     finally {
       logger.setLevel(previousLevel)
-      activeQueue.remove()
+      if (previousQueue == null) activeQueue.remove() else activeQueue.set(previousQueue)
     }
     captured.asScala.toList
   }

--- a/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
+++ b/src/test/scala/org/galaxio/gatling/testutil/LogCapture.scala
@@ -26,17 +26,17 @@ import scala.jdk.CollectionConverters._
   *   3. `ThreadLocal` capture queue — while a capture window is open, OTHER (non-capturing) suites running in parallel may
   *      still log to the same logger subtree on their own threads. Because each thread reads its OWN `ThreadLocal` slot,
   *      foreign threads see `null` and their events are silently dropped. This replaces the previous thread-name-equality
-  *      check, which was fragile: thread names are not guaranteed unique across JVM pools and can be mutated by test runners
-  *      at suite boundaries, causing spurious inclusions or exclusions.
+  *      check, which was fragile: thread names are not guaranteed unique across JVM pools and can be mutated by test runners at
+  *      suite boundaries, causing spurious inclusions or exclusions.
   *
   * All log-capturing suites must go through this object so the guarantee holds.
   */
 object LogCapture {
 
   /** A recording appender attached ONCE per logger and never detached. Events are forwarded to the calling thread's
-    * [[activeQueue]] slot; foreign threads (those not holding the capture window) see `null` and are ignored. `append`
-    * NEVER mutates the logger's appender list, so it can't race with concurrent foreign dispatch through the same logger
-    * (see the object doc).
+    * [[activeQueue]] slot; foreign threads (those not holding the capture window) see `null` and are ignored. `append` NEVER
+    * mutates the logger's appender list, so it can't race with concurrent foreign dispatch through the same logger (see the
+    * object doc).
     */
   private final class RecordingAppender extends AppenderBase[ILoggingEvent] {
     override def append(event: ILoggingEvent): Unit = {
@@ -45,9 +45,9 @@ object LogCapture {
     }
   }
 
-  /** Set only on the thread that currently holds the capture window; `null` on all other threads. Using a `ThreadLocal`
-    * makes the capturing side-channel invisible to foreign threads by construction, without relying on thread names
-    * (which are not guaranteed unique and can be mutated by test runners at suite boundaries).
+  /** Set only on the thread that currently holds the capture window; `null` on all other threads. Using a `ThreadLocal` makes
+    * the capturing side-channel invisible to foreign threads by construction, without relying on thread names (which are not
+    * guaranteed unique and can be mutated by test runners at suite boundaries).
     */
   private val activeQueue = new ThreadLocal[ConcurrentLinkedQueue[ILoggingEvent]]()
 


### PR DESCRIPTION
## Root cause

`CookieParserSpec` had a ~4.5 % flake rate (2 of 44 CI test-job executions over the last 7 days), observed on different commits and JVM versions:

| Run | SHA | JVM | Result |
|-----|-----|-----|--------|
| 28369328413 (2026-06-29) | `83147b96` | Java 17 | FAILED |
| 28137088694 (2026-06-28) | `55b8a38b` | Java 21 | FAILED |

In each case the other JVM leg on the same commit passed, confirming the bug is in the test infrastructure, not the production code.

The failure was in `LogCapture.events` (the shared log-capture utility all `captureWarns`-based tests use). It identified the capturing thread by saving `Thread.currentThread().getName` at the start of the capture and filtering captured events by that name after the body ran:

```scala
val captureThread = Thread.currentThread().getName
// ...
captured.asScala.iterator.filter(_.getThreadName == captureThread).toList
```

Thread names are **not guaranteed unique** across JVM thread pools and can be **mutated by test runners** at suite boundaries. Under parallel ScalaTest execution (each suite on its own thread from a shared pool), two threads from different pools can share a name. When that happens:

- A foreign WARN emitted on a same-named thread passes the filter → spurious WARN in "accept without warning" tests (`count shouldBe 0` fails with 1).
- If the test runner renames the logging thread between capture-start and event emission → the event is filtered out → `count shouldBe 1` fails with 0.

## Fix

Replace `@volatile var sink` + post-body thread-name filter with a `ThreadLocal[ConcurrentLinkedQueue[ILoggingEvent]]`:

- The `ThreadLocal` (`activeQueue`) is set to the capturing queue before `body` runs and cleared in `finally`.
- The `RecordingAppender.append` reads `activeQueue.get()` on the **emitting** thread. Foreign threads see `null` by construction — no name comparison, no name-mutation risk.
- The `synchronized` wrapper is retained to serialise level save/set/restore (the only part that genuinely needs mutual exclusion).
- The attach-once appender pattern is unchanged.

## Closes

Closes #259

---
_Generated by [Claude Code](https://claude.ai/code/session_013wXdKX6iGMtGdLSWjfgCkm)_