### PR TITLE
feat(faker): discrete LocalDateTime offset generator (#294)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/008-coverage-test-infra"
+  "feature_directory": "specs/009-faker-datetime-offset"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 @AGENTS.md
 
 <!-- SPECKIT START -->
-Active plan: [specs/008-coverage-test-infra/plan.md](specs/008-coverage-test-infra/plan.md)
+Active plan: [specs/009-faker-datetime-offset/plan.md](specs/009-faker-datetime-offset/plan.md)
 <!-- SPECKIT END -->

--- a/docs/faker-api.md
+++ b/docs/faker-api.md
@@ -134,7 +134,7 @@ The first slice includes:
 - `Faker.internet.email`, `username`, `domain`, `url`, `password`, `userAgent`, `ipv4`, `ipv6`
 - `Faker.location.country`, `countryCode`, `city`, `streetName`, `streetAddress`, `postalCode`, `latitude`, `longitude`
 - `Faker.localization.currency`, `languageCode`
-- `Faker.date.today`, `now`, `between`, `past`, `future`, `offset`, `range`
+- `Faker.date.today`, `now`, `between`, `past`, `future`, `offset` (`LocalDate`/whole days, and `LocalDateTime`/any supported `ChronoUnit` with a whole-days default), `range`
 - `Faker.finance.pan`, `amount`, `money`, `currency`, `accountNumber`, `bic`, `iban`, `transactionId`
 - `Faker.commerce.productName`, `category`, `sku`, `orderId`, `price`
 - `Faker.phone.mobile`, `tollFree`, `fromFormats`, `builder` — 16 countries supported
@@ -251,6 +251,14 @@ New:
 ```scala
 GeneratedFeeder.single(
   "createdAt",
-  Faker.date.past(days = 30).format("yyyy-MM-dd")
+  Faker.date.formatDateTime(
+    Faker.date.offset(LocalDateTime.now(), 0, 29),
+    "yyyy-MM-dd",
+  ),
 )
 ```
+
+The legacy feeder's positive delta is **exclusive** (30 means 0..29 whole days ahead) and its values are
+discrete whole-unit steps — so the replacement is `offset` (inclusive bounds, hence `29`), not `between`
+(which yields any second inside the range) and not `past`/`future` (continuous, `LocalDate`-based). Full
+mapping in [migration.md](migration.md#deprecations).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -213,4 +213,37 @@ Per the project's versioning policy, **removal of any deprecated API happens onl
 | `RedisSaddAction`, `RedisSremAction`, `RedisDelAction` | `picatinny 0.x` | Folded into one generic builder | `GenericRedisActionBuilder` + `RedisCommand.Sets.SAdd` / `.Sets.SRem` / `.Keys.Del` — see [redis.md](redis.md) |
 | NFR-YAML assertions: `assertionFromYaml` (Scala + Java), `AssertionBuilderException` | `1.18.0` | NFR-YAML loading to be replaced by a new assertions API | Forthcoming assertions functionality — still works; watch the CHANGELOG. See [assertions.md](assertions.md) |
 
+### `RandomDateFeeder` → `Faker.date.offset`
+
+The legacy feeder generates a **discrete** whole-unit offset: `dateFrom.plus(k, unit)` with `k` drawn from
+`[-negativeDelta, positiveDelta)` — the **upper delta is exclusive** (same `randomValue` helper as above:
+`randomValue(1, 11)` yields 1..10). `Faker.date.between` is NOT its replacement — it returns any whole
+second inside the range (same boundaries, different distribution and values). Use the discrete offset
+generator instead; its bounds are **inclusive** on both ends, so the upper bound becomes `positiveDelta − 1`:
+
+| Legacy | Replacement |
+|--------|-------------|
+| `RandomDateFeeder(name, P, N, pattern, from, unit, tz)` | `GeneratedFeeder.single(name, Faker.date.formatDateTime(Faker.date.offset(from, -N, P - 1, unit), pattern))` |
+
+Two edge cases of the mapping:
+
+- **`P == 0 && N == 0`** — a valid legacy configuration that always returns the base date. The general
+  formula would produce inverted bounds (`0, -1`); use `Faker.date.offset(from, 0, 0, unit)` instead
+  (deterministic base, same as the legacy behavior).
+- **Zone-aware patterns** (`z`, `XXX`, `VV`, …) — the legacy feeder formatted through `atZone(tz)`, so such
+  patterns worked; `formatDateTime` formats a plain `LocalDateTime` and throws
+  `UnsupportedTemporalTypeException` on them. Map through the zone first:
+
+  ```scala
+  Faker.date
+    .offset(from, -N, P - 1, unit)
+    .map(_.atZone(tz).format(DateTimeFormatter.ofPattern(pattern)))
+  ```
+
+  For zone-free patterns the plain `formatDateTime` mapping above is exact (the legacy `timezone` parameter
+  affected only formatting).
+
+From Java/Kotlin use `FakerApi.dateOffset(from, min, max)` (whole days) or
+`FakerApi.dateOffset(from, min, max, unit)`.
+
 Compiler note: deprecated members emit `@deprecated`/`@Deprecated` warnings (with the same message/replacement) at build time, so usages surface in your own compile logs.

--- a/specs/009-faker-datetime-offset/checklists/requirements.md
+++ b/specs/009-faker-datetime-offset/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Discrete Date-Time Offset Generation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All 16 items pass on first validation (2026-07-19).
+- US2 mentions "Scala function values" only as user-pain rationale for the facade story, not as solution prescription — accepted.
+- Design decision (which API shape realizes FR-001) is deliberately deferred to `/speckit-plan`; the from-scratch alternatives analysis lives in the conversation record and issue #294.
+- Ready for `/speckit-clarify` (optional — no open markers) or `/speckit-plan`.

--- a/specs/009-faker-datetime-offset/contracts/faker-date-api.md
+++ b/specs/009-faker-datetime-offset/contracts/faker-date-api.md
@@ -1,0 +1,51 @@
+# Public API Contract: Faker date — discrete LocalDateTime offset (009)
+
+The library's external interface is its published Scala API + Java/Kotlin facade. This contract is the compatibility-sensitive surface added by feature 009. Everything here is ADDITIVE; nothing existing changes.
+
+## Scala core (`org.galaxio.gatling.feeders.faker.Faker.date`)
+
+```scala
+def offset(
+    from: LocalDateTime,
+    minOffset: Long,
+    maxOffset: Long,
+    unit: TemporalUnit = ChronoUnit.DAYS,
+): Generator[LocalDateTime]
+```
+
+### Semantics
+
+1. Each `sample()` returns `from.plus(k, unit)` with `k` drawn **uniformly** from the **inclusive** range `[minOffset, maxOffset]`.
+2. Values lie exactly on the whole-`unit` grid anchored at `from` — no sub-unit remainder, ever (contrast: `between(from, to)` returns any whole second in range).
+3. `minOffset == maxOffset` → deterministic single value.
+4. Negative offsets and zero-spanning ranges are first-class.
+5. Generation is lazy and stateless (standard `Generator` contract); cost per sample: one RNG draw + one date-arithmetic op.
+
+### Errors
+
+| Condition | When | Error |
+|-----------|------|-------|
+| `minOffset > maxOffset` | construction | `IllegalArgumentException` naming both values |
+| `unit` unsupported by `LocalDateTime` (only `ChronoUnit.FOREVER`) | construction | `IllegalArgumentException` naming the unit |
+| result outside representable date-time range | `sample()` | JDK `DateTimeException` (not clamped) |
+
+## Java/Kotlin facade (`org.galaxio.gatling.javaapi.FakerApi`)
+
+```scala
+def dateOffset(from: LocalDateTime, minOffset: Long, maxOffset: Long): Generator[LocalDateTime]                     // unit = whole days
+def dateOffset(from: LocalDateTime, minOffset: Long, maxOffset: Long, unit: TemporalUnit): Generator[LocalDateTime]
+```
+
+Pure delegation to the Scala core (constitution I); identical semantics and errors; the 3-arg overload is the whole-days default (Java cannot see Scala default arguments).
+
+## Documented migration contract (FR-009)
+
+`RandomDateFeeder(name, P, N, pattern, from, unit, tz)` ≡ feeder over
+`Faker.date.formatDateTime(Faker.date.offset(from, −N, P − 1, unit), pattern)`
+— upper bound `P − 1` because the legacy helper's upper delta is exclusive; `tz` affected only legacy formatting (research R5/R6). Backed by an executable doc-parity test.
+
+## Compatibility
+
+- Additive only: MiMa vs `1.24.0` reports zero incompatibilities; no `mimaBinaryIssueFilters`.
+- Existing `between`/`offset(LocalDate)`/`past`/`future`/`range` signatures and behavior untouched.
+- Ships in MINOR v1.25.0.

--- a/specs/009-faker-datetime-offset/data-model.md
+++ b/specs/009-faker-datetime-offset/data-model.md
@@ -1,0 +1,24 @@
+# Data Model: Discrete Date-Time Offset Generation (009)
+
+## Discrete Offset Generator (new)
+
+- **Fields**: base date-time (`LocalDateTime`), inclusive lower offset (`Long`), inclusive upper offset (`Long`), time unit (`TemporalUnit`, default whole days).
+- **Validation rules** (at construction, FR-004): lower ≤ upper; unit supported by date-time arithmetic (`base.isSupported(unit)`; rejects `FOREVER`). Overflow of the representable range surfaces at generation as the JDK arithmetic error (not clamped).
+- **Value domain** (FR-001/002/003/005): `{ base + k·unit | k whole, lower ≤ k ≤ upper }`, k drawn uniformly; both endpoints producible; equal bounds → single deterministic value; range may span zero.
+- **Relationships**: composes with the existing formatting combinators (`formatDateTime`) for string output (FR-007); exposed 1:1 through the Java/Kotlin facade by delegation (FR-006).
+
+## Legacy Random-Date Feeder Configuration (existing, deprecated)
+
+- **Fields**: param name, positive delta P (`Int`, **exclusive** upper), negative delta N (`Int`, inclusive lower), date pattern, base date-time, unit, timezone (formatting-only).
+- **Relationships**: migration mapping (FR-009, research R5/R6):
+
+| Legacy | Replacement |
+|--------|-------------|
+| offset set `[−N, P−1]` in `unit` from base | `offset(base, −N, P − 1, unit)` |
+| `pattern` + `timezone` formatting | existing formatting combinator on the generator's output |
+
+- **State transitions**: none (stateless generation); the legacy feeder itself is untouched except documentation (FR-008).
+
+## Milestone Ledger
+
+- Issue [#294](https://github.com/galax-io/gatling-picatinny/issues/294) ← milestone 12 (v1.25.0 — Perf: Faker), assigned 2026-07-19; feature PR carries the same milestone and closes #294; prerequisite for milestone 27 (v2.0.0 deprecated-API removal).

--- a/specs/009-faker-datetime-offset/plan.md
+++ b/specs/009-faker-datetime-offset/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Discrete Date-Time Offset Generation
+
+**Branch**: `009-faker-datetime-offset` | **Date**: 2026-07-19 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/009-faker-datetime-offset/spec.md`
+
+## Summary
+
+Close the migration gap left by the deprecated `RandomDateFeeder` (issue [#294](https://github.com/galax-io/gatling-picatinny/issues/294)): add a discrete whole-unit offset generator for `LocalDateTime` to `Faker.date` — `offset(from, minOffset, maxOffset, unit = DAYS): Generator[LocalDateTime]`, inclusive bounds, uniform distribution, fail-fast validation — plus thin Java/Kotlin facade delegates (`FakerApi.dateOffset`, two overloads) and a corrected, test-backed migration mapping in the docs. Key planning discovery: the legacy feeder's upper delta is **exclusive** (`randomValue(min, max)` excludes `max`), so the documented parity mapping is `RandomDateFeeder(P, N, …, unit)` → `offset(from, −N, P−1, unit)`; the existing `docs/faker-api.md` migration example is wrong today (maps a future-offset feeder to `date.past`) and gets fixed as part of FR-009. Design alternatives and rationale in [research.md](research.md).
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18, compile target Java 17 (`--release 17`); facade consumed from Java 17+/Kotlin
+
+**Primary Dependencies**: none added — JDK `java.time` (`LocalDateTime`, `TemporalUnit`, `ChronoUnit`) + existing internal `Faker.number.long` (inclusive-bounds uniform generator over `ThreadLocalRandom`)
+
+**Storage**: N/A
+
+**Testing**: ScalaTest (`GeneratedFeederSpec`, `Test` scope), JUnit 5 via sbt-jupiter-interface (`JavaFeedersTest` facade layer), MiMa advisory gate, scoverage floor 75%/66%
+
+**Target Platform**: JVM library published to Maven Central; Gatling 3.13.x host stays `Provided`
+
+**Project Type**: published library (Scala core) + thin Java/Kotlin facade (`javaapi`)
+
+**Performance Goals**: `sample()` cost = one RNG call + one `LocalDateTime.plus` — same order as existing `offset(LocalDate, …)`; cheaper than `between(LocalDateTime, …)` (no range measurement per construction); no additional allocation beyond the produced value
+
+**Constraints**: purely additive public API (constitution II; MiMa clean vs 1.24.0 baseline); no new dependencies (constitution IV); existing `between`/`offset` behavior byte-for-byte unchanged; `-Werror` diagnostics and scalafix gates stay green
+
+**Scale/Scope**: 1 core method (overload), 2 facade delegates, ~7 unit cases + 1–2 facade cases, 2 documentation files touched (`docs/faker-api.md`, `docs/migration.md`), 1 issue (#294), milestone v1.25.0
+
+## Test Model *(mandatory — real cases + test sketches, NO implementation)*
+
+| Req | Real case to test | Layer | Test sketch (no code) |
+|-----|-------------------|-------|-----------------------|
+| FR-001 | "0..5 whole days from 2025-06-01T12:30:15" — the issue's motivating case | Unit/Functional | Sample repeatedly; for each value derive k = whole-day distance from base and assert exact reconstruction (base plus k equals the value to the nanosecond) with k inside 0..5. Boundary: sub-day remainder anywhere fails the exact-reconstruction assertion by construction. |
+| FR-002 | Equal bounds 3..3 weeks — deterministic corner | Unit/Functional | Every sample equals exactly base plus 3 weeks (exact-value assertion). Inclusivity boundary: for a 0..1-day range both endpoint values are observed across a sample run — distinguishes inclusive upper bound from the legacy exclusive one. |
+| FR-003 | Range spanning zero: −10..10 hours from one base | Unit/Functional | Across samples, at least one value strictly before and one strictly after the base occur; every value sits on the whole-hour grid inside [base−10h, base+10h]; endpoints −10 and +10 reachable. |
+| FR-004 | Inverted bounds (5..0); unsupported unit (FOREVER) | Unit/Functional | Both constructions throw the standard invalid-argument error naming the offending input BEFORE any sampling happens (negative-path row). |
+| FR-005 | Discreteness vs the continuous generator; no drift of `between` | Unit/Functional | Offset samples show zero sub-unit remainder (exact grid reconstruction). Control: the pre-existing `between(LocalDateTime)` spec cases remain untouched and still pass — proves the continuous generator's behavior did not change. |
+| FR-006 | Java caller builds the generator via facade, with and without explicit unit | Facade Delegation | JUnit test feeds facade-built generators; values are whole-step in-bounds; the no-unit overload behaves as whole days (default). Negative: facade construction with inverted bounds surfaces the same invalid-argument error (delegation, no facade-local softening). |
+| FR-007 | Formatted output like the legacy feeder produced (pattern string) | Unit/Functional | Deterministic equal-bounds offset generator piped through the existing date-time formatter yields the exact expected formatted string; parsed back, it lands on the grid inside bounds. |
+| FR-008 | Public surface stays additive | Compile Guard | Existing compile-guard specs locking public DSL signatures compile unchanged; MiMa advisory step reports zero incompatibilities against the 1.24.0 baseline (zero-findings gate). |
+| FR-009 | Legacy config (P=30, N=0, days, "yyyy-MM-dd") migrated per the documented mapping | Unit/Functional | Executable doc-parity test: the documented replacement produces only base+0..29-day values (upper = P−1, legacy-exclusive semantics), formatted output shape identical to the legacy feeder's. Negative: the naive mapping (upper = P) would emit base+30 — asserted never produced by the documented expression. |
+
+## Constitution Check
+
+- [x] **I. Scala DSL as Source of Truth** — core logic lives in `Faker.date`; `FakerApi.dateOffset` overloads are pure delegates (the no-unit overload delegates to the Scala default), zero facade-local logic.
+- [x] **II. Backward Compatibility** — purely additive overload + facade methods; no signature, DSL behavior, or serialized-format change; ships in MINOR v1.25.0; MiMa advisory must stay clean vs 1.24.0.
+- [x] **III. Test Discipline** — Test Model above covers all 9 FRs across Unit/Functional, Facade Delegation, Compile Guard; test-first (spec tests written red before the method exists); exact-value + negative cases per row; no mocking anywhere (pure value generation); coverage floor 75/66 unaffected (new branches fully covered).
+- [x] **IV. Small, Focused Changes** — no new dependencies; public API addition authorized by issue #294 + maintainer approval (conversation 2026-07-19); no opportunistic refactors — the wrong `docs/faker-api.md` migration example is corrected because FR-009 owns exactly that mapping, nothing else is touched.
+- [x] **V. Release Integrity** — not a release PR; lands on `main` via PR into milestone v1.25.0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-faker-datetime-offset/
+├── spec.md              # Feature specification (/speckit-specify)
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions & alternatives (incl. from-scratch API analysis)
+├── data-model.md        # Phase 1 — entities & validation rules
+├── quickstart.md        # Phase 1 — validation scenarios
+├── contracts/
+│   └── faker-date-api.md  # Phase 1 — public API contract (core + facade)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (16/16 pass)
+└── tasks.md             # Phase 2 (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/feeders/faker/
+└── Faker.scala                    # object date — ADD offset(LocalDateTime, Long, Long, TemporalUnit=DAYS) after the LocalDate offset; + TemporalUnit import
+
+src/main/java/org/galaxio/gatling/javaapi/
+└── FakerApi.scala                 # "--- Date ---" block — ADD dateOffset(from,min,max) and dateOffset(from,min,max,unit) delegates; + TemporalUnit import
+
+src/test/scala/org/galaxio/gatling/feeders/faker/
+└── GeneratedFeederSpec.scala      # ADD datetime-offset cases after "generate date offset within bounds" (FR-001..005, 007, 009 doc-parity)
+
+src/test/java/org/galaxio/gatling/javaapi/
+└── JavaFeedersTest.java           # ADD facade dateOffset usage (FR-006)
+
+docs/
+├── faker-api.md                   # catalog: date.offset now LocalDate AND LocalDateTime; FIX wrong RandomDateFeeder→past example → offset mapping
+└── migration.md                   # Deprecations: exact RandomDateFeeder(P,N,…,unit) → offset(from,−N,P−1,unit)+format mapping table (FR-009)
+```
+
+**Structure Decision**: single-module library layout as it exists today; feature touches exactly two production files (core + facade), two test files, two docs files. No new modules, no build changes.
+
+## Complexity Tracking
+
+No constitution violations — table not applicable.

--- a/specs/009-faker-datetime-offset/quickstart.md
+++ b/specs/009-faker-datetime-offset/quickstart.md
@@ -1,0 +1,43 @@
+# Quickstart Validation: Discrete Date-Time Offset Generation (009)
+
+Prerequisites: JDK 17+, sbt. All commands from the repository root. Contract details: [contracts/faker-date-api.md](contracts/faker-date-api.md); entity rules: [data-model.md](data-model.md).
+
+## V1. Core generator behavior (FR-001..005, 007, US1)
+
+```bash
+sbt "testOnly org.galaxio.gatling.feeders.faker.GeneratedFeederSpec"
+```
+
+**Expected**: new datetime-offset cases green — whole-unit grid & inclusive bounds (incl. a 0..1-day both-endpoints check), zero-spanning range, deterministic equal bounds, formatted composition, and the two rejection cases (inverted bounds, unsupported unit); pre-existing `between`/`offset(LocalDate)` cases untouched and green (FR-005 control).
+
+## V2. Facade delegation (FR-006, US2)
+
+```bash
+sbt "testOnly org.galaxio.gatling.javaapi.JavaFeedersTest"
+```
+
+**Expected**: Java-side `dateOffset` usage (with and without explicit unit) produces in-bounds grid values; inverted bounds surface the same error.
+
+## V3. Doc-parity migration mapping (FR-009, US3)
+
+```bash
+sbt "testOnly org.galaxio.gatling.feeders.faker.GeneratedFeederSpec"   # doc-parity case included in V1 run
+```
+
+**Expected**: the documented replacement for legacy `(P=30, N=0, days, "yyyy-MM-dd")` yields only base+0..29-day formatted values; the naive upper bound (base+30) is asserted absent. `docs/faker-api.md` example and `docs/migration.md` mapping table match the tested expression verbatim.
+
+## V4. Compatibility gate (FR-008)
+
+```bash
+sbt "mimaReportBinaryIssues || true"
+```
+
+**Expected**: zero incompatibilities vs the 1.24.0 baseline (additive-only change); no new `mimaBinaryIssueFilters` entries.
+
+## V5. Full verification chain (release-readiness)
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck "scalafixAll --check" compile test "IntegrationTest / test"
+```
+
+**Expected**: formatting, lint, strict diagnostics (`-Werror`), unit + integration suites all green; coverage floor 75/66 holds.

--- a/specs/009-faker-datetime-offset/research.md
+++ b/specs/009-faker-datetime-offset/research.md
@@ -1,0 +1,48 @@
+# Research: Discrete Date-Time Offset Generation (009)
+
+Phase 0 output. All Technical Context unknowns resolved; no NEEDS CLARIFICATION remain.
+
+## R1. API shape — overload `offset` vs alternatives (from-scratch analysis)
+
+- **Decision**: Add an overload `Faker.date.offset(from: LocalDateTime, minOffset: Long, maxOffset: Long, unit: TemporalUnit = ChronoUnit.DAYS): Generator[LocalDateTime]` next to the existing `offset(LocalDate, minDays, maxDays)`.
+- **Rationale**: (1) Java/Kotlin facade ergonomics — manual composition (`number.long(…).map(base.plus(_, unit))`) requires Scala function values, unusable as an API from Java/Kotlin, so a core method is the only way to give facade users a migration path; (2) precedent/symmetry — `offset(LocalDate, …)` is already public, refusing the `LocalDateTime` twin is inconsistent; (3) direct migration mental model — the legacy feeder thinks in "base ± delta", exactly what `offset` expresses.
+- **Alternatives considered**:
+  - *Do nothing / wontfix + doc recipe* (composition one-liner): cheapest and Scala-idiomatic, but abandons facade users and leaves the deprecation notice pointing at a replacement that cannot reproduce the behavior; rejected.
+  - *`between(from, to, step: TemporalUnit)` overload* (random node of a discrete grid inside a range): conceptually elegant — continuous `between` becomes the `step=SECONDS` special case — but the migration mapping becomes indirect (caller computes bounds from deltas) and it grows a second `between` family; rejected.
+  - *Per-unit methods* (`offsetDays`, `offsetHours`, …): method explosion; rejected.
+  - *`Duration`/`Period` bounds*: loses the discrete-grid property that is the entire point; rejected.
+
+## R2. Bounds semantics — inclusive, `Long`, uniform
+
+- **Decision**: Both bounds inclusive; `Long` offsets; uniform distribution via the existing `Faker.number.long(min, max)` (inclusive by construction, `ThreadLocalRandom`-backed).
+- **Rationale**: issue #294 explicitly requests inclusive bounds; `number.long` already implements inclusive uniform sampling with the `min == max` degenerate case handled; `Long` matches both `number.long` and the existing `offset(LocalDate, minDays: Long, maxDays: Long)`.
+- **Alternatives considered**: `Int` offsets (legacy feeder used `Int` deltas) — needless narrowing vs the sibling API; exclusive upper (legacy semantics) — rejected by the issue itself, handled in the migration mapping instead (R5).
+
+## R3. Validation — fail-fast at construction
+
+- **Decision**: `require(minOffset <= maxOffset)` and `require(from.isSupported(unit))` at generator construction; overflow of the representable date-time range surfaces naturally as the JDK arithmetic error at `sample()`.
+- **Rationale**: matches every sibling (`between`, `past`, `future`, `offset`, `range` all `require(...)` eagerly with messages naming the inputs); an unsupported unit (`ChronoUnit.FOREVER` is the only `ChronoUnit` `LocalDateTime` rejects) must not detonate mid-load-test; clamping bounds silently would hide caller bugs.
+- **Alternatives considered**: lazy validation at first sample — violates FR-004 and sibling convention; whitelisting units — `Temporal.isSupported(unit)` is the JDK-canonical check, no list to maintain.
+
+## R4. Default unit and facade shape
+
+- **Decision**: Scala default parameter `unit = ChronoUnit.DAYS`; facade exposes two explicit overloads `dateOffset(from, min, max)` and `dateOffset(from, min, max, unit)` — the 3-arg one delegating to the Scala default.
+- **Rationale**: whole days mirror the legacy feeder's default (`unit: TemporalUnit = ChronoUnit.DAYS`); Java cannot see Scala default arguments, and the existing facade already uses the explicit-overload pattern (`pan()`/`pan(bins)`, `phoneMobile(country)`/`phoneMobile(country, format)`).
+- **Alternatives considered**: single 4-arg facade method only — forces Java callers to spell `ChronoUnit.DAYS` for the common case; `@varargs`-style tricks — noise.
+
+## R5. Legacy parity semantics — CRITICAL planning discovery
+
+- **Decision**: Document the migration as `RandomDateFeeder(name, P, N, pattern, from, unit, tz)` → `date.formatDateTime(date.offset(from, −N, P − 1, unit), pattern)` and back it with an executable doc-parity test.
+- **Rationale**: the legacy path is `dateFrom.plus(randomValue(-negativeDelta, positiveDelta), unit)` and `RandomDataGenerators.randomValue(min, max)` is **max-exclusive** (its own scaladoc: "strictly less than max"; `docs/migration.md` example: `randomValue(1, 11)` yields 1..10). So the legacy offset set is `[−N, P−1]`, while the new generator is inclusive — the mapping absorbs the difference. Issue #294's "0…29 weeks" example (from a delta of 30) confirms the exclusive reading.
+- **Also discovered**: the existing `docs/faker-api.md` migration example is wrong today — it maps `RandomDateFeeder("createdAt", 30, 0)` (a FUTURE 0..29-day discrete offset, datetime-based) to `Faker.date.past(days = 30)` (a PAST range, `LocalDate`-based). FR-009 replaces it with the correct `offset` mapping.
+- **Alternatives considered**: making the new API exclusive-upper for drop-in numeric parity — contradicts the issue's explicit "bounds inclusive" and the sibling `offset(LocalDate)`/`number.long` semantics; rejected.
+
+## R6. Timezone parameter of the legacy feeder
+
+- **Decision**: no timezone parameter on the new generator; the migration note states that the legacy `timezone` only affected the *formatting* step (`atZone(tz).format(pattern)`), which the existing formatting combinators cover; callers needing zone-shifted output apply it in their format/map step.
+- **Rationale**: the generator's value domain is `LocalDateTime` (no zone); replicating a formatting-only parameter into the generator would smuggle presentation concerns into value generation.
+
+## R7. Versioning / compatibility
+
+- **Decision**: purely additive change shipped in MINOR v1.25.0 (milestone 12); MiMa advisory vs `1.24.0` expected clean; no `mimaBinaryIssueFilters` entries.
+- **Rationale**: constitution II classifies a new overload as additive (PATCH-trivial at minimum); it rides the already-open v1.25.0 minor. New public method appears in the facade too — also additive.

--- a/specs/009-faker-datetime-offset/spec.md
+++ b/specs/009-faker-datetime-offset/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Discrete Date-Time Offset Generation
+
+**Feature Branch**: `009-faker-datetime-offset`
+
+**Created**: 2026-07-19
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-picatinny/issues/294 — Add discrete LocalDateTime offset generator to Faker date API"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  TEST-MODEL HOOK (Constitution III): for each acceptance scenario below, keep in mind
+  the REAL case it exercises and the test LAYER it maps to (see TESTING.md: unit/functional,
+  DSL/action component, external integration, full Gatling e2e, compile guard, facade).
+  `/speckit-plan` will expand these into the plan's mandatory code-free "Test Model" table.
+-->
+
+### User Story 1 - Generate a date-time a whole number of units away from a base (Priority: P1)
+
+A load-test author needs a random date-time that is a **whole number** of time units
+(days, weeks, hours, …) away from a base date-time — for example "0 to 5 whole days
+from now" — with both bounds inclusive. Today the fake-data API can only produce a
+random point *anywhere inside* a date-time range (any second within it), which is a
+different distribution: same boundaries, different values. An author migrating from
+the deprecated random-date feeder must reproduce the old discrete behavior exactly,
+without hand-rolling the composition.
+
+**Why this priority**: This is the core capability gap (issue #294). The deprecated
+random-date feeder promises a replacement in the new fake-data API, but the promised
+replacement generates different values — the migration path is broken until this
+exists. It also blocks the planned removal of deprecated APIs in the next major
+release.
+
+**Independent Test**: Can be fully tested by requesting a generated date-time with a
+given base, bounds, and unit, and verifying every produced value is the base plus a
+whole number of the chosen unit, with that number always inside the inclusive bounds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a base date-time and inclusive bounds 0..5 in days, **When** values are generated repeatedly, **Then** every value equals the base plus 0, 1, 2, 3, 4, or 5 whole days — never a fractional-day point in between.
+2. **Given** bounds that span zero (e.g. −10..10 hours), **When** values are generated, **Then** values both before and after the base are produced, all on whole-hour steps from the base, none outside the bounds.
+3. **Given** equal lower and upper bounds (e.g. 3..3 weeks), **When** a value is generated, **Then** the result is always exactly the base plus 3 weeks (deterministic).
+4. **Given** a lower bound greater than the upper bound, **When** the generator is requested, **Then** the request is rejected immediately with a descriptive error (not at generation time).
+5. **Given** a time unit that date-time arithmetic cannot support, **When** the generator is requested, **Then** the request is rejected immediately with a descriptive error naming the unit.
+
+---
+
+### User Story 2 - Same capability from Java and Kotlin (Priority: P2)
+
+A Java or Kotlin load-test author needs the same discrete offset generation through
+the published Java/Kotlin facade. Composing it manually from the number generator is
+not practical from those languages (it requires constructing Scala function values),
+so without a facade entry point these users have no reasonable migration path at all.
+
+**Why this priority**: The library ships a first-class Java/Kotlin facade; a
+capability that exists only for Scala users leaves facade users stranded on the
+deprecated feeder. Depends on User Story 1 existing.
+
+**Independent Test**: Can be fully tested by invoking the facade entry point from
+Java test code and verifying it produces values identical in kind to the core
+generator (whole-unit steps inside inclusive bounds).
+
+**Acceptance Scenarios**:
+
+1. **Given** the Java/Kotlin facade, **When** a discrete offset generator is requested with base, bounds, and unit, **Then** generated values behave exactly as in User Story 1 (facade delegates, adds no logic).
+2. **Given** the facade without an explicit unit, **When** a discrete offset generator is requested with base and bounds only, **Then** whole days are used as the default unit.
+
+---
+
+### User Story 3 - Documented migration from the deprecated random-date feeder (Priority: P3)
+
+An author still using the deprecated random-date feeder needs to know exactly how to
+express an existing configuration (positive delta, negative delta, base, unit,
+output pattern) with the new API, so the eventual removal of the deprecated feeder
+is a mechanical replacement, not a re-design.
+
+**Why this priority**: Documentation parity completes the migration story but has no
+value until Stories 1–2 ship.
+
+**Independent Test**: Can be fully tested by taking a representative deprecated
+feeder configuration, following the documented mapping, and verifying the new
+expression produces values with the same distribution shape (discrete steps, same
+inclusive range) and the same formatted output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deprecated feeder configuration with positive delta P, negative delta N, base B and unit U, **When** the documented replacement mapping is applied, **Then** the new generator covers exactly B − N·U … B + (P−1)·U on whole-unit steps — the deprecated feeder's upper delta is exclusive (discovered during planning), while the new generator's bounds are inclusive — and the deprecation notice points to a replacement that truly reproduces the behavior.
+2. **Given** a deprecated configuration that also formats output with a date pattern, **When** the documented mapping is applied, **Then** the formatted output shape matches the old feeder's output shape.
+
+---
+
+### Edge Cases
+
+- Lower bound greater than upper bound → rejected at generator construction with a descriptive error (never a silently empty or inverted range).
+- Lower bound equal to upper bound → deterministic value, still valid.
+- Bounds spanning zero (past and future from the same base) → supported; both sides reachable.
+- Time unit unsupported by date-time arithmetic → rejected at construction, naming the unit, not at first generation inside a running load test.
+- Offsets large enough to overflow the representable date-time range → the underlying date-time arithmetic error surfaces at generation; bounds themselves are not silently clamped.
+- Distribution boundary: both endpoint values must actually be producible (inclusive, not exclusive, bounds).
+- The existing continuous "random point inside a range" generator keeps its current behavior untouched — the new capability is additive, not a redefinition.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The fake-data date API MUST offer a generator producing a date-time equal to a caller-supplied base plus a whole number of caller-chosen time units, where that whole number is drawn uniformly from a caller-supplied inclusive range.
+- **FR-002**: Both range endpoints MUST be producible (inclusive bounds); an equal-bounds range MUST yield exactly the single corresponding value.
+- **FR-003**: Negative offsets MUST be supported, including ranges spanning zero, so past-and-future generation from one base is expressible in a single generator.
+- **FR-004**: An invalid request — lower bound above upper bound, or a time unit the date-time arithmetic does not support — MUST be rejected when the generator is constructed, with a descriptive error, rather than failing later during value generation.
+- **FR-005**: Generated values MUST lie exactly on whole-unit steps from the base — no sub-unit remainder — making the distribution observably different from the existing continuous in-range generator, whose behavior MUST remain unchanged.
+- **FR-006**: The Java/Kotlin facade MUST expose the same capability by pure delegation to the core implementation (no facade-local logic), including a whole-days default when no unit is given.
+- **FR-007**: The new generator MUST compose with the existing date-time formatting capability so formatted string output (as the deprecated feeder produced) is expressible without new formatting machinery.
+- **FR-008**: The change MUST be purely additive: no existing public signature, generator behavior, or serialized format changes; the deprecated random-date feeder itself is not modified beyond documentation.
+- **FR-009**: Migration documentation MUST state the exact mapping from every deprecated random-date feeder parameter set (positive delta, negative delta, base, unit, pattern) to the new API.
+
+### Key Entities
+
+- **Discrete offset generator**: description of "base date-time + whole-unit random offset"; attributes: base date-time, inclusive lower offset, inclusive upper offset, time unit (whole-days default).
+- **Deprecated random-date feeder configuration**: the legacy parameter set (positive delta, negative delta, base, unit, output pattern, timezone) whose behavior the new generator must be able to reproduce; related to the discrete offset generator by the documented migration mapping.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of sampled generated values fall inside the requested inclusive range and lie exactly on whole-unit steps from the base (zero sub-unit remainders across the sampled runs).
+- **SC-002**: Every deprecated random-date feeder parameter combination (any positive/negative delta pair, any supported unit, any pattern) has a documented one-to-one replacement expression producing the same value set and output shape.
+- **SC-003**: A Java or Kotlin author can obtain the capability through the facade with a single call — zero Scala-specific constructs required on the caller's side.
+- **SC-004**: All pre-existing tests pass unchanged: zero behavioral drift in existing generators.
+- **SC-005**: Invalid requests (inverted bounds, unsupported unit) are rejected at construction in 100% of cases with an error message naming the offending input.
+
+## Assumptions
+
+- Uniform distribution over the whole-number offset range matches the deprecated feeder's behavior and user expectation; no weighting options are in scope.
+- The deprecated feeder's upper delta is **exclusive** (its random-value helper excludes the upper bound); the new generator uses **inclusive** bounds as issue #294 requests, and the migration mapping absorbs the difference (upper bound = positive delta − 1).
+- Whole days are the correct default unit (mirrors the deprecated feeder's default).
+- The offset range uses whole numbers of arbitrary magnitude within the platform's standard integer range; fractional offsets are explicitly out of scope (the continuous generator already covers them).
+- Timezone handling stays as in the existing date API (the deprecated feeder's timezone parameter only affected formatting, which the existing formatting capability already covers).
+- Scope is the library and its Java/Kotlin facade only; example overlay projects are unaffected.
+- This feature belongs to the active release milestone (v1.25.0) and closes issue [#294](https://github.com/galax-io/gatling-picatinny/issues/294); it is a prerequisite for removing the deprecated feeder in the planned 2.0.0 cleanup (milestone "v2.0.0 — Remove deprecated APIs").

--- a/specs/009-faker-datetime-offset/tasks.md
+++ b/specs/009-faker-datetime-offset/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: Discrete Date-Time Offset Generation
+
+**Input**: Design documents from `/specs/009-faker-datetime-offset/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/faker-date-api.md](contracts/faker-date-api.md), [quickstart.md](quickstart.md)
+
+**Tests**: MANDATORY — constitution III is test-first (red → green); every story starts with failing tests.
+
+**Commit discipline**: 1 issue = 1 commit — the entire feature (core + facade + tests + docs) lands as ONE semantic commit `feat(faker): discrete LocalDateTime offset generator (#294)` at the end (T011); spec/plan artifacts are already committed separately (`17c092b`, spec-first rule). Working commits along the way are not pushed — squash before review.
+
+**Organization**: grouped by user story; US1 is the MVP increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+**Purpose**: sanity baseline — nothing to scaffold (no new deps, no build changes; plan Technical Context)
+
+- [X] T001 Verify branch baseline is green before any change: `sbt compile test` on `009-faker-datetime-offset` (fails fast on a broken environment, isolates regressions to this feature) ✅ 770 tests green (14s)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**None** — single additive method on existing infrastructure (`Generator`, `Faker.number.long`, `Faker.date`); no shared prerequisites beyond Setup. User stories may begin immediately after T001.
+
+---
+
+## Phase 3: User Story 1 - Generate a date-time a whole number of units away from a base (Priority: P1) 🎯 MVP
+
+**Goal**: `Faker.date.offset(from: LocalDateTime, minOffset, maxOffset, unit = DAYS)` — inclusive whole-unit uniform offsets (contract: [contracts/faker-date-api.md](contracts/faker-date-api.md))
+
+**Independent Test**: quickstart V1 — every sampled value reconstructs exactly as base + k·unit with k inside inclusive bounds; both rejection cases throw at construction
+
+### Tests for User Story 1 (RED first) ⚠️
+
+- [X] T002 [US1] Add failing ScalaTest cases to `src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala` (after "generate date offset within bounds"), per Test Model rows FR-001..005/007/009: (a) 0..5 whole days from fixed base — exact grid reconstruction, k∈[0,5]; (b) −10..10 hours — values on both sides of base, whole-hour grid, endpoints reachable; (c) 3..3 weeks — deterministic exact value; (d) 0..1 day — BOTH endpoints observed across samples (inclusive upper, unlike legacy exclusive); (e) inverted bounds (5..0) → IllegalArgumentException at construction; (f) `ChronoUnit.FOREVER` → IllegalArgumentException naming the unit; (g) equal-bounds generator through `formatDateTime` → exact formatted string (FR-007); (h) doc-parity: legacy (P=30, N=0, days, "yyyy-MM-dd") replacement `offset(base, 0, 29)` + format yields only base+0..29 formatted values and NEVER base+30 (FR-009). Verify RED: `sbt "testOnly org.galaxio.gatling.feeders.faker.GeneratedFeederSpec"` fails (method absent → compile error) ✅ 8 cases added; RED verified (type mismatch — LocalDateTime overload absent)
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Implement `offset(from: LocalDateTime, minOffset: Long, maxOffset: Long, unit: TemporalUnit = ChronoUnit.DAYS): Generator[LocalDateTime]` in `src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala` (object `date`, directly after the `LocalDate` offset): `require(minOffset <= maxOffset, …)`, `require(from.isSupported(unit), …)`, body `number.long(minOffset, maxOffset).map(from.plus(_, unit))`; add `java.time.temporal.TemporalUnit` import. GREEN: all T002 cases pass ✅ implemented; GREEN — GeneratedFeederSpec 175/175
+- [X] T004 [US1] Run full unit suite + coverage: `sbt test` green, scoverage floor 75%/66% holds (new require branches fully covered by T002 e/f) ✅ unit suite 778/778 green; branch 68.25% ≥ 66; new statements covered (scoverage invoked>0); statement floor 75% requires `IntegrationTest/test` in the denominator (CI gate command) — Docker unavailable locally, validated by CI on the PR
+
+**Checkpoint**: US1 fully functional — quickstart V1 passes; MVP delivered
+
+---
+
+## Phase 4: User Story 2 - Same capability from Java and Kotlin (Priority: P2)
+
+**Goal**: `FakerApi.dateOffset` — two thin delegates (3-arg whole-days default, 4-arg explicit unit), constitution I
+
+**Independent Test**: quickstart V2 — Java-built generators produce in-bounds grid values; inverted bounds surface the same error
+
+### Tests for User Story 2 (RED first) ⚠️
+
+- [X] T005 [US2] Add failing JUnit 5 usage to `src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java` (existing date-feeder block): `dateOffset(base, 0, 5, ChronoUnit.DAYS)` and 3-arg `dateOffset(base, 0, 5)` through `formatDateTime`/`GeneratedFeeder`, asserting in-bounds whole-day values; plus inverted-bounds construction → IllegalArgumentException. Verify RED (facade method absent → compile error). Depends on T003 (core exists; facade still missing) ✅ RED verified (`cannot find symbol dateOffset`); assertions placed in JavaApiExampleSmokeTest (JUnit 5 facade layer per TESTING.md), usage smoke in JavaFeedersTest dates feeder
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] Implement both `dateOffset` delegates in `src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala` ("--- Date ---" block after `dateBetween`): 4-arg → `Faker.date.offset(from, min, max, unit)`, 3-arg → `Faker.date.offset(from, min, max)` (Scala default = days); add `java.time.temporal.TemporalUnit` import; zero facade-local logic. GREEN: T005 passes ✅ two delegates added; GREEN — JavaApiExampleSmokeTest 59/59 incl. both dateOffset tests
+
+**Checkpoint**: US1 + US2 independently green (quickstart V1 + V2)
+
+---
+
+## Phase 5: User Story 3 - Documented migration from the deprecated random-date feeder (Priority: P3)
+
+**Goal**: correct, test-backed migration mapping (FR-009; executable side already in T002-h)
+
+**Independent Test**: quickstart V3 — doc expressions match the tested mapping verbatim; wrong `past` example gone
+
+### Implementation for User Story 3
+
+- [X] T007 [P] [US3] Fix `docs/faker-api.md`: Generator Catalog — note `date.offset` covers `LocalDate` (days) AND `LocalDateTime` (any supported unit, whole-days default); REPLACE the wrong migration example (`RandomDateFeeder("createdAt", 30, 0)` → `Faker.date.past(days = 30)`, wrong direction + wrong type) with the correct discrete mapping `Faker.date.offset(base, 0, 29)` + format — expression textually identical to the T002-h doc-parity test. Depends on T003 ✅ catalog line + wrong past-example replaced with offset(…, 0, 29) mapping + exclusive-delta note
+- [X] T008 [P] [US3] Extend `docs/migration.md` Deprecations section: mapping table `RandomDateFeeder(name, P, N, pattern, from, unit, tz)` → feeder over `formatDateTime(offset(from, −N, P − 1, unit), pattern)`; note the legacy upper delta is EXCLUSIVE (hence P − 1; `randomValue(1, 11)` yields 1..10) and `tz` affected formatting only (research R5/R6). Depends on T003 ✅ RandomDateFeeder→offset subsection with mapping table, P−1 rationale, tz note, FakerApi pointers
+
+**Checkpoint**: all three stories independently verifiable (quickstart V1–V3)
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T009 Format + lint + strict diagnostics to zero findings: `sbt scalafixAll scalafmtAll`, then gates `sbt scalafmtCheckAll scalafmtSbtCheck "scalafixAll --check" compile` (`-Werror` clean) ✅ scalafixAll+scalafmtAll applied (1 file reformatted); all gates green (fmt, sbt-fmt, scalafix --check, -Werror compile)
+- [X] T010 Full quickstart validation V1–V5 incl. compatibility: `sbt "mimaReportBinaryIssues || true"` → zero incompatibilities vs 1.24.0 (FR-008), full verify chain green ✅ V1 175/175, V2 59/59, V3 doc-parity green + docs match expression, V4 MiMa zero issues vs 1.24.0, V5 unit chain green (IT part deferred to CI — no local Docker)
+- [X] T011 Single semantic commit `feat(faker): discrete LocalDateTime offset generator (#294)` (core + facade + tests + docs — 1 issue = 1 commit), push `009-faker-datetime-offset`, open DRAFT PR → `main` with milestone **v1.25.0 — Perf: Faker** and `Closes #294` (ask-before-commit rule: confirm with maintainer before commit/push/PR) ✅ commits 81080d3 (tasks) + 63674b0 (feat); draft PR #296 → main, milestone v1.25.0
+
+---
+
+## Dependencies & Execution Order
+
+- **T001** → everything
+- **US1 (T002 → T003 → T004)**: strict TDD chain; blocks US2 and US3
+- **US2 (T005 → T006)**: after T003 (facade delegates to core)
+- **US3 (T007 ∥ T008)**: after T003 (docs must match shipped expression; executable parity lives in T002-h)
+- **Polish (T009 → T010 → T011)**: after all stories
+
+### Parallel Opportunities
+
+- After T003: **T005 ∥ T007 ∥ T008** (three different files, no shared state); T004 can run alongside
+- T007 ∥ T008 always mutually parallel (different doc files)
+
+## Implementation Strategy
+
+**MVP first**: T001 → T002 → T003 → T004 = shippable US1 (Scala users unblocked). Then US2 (facade users), US3 (docs), Polish. Single-developer order: T001..T011 sequentially; the parallel set collapses naturally. Stop-points at each checkpoint validate the story in isolation via its quickstart scenario.

--- a/src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala
+++ b/src/main/java/org/galaxio/gatling/javaapi/FakerApi.scala
@@ -2,6 +2,7 @@ package org.galaxio.gatling.javaapi
 
 import org.galaxio.gatling.feeders.faker._
 
+import java.time.temporal.TemporalUnit
 import java.time.{LocalDate, LocalDateTime}
 import java.{util => ju}
 import scala.jdk.CollectionConverters._
@@ -88,6 +89,11 @@ object FakerApi {
   def datePast(days: Long): Generator[LocalDate]                        = Faker.date.past(days)
   def dateFuture(days: Long): Generator[LocalDate]                      = Faker.date.future(days)
   def dateBetween(from: LocalDate, to: LocalDate): Generator[LocalDate] = Faker.date.between(from, to)
+
+  def dateOffset(from: LocalDateTime, minOffset: Long, maxOffset: Long): Generator[LocalDateTime]                     =
+    Faker.date.offset(from, minOffset, maxOffset)
+  def dateOffset(from: LocalDateTime, minOffset: Long, maxOffset: Long, unit: TemporalUnit): Generator[LocalDateTime] =
+    Faker.date.offset(from, minOffset, maxOffset, unit)
 
   def formatDate(gen: Generator[LocalDate], pattern: String): Generator[String]         = Faker.date.formatDate(gen, pattern)
   def formatDateTime(gen: Generator[LocalDateTime], pattern: String): Generator[String] =

--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -13,7 +13,7 @@ import org.galaxio.gatling.utils.phone.{PhoneFormat, TypePhone}
 import org.galaxio.gatling.utils.{RandomDataGenerators, RandomPhoneGenerator}
 
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
+import java.time.temporal.{ChronoUnit, TemporalUnit}
 import java.time.{LocalDate, LocalDateTime, ZoneId}
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
@@ -370,6 +370,17 @@ object Faker {
     def offset(from: LocalDate, minDays: Long, maxDays: Long): Generator[LocalDate] = {
       require(minDays <= maxDays, s"minDays must be <= maxDays: $minDays > $maxDays")
       number.long(minDays, maxDays).map(from.plusDays)
+    }
+
+    def offset(
+        from: LocalDateTime,
+        minOffset: Long,
+        maxOffset: Long,
+        unit: TemporalUnit = ChronoUnit.DAYS,
+    ): Generator[LocalDateTime] = {
+      require(minOffset <= maxOffset, s"minOffset must be <= maxOffset: $minOffset > $maxOffset")
+      require(from.isSupported(unit), s"unit must be supported by LocalDateTime: $unit")
+      number.long(minOffset, maxOffset).map(from.plus(_, unit))
     }
 
     def range(

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaApiExampleSmokeTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaApiExampleSmokeTest.java
@@ -14,11 +14,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.galaxio.gatling.javaapi.FakerApi.*;
 import static org.galaxio.gatling.javaapi.Feeders.*;
 
@@ -215,6 +218,29 @@ class JavaApiExampleSmokeTest {
             assertThat(past).isBeforeOrEqualTo(LocalDate.now());
             assertThat(record.get("future").toString()).matches("\\d{4}-\\d{2}-\\d{2}");
             assertThat(record.get("between").toString()).matches("\\d{4}-\\d{2}-\\d{2}");
+        }
+
+        @Test
+        void dateOffsetProducesWholeUnitStepsWithinBounds() {
+            var base = LocalDateTime.of(2026, 1, 1, 12, 0, 0);
+            var record = next(GeneratedFeeder(
+                    field("days", formatDateTime(dateOffset(base, 0, 5), "yyyy-MM-dd'T'HH:mm:ss")),
+                    field("hours", formatDateTime(dateOffset(base, -10, 10, ChronoUnit.HOURS), "yyyy-MM-dd'T'HH:mm:ss"))
+            ));
+            var days = LocalDateTime.parse(record.get("days").toString());
+            var dayOffset = ChronoUnit.DAYS.between(base, days);
+            assertThat(days).isEqualTo(base.plusDays(dayOffset));
+            assertThat(dayOffset).isBetween(0L, 5L);
+            var hours = LocalDateTime.parse(record.get("hours").toString());
+            var hourOffset = ChronoUnit.HOURS.between(base, hours);
+            assertThat(hours).isEqualTo(base.plusHours(hourOffset));
+            assertThat(hourOffset).isBetween(-10L, 10L);
+        }
+
+        @Test
+        void dateOffsetRejectsInvertedBounds() {
+            assertThatThrownBy(() -> dateOffset(LocalDateTime.of(2026, 1, 1, 0, 0), 5, 0))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test

--- a/src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java
+++ b/src/test/java/org/galaxio/gatling/javaapi/JavaFeedersTest.java
@@ -120,7 +120,9 @@ public class JavaFeedersTest extends Simulation {
     Iterator<Map<String, Object>> dates = GeneratedFeeder(
             field("createdAt", formatDate(datePast(30), "yyyy-MM-dd")),
             field("validFrom", formatDate(dateBetween(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 6, 30)), "yyyy-MM-dd")),
-            field("validTo", formatDate(dateFuture(90), "yyyy-MM-dd"))
+            field("validTo", formatDate(dateFuture(90), "yyyy-MM-dd")),
+            field("expiresAt", formatDateTime(dateOffset(LocalDateTime.of(2026, 1, 1, 0, 0), 0, 5), "yyyy-MM-dd'T'HH:mm:ss")),
+            field("retryAfter", formatDateTime(dateOffset(LocalDateTime.of(2026, 1, 1, 0, 0), -3, 3, ChronoUnit.HOURS), "yyyy-MM-dd'T'HH:mm:ss"))
     );
 
     Iterator<Map<String, Object>> finance = GeneratedFeeder(

--- a/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
@@ -7,7 +7,9 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.{ChronoUnit, UnsupportedTemporalTypeException}
+import java.time.{LocalDate, LocalDateTime, ZoneId}
 
 class GeneratedFeederSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
@@ -649,6 +651,100 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
         val d = Faker.date.offset(base, -10, 10).sample()
         d.isBefore(base.minusDays(10)) shouldBe false
         d.isAfter(base.plusDays(10)) shouldBe false
+      }
+    }
+
+    "generate datetime offset within bounds on whole-unit steps" in {
+      val base = LocalDateTime.of(2025, 6, 1, 12, 30, 15)
+      (1 to sampleCount).foreach { _ =>
+        val d = Faker.date.offset(base, 0, 5).sample()
+        val k = ChronoUnit.DAYS.between(base, d)
+        d shouldBe base.plusDays(k)
+        k should (be >= 0L and be <= 5L)
+      }
+    }
+
+    "generate datetime offset across zero with a non-day unit" in {
+      val base    = LocalDateTime.of(2025, 6, 1, 12, 30, 15)
+      val samples = (1 to sampleCount * 4).map(_ => Faker.date.offset(base, -10, 10, ChronoUnit.HOURS).sample())
+      samples.foreach { d =>
+        val k = ChronoUnit.HOURS.between(base, d)
+        d shouldBe base.plusHours(k)
+        k should (be >= -10L and be <= 10L)
+      }
+      samples.exists(_.isBefore(base)) shouldBe true
+      samples.exists(_.isAfter(base)) shouldBe true
+    }
+
+    "generate deterministic datetime offset when bounds are equal" in {
+      val base = LocalDateTime.of(2025, 6, 1, 0, 0)
+      (1 to sampleCount).foreach { _ =>
+        Faker.date.offset(base, 3, 3, ChronoUnit.WEEKS).sample() shouldBe base.plusWeeks(3)
+      }
+    }
+
+    "produce both inclusive endpoints of a datetime offset range" in {
+      val base    = LocalDateTime.of(2025, 6, 1, 0, 0)
+      val samples = (1 to sampleCount * 4).map(_ => Faker.date.offset(base, 0, 1).sample()).toSet
+      samples should contain(base)
+      samples should contain(base.plusDays(1))
+    }
+
+    "reject datetime offset with min greater than max" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.date.offset(LocalDateTime.of(2025, 6, 1, 0, 0), 5, 0)
+      }
+    }
+
+    "reject datetime offset with unsupported unit" in {
+      assertThrows[IllegalArgumentException] {
+        Faker.date.offset(LocalDateTime.of(2025, 6, 1, 0, 0), 0, 5, ChronoUnit.FOREVER)
+      }
+    }
+
+    "format datetime offset output with a pattern" in {
+      val base = LocalDateTime.of(2026, 1, 2, 3, 4, 5)
+      val s    = Faker.date.formatDateTime(Faker.date.offset(base, 2, 2), "yyyy-MM-dd'T'HH:mm:ss").sample()
+      s shouldBe "2026-01-04T03:04:05"
+    }
+
+    "reproduce the documented RandomDateFeeder migration mapping" in {
+      // docs mapping under test: RandomDateFeeder("createdAt", 30, 0) has an EXCLUSIVE upper
+      // delta, so its replacement is offset(base, 0, 29) — base+30 must never appear.
+      val base     = LocalDateTime.of(2025, 6, 1, 12, 0, 0)
+      val expected = (0 to 29).map(k => base.plusDays(k.toLong).format(DateTimeFormatter.ISO_LOCAL_DATE)).toSet
+      val gen      = Faker.date.formatDateTime(Faker.date.offset(base, 0, 29), "yyyy-MM-dd")
+      val seen     = (1 to sampleCount * 8).map(_ => gen.sample()).toSet
+      seen.subsetOf(expected) shouldBe true
+      seen should not contain base.plusDays(30L).format(DateTimeFormatter.ISO_LOCAL_DATE)
+    }
+
+    "reproduce the documented zero-delta RandomDateFeeder mapping" in {
+      // docs/migration.md edge case: P == 0 && N == 0 is a valid legacy config that always returns
+      // the base date; it maps to offset(from, 0, 0), not the general (inverted) offset(from, 0, -1).
+      val base = LocalDateTime.of(2025, 6, 1, 12, 0, 0)
+      (1 to sampleCount).foreach { _ =>
+        Faker.date.offset(base, 0, 0).sample() shouldBe base
+      }
+    }
+
+    "reproduce the documented timezone-pattern migration recipe" in {
+      // docs/migration.md edge case: zone-aware legacy patterns map through atZone(tz) before formatting.
+      val base = LocalDateTime.of(2026, 1, 2, 3, 4, 5)
+      val s    = Faker.date
+        .offset(base, 2, 2)
+        .map(_.atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX")))
+        .sample()
+      s shouldBe "2026-01-04T03:04:05Z"
+    }
+
+    "fail fast when a zone pattern is applied without the atZone recipe" in {
+      val gen = Faker.date.formatDateTime(
+        Faker.date.offset(LocalDateTime.of(2026, 1, 2, 3, 4, 5), 2, 2),
+        "yyyy-MM-dd'T'HH:mm:ssXXX",
+      )
+      assertThrows[UnsupportedTemporalTypeException] {
+        gen.sample()
       }
     }
 


### PR DESCRIPTION
Closes #294. Spec: `specs/009-faker-datetime-offset/` (full speckit cycle: spec → plan → tasks → TDD implementation → adversarial review).

## What

- **Core**: `Faker.date.offset(from: LocalDateTime, minOffset, maxOffset, unit = ChronoUnit.DAYS): Generator[LocalDateTime]` — uniform **whole-unit** offsets, **inclusive** bounds, negative/zero-spanning ranges, fail-fast `require` on inverted bounds and unsupported units (`ChronoUnit.FOREVER`). Sits next to the existing `offset(LocalDate, …)`.
- **Facade**: `FakerApi.dateOffset` — 3-arg (whole-days default) + 4-arg (explicit `TemporalUnit`) pure delegates (constitution I; Java can't see Scala default args).
- **Docs**: `docs/faker-api.md` — catalog note + the wrong migration example REPLACED (it mapped a future discrete-offset feeder to `Faker.date.past`); `docs/migration.md` — exact `RandomDateFeeder` mapping table **plus its two edge cases** (below).

## Why

The deprecated `RandomDateFeeder` promises "use Faker.date instead", but `between` yields any second in range — a different distribution than the legacy discrete whole-unit offsets. The migration path was broken; this also blocks the v2.0.0 deprecated-API removal (milestone 27). Design alternatives (`between`+step, wontfix+recipe, per-unit methods) analyzed in `research.md`.

## Key discoveries (reviewer attention)

1. **Legacy upper delta is exclusive** (`randomValue(min, max)` is max-exclusive), so the mapping is `RandomDateFeeder(name, P, N, pattern, from, unit, tz)` → `formatDateTime(offset(from, −N, P − 1, unit), pattern)`. Locked by a doc-parity test (base+30 asserted never produced for P=30).
2. **Mapping edge cases** (found by Codex + adversarial code review, both confirmed and covered):
   - `P == 0 && N == 0` is a valid legacy config (always the base date); the general formula would invert bounds — documented special case `offset(from, 0, 0, unit)`, locked by a deterministic test.
   - Zone-aware patterns (`z`, `XXX`, `VV`) worked in the legacy feeder via `atZone(tz)`; plain `formatDateTime` throws on them — documented `.map(_.atZone(tz).format(…))` recipe, locked by a positive recipe test and a negative fail-fast test.
3. **Out of scope**: the review also surfaced a pre-existing wide-range bounds defect in `Faker.number.long` (`negativeLong` affected out of the box) — tracked as #297 (severity:high, this milestone), zero lines touched here.

## Verification

- TDD red→green per story: GeneratedFeederSpec **178/178** (11 new cases incl. endpoint inclusivity, zero-spanning hours, two rejection cases, three doc-parity/edge-case tests), JavaApiExampleSmokeTest **59/59** (2 new facade tests).
- **CI fully green** incl. the real coverage gate (unit + IT): 6/6 checks.
- **MiMa: zero incompatibilities** vs 1.24.0 — purely additive (MINOR, ships in v1.25.0).
- scalafmt + scalafix `--check` + `-Werror` compile: clean.

## History

Two commits, spec-first: `docs(speckit)` spec/plan/tasks → `feat(faker)` (implementation + tests + docs incl. review follow-ups, squashed — no churn). Rebase-merge keeps them linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
