### PR TITLE
chore(gitignore): ignore Metals/Bloop build-tool artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /.vscode
 /.project
 /\.bsp/
+.bloop/
+.metals/
+metals.sbt
+.mcp.json
 /project/project/
 /project/target/
 /report/


### PR DESCRIPTION
## Summary
- Ignore `.bloop/`, `.metals/`, `metals.sbt`, `.mcp.json` (unanchored, so nested `project/.bloop/` etc. is covered too) — generated locally by Metals MCP / bloop BSP import, not meant to be checked in.

## Context
Setting up `metals-mcp` (Scala LSP MCP server) for agentic dev in this repo generates these local artifacts on first `bloopInstall`. Repo-relevant part of that setup is just this `.gitignore` fix; the rest (coursier install, launchd autostart, Claude Code SessionStart hook) is machine-local config, not repo content.

## Test plan
- [x] `git status` clean after regenerating `.bloop/`, `project/.bloop/`, `project/metals.sbt`, `.metals/`
- [x] `git check-ignore -v` confirms all four patterns match