### PR TITLE
docs(constitution): scope force-push ban to protected branches (v1.1.5)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -123,7 +123,9 @@ Gatling MUST stay `Provided` — it is the host runtime, not a bundled dependenc
 2. Run `sbt scalafmtAll scalafmtSbt` before committing.
 3. CI gate: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` MUST pass.
 4. Integration gate (when touching Redis, diagnostics, JWT): `sbt "IntegrationTest / test"`.
-5. PRs only — force-push and merge commits in PR branches are prohibited (rebase only).
+5. PRs only — merge commits in PR branches are prohibited (rebase only); after a rebase,
+   update the PR branch with `git push --force-with-lease`. Force-pushing `main` or
+   `release/*` is prohibited.
 6. Commits MUST be semantic (conventional commits) and leave the build green.
 7. New or changed examples in `examples/` MUST compile against the published artifact
    version, not a local snapshot, before release.
@@ -146,4 +148,4 @@ versioning policy below, and propagate changes to affected templates and AGENTS.
 Violations require explicit justification in the plan's Complexity Tracking table
 before merging.
 
-**Version**: 1.1.4 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-07-04
+**Version**: 1.1.5 | **Ratified**: 2026-06-20 | **Last Amended**: 2026-07-21


### PR DESCRIPTION
## Summary

Constitution Development Workflow rule 5 read literally banned `git push --force-with-lease` on PR branches, yet the rebase-only workflow requires it and AGENTS.md explicitly instructs "update with `--force-with-lease`" (its Never-list scopes the force-push ban to `main`). Flagged as finding **D2** by `/speckit-analyze` of `specs/010-faker-syntax-perf`; deferred there as a separate constitution PATCH.

## Change

Rule 5 rescoped:
- Force-pushing `main` or `release/*`: prohibited (unchanged intent).
- PR branches: rebase-only, merge commits remain prohibited; after a rebase, update with `git push --force-with-lease`.

Per the governance versioning policy this is a **PATCH** (clarification, no semantic change): version `1.1.4` → `1.1.5`, Last Amended `2026-07-21`.

No template/AGENTS.md propagation needed — AGENTS.md already states the correct rule; `force-push` appears nowhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)