### PR TITLE
fix(faker): enforce inclusive bounds in number.long for wide ranges (#297)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -91,15 +91,17 @@ object Faker {
 
     private def nextLongInclusive(min: Long, max: Long): Long =
       if (min == max) min
+      else if (min == Long.MinValue && max == Long.MaxValue) ThreadLocalRandom.current().nextLong()
       else if (BigInt(max) - BigInt(min) + 1 <= BigInt(Long.MaxValue)) {
         val bound = (BigInt(max) - BigInt(min) + 1).toLong
         min + ThreadLocalRandom.current().nextLong(bound)
-      } else if (min == Long.MinValue) ThreadLocalRandom.current().nextLong()
-      else {
+      } else {
+        // Range wider than Long.MaxValue covers more than half the Long domain, so
+        // rejection sampling accepts with probability > 1/2 (expected < 2 draws).
         @tailrec
         def retry(): Long = {
           val value = ThreadLocalRandom.current().nextLong()
-          if (value >= min) value else retry()
+          if (value >= min && value <= max) value else retry()
         }
         retry()
       }

--- a/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
@@ -369,6 +369,26 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
       Faker.number.negativeInt.sample() should be < 0
     }
 
+    "generate negative longs strictly below zero" in {
+      (1 to sampleCount * 4).foreach { _ =>
+        Faker.number.negativeLong.sample() should be < 0L
+      }
+    }
+
+    "keep wide long ranges inside both inclusive bounds" in {
+      (1 to sampleCount * 4).foreach { _ =>
+        Faker.number.long(Long.MinValue, -1L).sample() should be <= -1L
+        val v = Faker.number.long(Long.MinValue + 1L, 100L).sample()
+        v should (be >= (Long.MinValue + 1L) and be <= 100L)
+      }
+    }
+
+    "support the full long domain" in {
+      val samples = (1 to sampleCount * 4).map(_ => Faker.number.long(Long.MinValue, Long.MaxValue).sample())
+      samples.exists(_ < 0L) shouldBe true
+      samples.exists(_ >= 0L) shouldBe true
+    }
+
     "generate percentage 0-100" in {
       (1 to sampleCount).foreach { _ =>
         val v = Faker.number.percentage.sample()


### PR DESCRIPTION
Refs #297 (declined — unrequested scope). Single-fix patch for **v1.24.1**.

## What

`nextLongInclusive` checked only the LOWER bound in both wide-range fallback branches (range wider than `Long.MaxValue`):
- `min == Long.MinValue` branch drew an unbounded `nextLong()`;
- the rejection loop tested `value >= min` but never `value <= max`.

**`Faker.number.negativeLong` (= `long(Long.MinValue, -1)`) was broken out of the box** — non-negative values on ~every other draw.

Fix: bare `nextLong()` kept only for the full domain `(Long.MinValue, Long.MaxValue)`; the rejection loop enforces BOTH bounds. A wide range covers more than half the Long domain, so acceptance probability > 1/2 (expected < 2 draws) — no perf concern.

## Verification

- TDD: regression tests written first and observed RED on the old code (negativeLong produced ≥ 0 within 200 samples; wide range escaped the upper bound), GREEN after — **786/786**.
- New cases: `negativeLong` strictly negative; `long(Long.MinValue, -1)` ≤ −1; `long(Long.MinValue+1, 100)` inside both bounds; full-domain `long(MinValue, MaxValue)` samples both sides of zero; narrow-range behavior untouched.
- Gates: scalafmt, scalafix `--check`, `-Werror` compile — clean. MiMa: zero issues (private method). Dependency-hygiene report: zero findings (pre-tag checklist).

## Release plan

Fix lands on `main` first, then `git cherry-pick` onto `release/1.24.0`, tag `v1.24.1` (AGENTS.md patch process). Milestone: **v1.24.0** per the patch→minor milestone mapping of `check-linkage.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)