### PR TITLE
fix(feeder): check both bounds when Faker.long range is wider than Long.MaxValue

### DIFF
--- a/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
+++ b/src/main/scala/org/galaxio/gatling/feeders/faker/Faker.scala
@@ -91,15 +91,15 @@ object Faker {
 
     private def nextLongInclusive(min: Long, max: Long): Long =
       if (min == max) min
+      else if (min == Long.MinValue && max == Long.MaxValue) ThreadLocalRandom.current().nextLong()
       else if (BigInt(max) - BigInt(min) + 1 <= BigInt(Long.MaxValue)) {
         val bound = (BigInt(max) - BigInt(min) + 1).toLong
         min + ThreadLocalRandom.current().nextLong(bound)
-      } else if (min == Long.MinValue) ThreadLocalRandom.current().nextLong()
-      else {
+      } else {
         @tailrec
         def retry(): Long = {
           val value = ThreadLocalRandom.current().nextLong()
-          if (value >= min) value else retry()
+          if (value >= min && value <= max) value else retry()
         }
         retry()
       }

--- a/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/feeders/faker/GeneratedFeederSpec.scala
@@ -305,6 +305,30 @@ class GeneratedFeederSpec extends AnyWordSpec with Matchers with ScalaCheckDrive
       }
     }
 
+    "correctly generate longs when range is wider than Long.MaxValue" in {
+      val minOffset = Long.MinValue
+      val maxOffset = -1L
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.long(minOffset, maxOffset).sample()
+        v should (be >= minOffset and be <= maxOffset)
+      }
+
+      val minOffset2 = Long.MinValue + 1
+      val maxOffset2 = 100L
+      (1 to sampleCount).foreach { _ =>
+        val v = Faker.number.long(minOffset2, maxOffset2).sample()
+        v should (be >= minOffset2 and be <= maxOffset2)
+      }
+
+      val minOffset3 = Long.MinValue
+      val maxOffset3 = Long.MaxValue
+      val samples    = (1 to sampleCount).map { _ =>
+        Faker.number.long(minOffset3, maxOffset3).sample()
+      }
+      samples.exists(_ > 0) shouldBe true
+      samples.exists(_ < 0) shouldBe true
+    }
+
     "generate doubles within range" in {
       forAll(Gen.choose(0.0, 1000.0)) { max =>
         whenever(max > 0.01) {


### PR DESCRIPTION
Closes #297

This PR fixes `Faker.number.long` silent inclusive bounds violations for ranges wider than `Long.MaxValue` (i.e., where `BigInt(max) - BigInt(min) + 1 > Long.MaxValue`).

### Problem
When the range is wider than `Long.MaxValue`, `nextLongInclusive` falls back to two branches:
1. `min == Long.MinValue` branch: returns an unbounded `ThreadLocalRandom.current().nextLong()`, which can be positive (above `max`) when `max` is negative (e.g. `long(Long.MinValue, -1L)`).
2. General wide-range branch: `retry()` only checks if the value is `>= min`, completely ignoring the upper bound `max` (e.g. `long(Long.MinValue + 1, 100L)` can return positive values up to `Long.MaxValue`).

### Solution
- When the range spans the full domain (`min == Long.MinValue && max == Long.MaxValue`), directly return any random long.
- Otherwise, for ranges wider than `Long.MaxValue`, use a rejection loop that checks both bounds: `value >= min && value <= max`. Since the range spans at least `2^63` values, the acceptance probability is at least `50%`, ensuring high performance (expected number of draws < 2).
- Added comprehensive unit tests covering wide range generation, including offset boundaries.
